### PR TITLE
Bugfix: AYON menu disappeared when the workspace has been changed in 3dsMax

### DIFF
--- a/client/ayon_core/hosts/max/api/pipeline.py
+++ b/client/ayon_core/hosts/max/api/pipeline.py
@@ -60,6 +60,9 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         rt.callbacks.addScript(rt.Name('filePostOpen'),
                                lib.check_colorspace)
 
+        rt.callbacks.addScript(rt.Name('postWorkspaceChange'),
+                               self._deferred_menu_creation)
+
     def has_unsaved_changes(self):
         # TODO: how to get it from 3dsmax?
         return True


### PR DESCRIPTION
## Changelog Description
The ported version of this PR in OP Repo. https://github.com/ynput/OpenPype/pull/6200
AYON plugins are not correctly registered when switching to different workspaces. 

## Additional info
n/a

## Testing notes:
1. launch Max via launcher
2. Open a workfile
3. Switch different workspace
4. Try to publish/load everything to see if it succeeds.