### PR TITLE
Deadline: Version GlobalJobPreLoad

### DIFF
--- a/client/ayon_core/modules/deadline/repository/custom/plugins/Ayon/Ayon.py
+++ b/client/ayon_core/modules/deadline/repository/custom/plugins/Ayon/Ayon.py
@@ -15,6 +15,7 @@ import re
 import os
 import platform
 
+__version__ = "1.0.0"
 
 ######################################################################
 # This is the function that Deadline calls to get an instance of the
@@ -52,6 +53,9 @@ class AyonDeadlinePlugin(DeadlinePlugin):
         del self.RenderArgumentCallback
 
     def InitializeProcess(self):
+        self.LogInfo(
+            "Initializing process with AYON plugin {}".format(__version__)
+        )
         self.PluginType = PluginType.Simple
         self.StdoutHandling = True
 

--- a/client/ayon_core/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
+++ b/client/ayon_core/modules/deadline/repository/custom/plugins/GlobalJobPreLoad.py
@@ -14,7 +14,7 @@ from Deadline.Scripting import (
     DirectoryUtils,
     ProcessUtils,
 )
-
+__version__ = "1.0.0"
 VERSION_REGEX = re.compile(
     r"(?P<major>0|[1-9]\d*)"
     r"\.(?P<minor>0|[1-9]\d*)"
@@ -593,7 +593,7 @@ def inject_render_job_id(deadlinePlugin):
 
 
 def __main__(deadlinePlugin):
-    print("*** GlobalJobPreload start ...")
+    print("*** GlobalJobPreload {} start ...".format(__version__))
     print(">>> Getting job ...")
     job = deadlinePlugin.GetJob()
 


### PR DESCRIPTION
## Changelog Description
Add version that is printed in GlobalJobPreLoad plugin.

## Additional info
Sometimes it is hard to debug issues with the plugin, with version printed in the log it should be a little bit easier.

## Testing notes:
1. Copy new plugin to deadline repository
2. Version should be printed in the job logs
