### PR TITLE
Core: Do not force asset and task during publishing

### DIFF
--- a/client/ayon_core/plugins/publish/collect_from_create_context.py
+++ b/client/ayon_core/plugins/publish/collect_from_create_context.py
@@ -61,7 +61,10 @@ class CollectFromCreateContext(pyblish.api.ContextPlugin):
             ("AVALON_ASSET", asset_name),
             ("AVALON_TASK", task_name)
         ):
-            os.environ[key] = value
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
     def create_instance(
         self,


### PR DESCRIPTION
## Changelog Description
Do not set environment variables to `None` in `CollectFromCreateContext`.

## Additional info
Set environment variable to `None` is invalid thus the key is removed when the value is not set. This should fix traypublisher collection.
