### PR TITLE
Maya: Add repair action to hidden joints validator

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/validate_rig_joints_hidden.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_rig_joints_hidden.py
@@ -7,6 +7,7 @@ from ayon_core.hosts.maya.api import lib
 from ayon_core.pipeline.publish import (
     RepairAction,
     ValidateContentsOrder,
+    PublishValidationError
 )
 
 
@@ -38,7 +39,8 @@ class ValidateRigJointsHidden(pyblish.api.InstancePlugin):
         invalid = self.get_invalid(instance)
 
         if invalid:
-            raise ValueError("Visible joints found: {0}".format(invalid))
+            raise PublishValidationError(
+                "Visible joints found: {0}".format(invalid))
 
     @classmethod
     def repair(cls, instance):


### PR DESCRIPTION
## Changelog Description
Joints Hidden is missing repair action, this adds it back

## Additional info
Paragraphs of text giving context of additional technical information or code examples.

## Testing notes:
1. enable the Validate Rig Joints Hidden for your current bundle under "ayon+settings://maya/publish/ValidateRigJointsHidden/enabled"
2. Create some visible joints in Maya scene.
3. Create a rig from selection
4. run validation
5. repair action should be available from Report tab
