### PR TITLE
Small addon bugs & enhancements

### DIFF
--- a/client/ayon_core/__init__.py
+++ b/client/ayon_core/__init__.py
@@ -7,3 +7,6 @@ AYON_CORE_ROOT = os.path.dirname(os.path.abspath(__file__))
 PACKAGE_DIR = AYON_CORE_ROOT
 PLUGINS_DIR = os.path.join(AYON_CORE_ROOT, "plugins")
 AYON_SERVER_ENABLED = True
+
+# Indicate if AYON entities should be used instead of OpenPype entities
+USE_AYON_ENTITIES = False

--- a/client/ayon_core/hosts/houdini/api/lib.py
+++ b/client/ayon_core/hosts/houdini/api/lib.py
@@ -6,6 +6,7 @@ import re
 import uuid
 import logging
 import json
+from contextlib import contextmanager
 
 import six
 

--- a/client/ayon_core/hosts/resolve/startup.py
+++ b/client/ayon_core/hosts/resolve/startup.py
@@ -33,7 +33,7 @@ def ensure_installed_host():
 
 
 def launch_menu():
-    print("Launching Resolve OpenPype menu..")
+    print("Launching Resolve AYON menu..")
     ensure_installed_host()
     ayon_core.hosts.resolve.api.launch_pype_menu()
 
@@ -54,7 +54,7 @@ def main():
     else:
         log.info("No last workfile set to open. Skipping..")
 
-    # Launch OpenPype menu
+    # Launch AYON menu
     from ayon_core.settings import get_project_settings
     from ayon_core.pipeline.context_tools import get_current_project_name
     project_name = get_current_project_name()
@@ -62,7 +62,7 @@ def main():
 
     settings = get_project_settings(project_name)
     if settings.get("resolve", {}).get("launch_openpype_menu_on_start", True):
-        log.info("Launching OpenPype menu..")
+        log.info("Launching AYON menu..")
         launch_menu()
 
 

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -38,8 +38,8 @@ class AYONSecureRegistry:
     Registry should be used for private data that should be available only for
     user.
 
-    All passed registry names will have added prefix `OpenPype/` to easier
-    identify which data were created by OpenPype.
+    All passed registry names will have added prefix `AYON/` to easier
+    identify which data were created by AYON.
 
     Args:
         name(str): Name of registry used as identifier for data.

--- a/client/ayon_core/modules/job_queue/module.py
+++ b/client/ayon_core/modules/job_queue/module.py
@@ -1,4 +1,4 @@
-"""Job queue OpenPype module was created for remote execution of commands.
+"""Job queue AYON addon was created for remote execution of commands.
 
 ## Why is needed
 Primarily created for hosts which are not easilly controlled from command line
@@ -30,7 +30,7 @@ workstations know where to send or receive jobs.
 
 ### start_worker
 - start worker which will process jobs
-- has required possitional argument which is application name from OpenPype
+- has required possitional argument which is application name from AYON
     settings e.g. 'tvpaint/11-5' ('tvpaint' is group '11-5' is variant)
 - it is possible to specify server url but url from settings is used when not
     passed (this is added mainly for developing purposes)

--- a/client/ayon_core/modules/timers_manager/widget_user_idle.py
+++ b/client/ayon_core/modules/timers_manager/widget_user_idle.py
@@ -9,7 +9,7 @@ class WidgetUserIdle(QtWidgets.QWidget):
     def __init__(self, module):
         super(WidgetUserIdle, self).__init__()
 
-        self.setWindowTitle("OpenPype - Stop timers")
+        self.setWindowTitle("AYON - Stop timers")
 
         icon = QtGui.QIcon(resources.get_ayon_icon_filepath())
         self.setWindowIcon(icon)

--- a/client/ayon_core/modules/webserver/webserver_module.py
+++ b/client/ayon_core/modules/webserver/webserver_module.py
@@ -1,6 +1,6 @@
 """WebServerAddon spawns aiohttp server in asyncio loop.
 
-Main usage of the module is in OpenPype tray where make sense to add ability
+Main usage of the module is in AYON tray where make sense to add ability
 of other modules to add theirs routes. Module which would want use that
 option must have implemented method `webserver_initialization` which must
 expect `WebServerManager` object where is possible to add routes or paths

--- a/client/ayon_core/pipeline/farm/patterning.py
+++ b/client/ayon_core/pipeline/farm/patterning.py
@@ -11,7 +11,7 @@ def match_aov_pattern(host_name, aov_patterns, render_file_name):
     that we have grabbed from `exp_files`.
 
     Args:
-        app (str): Host name.
+        host_name (str): Host name.
         aov_patterns (dict):  AOV patterns from AOV filters.
         render_file_name (str): Incoming file name to match against.
 

--- a/client/ayon_core/style/__init__.py
+++ b/client/ayon_core/style/__init__.py
@@ -198,7 +198,7 @@ def _load_font():
 
 
 def load_stylesheet():
-    """Load and return OpenPype Qt stylesheet."""
+    """Load and return AYON Qt stylesheet."""
 
     if _Cache.stylesheet is None:
         _Cache.stylesheet = _load_stylesheet()
@@ -207,7 +207,7 @@ def load_stylesheet():
 
 
 def get_app_icon_path():
-    """Path to OpenPype icon."""
+    """Path to AYON icon."""
     return resources.get_ayon_icon_filepath()
 
 

--- a/client/ayon_core/tools/traypublisher/window.py
+++ b/client/ayon_core/tools/traypublisher/window.py
@@ -35,7 +35,7 @@ class TrayPublisherController(QtPublisherController):
 
 
 class TrayPublisherRegistry(JSONSettingRegistry):
-    """Class handling OpenPype general settings registry.
+    """Class handling AYON general settings registry.
 
     Attributes:
         vendor (str): Name used for path construction.

--- a/client/ayon_core/tools/traypublisher/window.py
+++ b/client/ayon_core/tools/traypublisher/window.py
@@ -12,7 +12,7 @@ from qtpy import QtWidgets, QtCore
 import qtawesome
 import appdirs
 
-from ayon_core.lib import JSONSettingRegistry
+from ayon_core.lib import JSONSettingRegistry, is_running_from_build
 from ayon_core.pipeline import install_host
 from ayon_core.hosts.traypublisher.api import TrayPublisherHost
 from ayon_core.tools.publisher.control_qt import QtPublisherController
@@ -265,7 +265,7 @@ def main():
 
     app_instance = get_ayon_qt_app()
 
-    if platform.system().lower() == "windows":
+    if not is_running_from_build() and platform.system().lower() == "windows":
         import ctypes
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
             u"traypublisher"


### PR DESCRIPTION
## Changelog Description
Use AYON in docstrings and labels. Fixed import in houdini. Added `USE_AYON_ENTITIES` which indicates if is used AYON entity structure or OpenPype entity structure (for forwards compatibility).

## Testing notes:
- Houdini should not complain about missing `cotextmanager`.
- Read changed labels and docstrings.
