### PR TITLE
Use AYON_MENU_LABEL

### DIFF
--- a/client/ayon_core/hosts/blender/api/ops.py
+++ b/client/ayon_core/hosts/blender/api/ops.py
@@ -374,7 +374,7 @@ class TOPBAR_MT_avalon(bpy.types.Menu):
     """Avalon menu."""
 
     bl_idname = "TOPBAR_MT_avalon"
-    bl_label = os.environ.get("AVALON_LABEL")
+    bl_label = os.environ.get("AYON_MENU_LABEL")
 
     def draw(self, context):
         """Draw the menu in the UI."""

--- a/client/ayon_core/hosts/fusion/api/menu.py
+++ b/client/ayon_core/hosts/fusion/api/menu.py
@@ -21,7 +21,7 @@ from .pipeline import FusionEventHandler
 from .pulse import FusionPulse
 
 
-MENU_LABEL = os.environ["AVALON_LABEL"]
+MENU_LABEL = os.environ["AYON_MENU_LABEL"]
 
 
 self = sys.modules[__name__]

--- a/client/ayon_core/hosts/harmony/api/TB_sceneOpened.js
+++ b/client/ayon_core/hosts/harmony/api/TB_sceneOpened.js
@@ -370,7 +370,7 @@ function start() {
     app.avalonMenu = null;
 
     for (var i = 0 ; i < actions.length; i++) {
-        label = System.getenv('AVALON_LABEL');
+        label = System.getenv('AYON_MENU_LABEL');
         if (actions[i].text == label) {
             app.avalonMenu = true;
         }
@@ -378,7 +378,7 @@ function start() {
 
     var menu = null;
     if (app.avalonMenu == null) {
-        menu = menuBar.addMenu(System.getenv('AVALON_LABEL'));
+        menu = menuBar.addMenu(System.getenv('AYON_MENU_LABEL'));
     }
     // menu = menuBar.addMenu('Avalon');
 

--- a/client/ayon_core/hosts/hiero/api/menu.py
+++ b/client/ayon_core/hosts/hiero/api/menu.py
@@ -63,7 +63,7 @@ def menu_install():
 
     # here is the best place to add menu
 
-    menu_name = os.environ['AVALON_LABEL']
+    menu_name = os.environ['AYON_MENU_LABEL']
 
     context_label = get_context_label()
 

--- a/client/ayon_core/hosts/houdini/api/creator_node_shelves.py
+++ b/client/ayon_core/hosts/houdini/api/creator_node_shelves.py
@@ -173,7 +173,7 @@ def install():
         os.remove(filepath)
 
     icon = get_ayon_icon_filepath()
-    tab_menu_label = os.environ.get("AVALON_LABEL") or "AYON"
+    tab_menu_label = os.environ.get("AYON_MENU_LABEL") or "AYON"
 
     # Create context only to get creator plugins, so we don't reset and only
     # populate what we need to retrieve the list of creator plugins

--- a/client/ayon_core/hosts/houdini/api/lib.py
+++ b/client/ayon_core/hosts/houdini/api/lib.py
@@ -1040,7 +1040,7 @@ def self_publish():
 def add_self_publish_button(node):
     """Adds a self publish button to the rop node."""
 
-    label = os.environ.get("AVALON_LABEL") or "AYON"
+    label = os.environ.get("AYON_MENU_LABEL") or "AYON"
 
     button_parm = hou.ButtonParmTemplate(
         "ayon_self_publish",

--- a/client/ayon_core/hosts/houdini/startup/MainMenuCommon.xml
+++ b/client/ayon_core/hosts/houdini/startup/MainMenuCommon.xml
@@ -4,7 +4,7 @@
         <subMenu id="openpype_menu">
             <labelExpression><![CDATA[
 import os
-return os.environ.get("AVALON_LABEL") or "AYON"
+return os.environ.get("AYON_MENU_LABEL") or "AYON"
 ]]></labelExpression>
             <actionItem id="asset_name">
                     <labelExpression><![CDATA[

--- a/client/ayon_core/hosts/max/api/menu.py
+++ b/client/ayon_core/hosts/max/api/menu.py
@@ -78,7 +78,7 @@ class OpenPypeMenu(object):
 
             if before in item.title():
                 help_action = item.menuAction()
-        tab_menu_label = os.environ.get("AVALON_LABEL") or "AYON"
+        tab_menu_label = os.environ.get("AYON_MENU_LABEL") or "AYON"
         op_menu = QtWidgets.QMenu("&{}".format(tab_menu_label))
         menu_bar.insertMenu(help_action, op_menu)
 

--- a/client/ayon_core/hosts/maya/api/menu.py
+++ b/client/ayon_core/hosts/maya/api/menu.py
@@ -55,7 +55,7 @@ def install(project_settings):
         parent_widget = get_main_window()
         cmds.menu(
             MENU_NAME,
-            label=os.environ.get("AVALON_LABEL") or "OpenPype",
+            label=os.environ.get("AYON_MENU_LABEL") or "AYON",
             tearOff=True,
             parent="MayaWindow"
         )

--- a/client/ayon_core/hosts/nuke/api/lib.py
+++ b/client/ayon_core/hosts/nuke/api/lib.py
@@ -59,10 +59,9 @@ from .utils import get_node_outputs
 
 log = Logger.get_logger(__name__)
 
-_NODE_TAB_NAME = "{}".format(os.getenv("AVALON_LABEL") or "Avalon")
-AVALON_LABEL = os.getenv("AVALON_LABEL") or "Avalon"
-AVALON_TAB = "{}".format(AVALON_LABEL)
-AVALON_DATA_GROUP = "{}DataGroup".format(AVALON_LABEL.capitalize())
+MENU_LABEL = os.getenv("AYON_MENU_LABEL") or "AYON"
+NODE_TAB_NAME = MENU_LABEL
+DATA_GROUP_KEY = "{}DataGroup".format(MENU_LABEL.capitalize())
 EXCLUDED_KNOB_TYPE_ON_READ = (
     20,  # Tab Knob
     26,  # Text Knob (But for backward compatibility, still be read
@@ -443,7 +442,7 @@ def set_avalon_knob_data(node, data=None, prefix="avalon:"):
     data = data or dict()
     create = OrderedDict()
 
-    tab_name = AVALON_TAB
+    tab_name = NODE_TAB_NAME
     editable = ["asset", "subset", "name", "namespace"]
 
     existed_knobs = node.knobs()
@@ -477,7 +476,7 @@ def set_avalon_knob_data(node, data=None, prefix="avalon:"):
             (("warn", ""), warn),
             (("divd", ""), divd),
         ]
-        tab[AVALON_DATA_GROUP] = OrderedDict(head + list(create.items()))
+        tab[DATA_GROUP_KEY] = OrderedDict(head + list(create.items()))
         create = tab
 
     imprint(node, create, tab=tab_name)
@@ -500,7 +499,7 @@ def get_avalon_knob_data(node, prefix="avalon:", create=True):
     """
 
     data = {}
-    if AVALON_TAB not in node.knobs():
+    if NODE_TAB_NAME not in node.knobs():
         return data
 
     # check if lists
@@ -512,7 +511,7 @@ def get_avalon_knob_data(node, prefix="avalon:", create=True):
         # check if the node is avalon tracked
         try:
             # check if data available on the node
-            test = node[AVALON_DATA_GROUP].value()
+            test = node[DATA_GROUP_KEY].value()
             log.debug("Only testing if data available: `{}`".format(test))
         except NameError as e:
             # if it doesn't then create it

--- a/client/ayon_core/hosts/nuke/api/pipeline.py
+++ b/client/ayon_core/hosts/nuke/api/pipeline.py
@@ -46,7 +46,8 @@ from .lib import (
     add_scripts_menu,
     add_scripts_gizmo,
     get_node_data,
-    set_node_data
+    set_node_data,
+    MENU_LABEL,
 )
 from .workfile_template_builder import (
     NukePlaceholderLoadPlugin,
@@ -72,8 +73,6 @@ PUBLISH_PATH = os.path.join(PLUGINS_DIR, "publish")
 LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
-
-MENU_LABEL = os.environ["AVALON_LABEL"]
 
 # registering pyblish gui regarding settings in presets
 if os.getenv("PYBLISH_GUI", None):
@@ -497,9 +496,6 @@ def ls():
     This function is used by the Container Manager in Nuke. You'll
     need to implement a for-loop that then *yields* one Container at
     a time.
-
-    See the `container.json` schema for details on how it should look,
-    and the Maya equivalent, which is in `avalon.maya.pipeline`
     """
     all_nodes = nuke.allNodes(recurseGroups=False)
 

--- a/client/ayon_core/hosts/nuke/plugins/create/convert_legacy.py
+++ b/client/ayon_core/hosts/nuke/plugins/create/convert_legacy.py
@@ -3,7 +3,7 @@ from ayon_core.hosts.nuke.api.lib import (
     INSTANCE_DATA_KNOB,
     get_node_data,
     get_avalon_knob_data,
-    AVALON_TAB,
+    NODE_TAB_NAME,
 )
 from ayon_core.hosts.nuke.api.plugin import convert_to_valid_instaces
 
@@ -24,7 +24,7 @@ class LegacyConverted(SubsetConvertorPlugin):
             if get_node_data(node, INSTANCE_DATA_KNOB):
                 continue
 
-            if AVALON_TAB not in node.knobs():
+            if NODE_TAB_NAME not in node.knobs():
                 continue
 
             # get data from avalon knob

--- a/client/ayon_core/hosts/resolve/api/menu.py
+++ b/client/ayon_core/hosts/resolve/api/menu.py
@@ -7,7 +7,7 @@ from ayon_core.tools.utils import host_tools
 from ayon_core.pipeline import registered_host
 
 
-MENU_LABEL = os.environ["AVALON_LABEL"]
+MENU_LABEL = os.environ["AYON_MENU_LABEL"]
 
 
 def load_stylesheet():

--- a/client/ayon_core/hosts/substancepainter/api/pipeline.py
+++ b/client/ayon_core/hosts/substancepainter/api/pipeline.py
@@ -170,7 +170,7 @@ class SubstanceHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
         parent = substance_painter.ui.get_main_window()
 
-        tab_menu_label = os.environ.get("AVALON_LABEL") or "AYON"
+        tab_menu_label = os.environ.get("AYON_MENU_LABEL") or "AYON"
         menu = QtWidgets.QMenu(tab_menu_label)
 
         action = menu.addAction("Create...")

--- a/client/ayon_core/hosts/tvpaint/api/communication_server.py
+++ b/client/ayon_core/hosts/tvpaint/api/communication_server.py
@@ -834,7 +834,7 @@ class BaseCommunicator:
 
 
 class QtCommunicator(BaseCommunicator):
-    label = os.getenv("AVALON_LABEL") or "AYON"
+    label = os.getenv("AYON_MENU_LABEL") or "AYON"
     title = "{} Tools".format(label)
     menu_definitions = {
         "title": title,

--- a/client/ayon_core/hosts/tvpaint/tvpaint_plugin/plugin_code/library.cpp
+++ b/client/ayon_core/hosts/tvpaint/tvpaint_plugin/plugin_code/library.cpp
@@ -488,9 +488,9 @@ static char* GetLocalString( PIFilter* iFilter, int iNum, char* iDefault )
 std::string label_from_evn()
 {
     std::string _plugin_label = "OpenPype";
-    if (std::getenv("AVALON_LABEL") && std::getenv("AVALON_LABEL") != "")
+    if (std::getenv("AYON_MENU_LABEL") && std::getenv("AYON_MENU_LABEL") != "")
     {
-        _plugin_label = std::getenv("AVALON_LABEL");
+        _plugin_label = std::getenv("AYON_MENU_LABEL");
     }
     return _plugin_label;
 }

--- a/client/ayon_core/lib/applications.py
+++ b/client/ayon_core/lib/applications.py
@@ -1939,7 +1939,7 @@ def should_start_last_workfile(
     """Define if host should start last version workfile if possible.
 
     Default output is `False`. Can be overridden with environment variable
-    `AVALON_OPEN_LAST_WORKFILE`, valid values without case sensitivity are
+    `AYON_OPEN_LAST_WORKFILE`, valid values without case sensitivity are
     `"0", "1", "true", "false", "yes", "no"`.
 
     Args:


### PR DESCRIPTION
## Changelog Description
Replace usage of `AVALON_LABEL` with `AYON_MENU_LABEL`.

## Additional info
The most changes happened in nuke where variables into which was value stored did contain `AVALON_` and was duplicated multiple times. Variables in nuke were reduced `_NODE_TAB_NAME` renamed to `NODE_TAB_NAME`, `AVALON_LABEL` renamed to `MENU_LABEL`, `AVALON_TAB` replaced by `NODE_TAB_NAME`, `AVALON_DATA_GROUP` renamed to `DATA_GROUP_KEY`.

## Testing notes:
1. All labels should work as before and show correct label `AYON`.

- [x] Blender
- [x] Maya
- [x] Max
- [ ] Houdini
- [ ] Harmony
- [x] SubstancePainter
- [x] Nuke
- [ ] Hiero
- [ ] Fusion
- [ ] Resolve
- [ ] AE
- [ ] TvPaint