### PR TITLE
Harmony: Use AYON prefix in env variables

### DIFF
--- a/client/ayon_core/hosts/harmony/api/README.md
+++ b/client/ayon_core/hosts/harmony/api/README.md
@@ -52,7 +52,7 @@ Because Harmony projects are directories, this integration uses `.zip` as work f
 
 ### Show Workfiles on launch
 
-You can show the Workfiles app when Harmony launches by setting environment variable `AVALON_HARMONY_WORKFILES_ON_LAUNCH=1`.
+You can show the Workfiles app when Harmony launches by setting environment variable `AYON_HARMONY_WORKFILES_ON_LAUNCH=1`.
 
 ## Developing
 

--- a/client/ayon_core/hosts/harmony/api/TB_sceneOpened.js
+++ b/client/ayon_core/hosts/harmony/api/TB_sceneOpened.js
@@ -349,7 +349,7 @@ function start() {
     /** hostname or ip of server - should be localhost */
     var host = '127.0.0.1';
     /** port of the server */
-    var port = parseInt(System.getenv('AVALON_HARMONY_PORT'));
+    var port = parseInt(System.getenv('AYON_HARMONY_PORT'));
 
     // Attach the client to the QApplication to preserve.
     var app = QCoreApplication.instance();

--- a/client/ayon_core/hosts/harmony/api/lib.py
+++ b/client/ayon_core/hosts/harmony/api/lib.py
@@ -189,14 +189,14 @@ def launch(application_path, *args):
     install_host(harmony)
 
     ProcessContext.port = random.randrange(49152, 65535)
-    os.environ["AVALON_HARMONY_PORT"] = str(ProcessContext.port)
+    os.environ["AYON_HARMONY_PORT"] = str(ProcessContext.port)
     ProcessContext.application_path = application_path
 
     # Launch Harmony.
     setup_startup_scripts()
     check_libs()
 
-    if not os.environ.get("AVALON_HARMONY_WORKFILES_ON_LAUNCH", False):
+    if not os.environ.get("AYON_HARMONY_WORKFILES_ON_LAUNCH", False):
         open_empty_workfile()
         return
 

--- a/client/ayon_core/settings/defaults/system_settings/applications.json
+++ b/client/ayon_core/settings/defaults/system_settings/applications.json
@@ -1271,7 +1271,7 @@
         "icon": "{}/app_icons/harmony.png",
         "host_name": "harmony",
         "environment": {
-            "AVALON_HARMONY_WORKFILES_ON_LAUNCH": "1"
+            "AYON_HARMONY_WORKFILES_ON_LAUNCH": "1"
         },
         "variants": {
             "21": {


### PR DESCRIPTION
## Changelog Description
Use `AYON_` prefix in harmony environment variables.

## Additional info
Replaced `AVALON_HARMONY_WORKFILES_ON_LAUNCH` > `AYON_HARMONY_WORKFILES_ON_LAUNCH` and `AVALON_HARMONY_PORT` > `AYON_HARMONY_PORT`.
