### PR TITLE
Bugfix Houdini: Add missing `contextlib` import

### DIFF
--- a/client/ayon_core/hosts/houdini/api/lib.py
+++ b/client/ayon_core/hosts/houdini/api/lib.py
@@ -6,7 +6,7 @@ import re
 import uuid
 import logging
 import json
-
+import contextlib
 import six
 
 from ayon_core.lib import StringTemplate
@@ -500,7 +500,7 @@ def read(node):
     return data
 
 
-@contextmanager
+@contextlib.contextmanager
 def maintained_selection():
     """Maintain selection during context
     Example:


### PR DESCRIPTION
## Changelog Description
For some reason the import was accidently removed. 
This PR adds it back.

## Testing notes:
1. Houdini should launch without any issues.
