### PR TITLE
TrayPublisher: Use AYON settings

### DIFF
--- a/client/ayon_core/hosts/traypublisher/api/editorial.py
+++ b/client/ayon_core/hosts/traypublisher/api/editorial.py
@@ -92,7 +92,9 @@ class ShotMetadataSolver:
 
         search_text = parent_name + clip_name
 
-        for token_key, pattern in self.clip_name_tokenizer.items():
+        for clip_name_item in self.clip_name_tokenizer:
+            token_key = clip_name_item["name"]
+            pattern = clip_name_item["regex"]
             p = re.compile(pattern)
             match = p.findall(search_text)
             if not match:
@@ -143,11 +145,11 @@ class ShotMetadataSolver:
             ))
 
         _parent_tokens_type = {
-            parent_token["name"]: parent_token["type"]
+            parent_token["name"]: parent_token["parent_type"]
             for parent_token in hierarchy_parents
         }
         for _index, _parent in enumerate(
-                shot_hierarchy["parents_path"].split("/")
+            shot_hierarchy["parents_path"].split("/")
         ):
             # format parent token with value which is formatted
             try:
@@ -268,22 +270,22 @@ class ShotMetadataSolver:
         """
         tasks_to_add = {}
 
-        project_tasks = project_doc["config"]["tasks"]
-        for task_name, task_data in self.shot_add_tasks.items():
-            _task_data = deepcopy(task_data)
+        project_task_types = project_doc["config"]["tasks"]
+        for task_item in self.shot_add_tasks:
+            task_name = task_item["name"]
+            task_type = task_item["task_type"]
 
             # check if task type in project task types
-            if _task_data["type"] in project_tasks.keys():
-                tasks_to_add[task_name] = _task_data
-            else:
+            if task_type not in project_task_types.keys():
                 raise KeyError(
                     "Missing task type `{}` for `{}` is not"
                     " existing in `{}``".format(
-                        _task_data["type"],
+                        task_type,
                         task_name,
-                        list(project_tasks.keys())
+                        list(project_task_types.keys())
                     )
                 )
+            tasks_to_add[task_name] = {"type": task_type}
 
         return tasks_to_add
 

--- a/client/ayon_core/hosts/traypublisher/api/editorial.py
+++ b/client/ayon_core/hosts/traypublisher/api/editorial.py
@@ -16,25 +16,31 @@ class ShotMetadataSolver:
 
     NO_DECOR_PATERN = re.compile(r"\{([a-z]*?)\}")
 
-    # presets
-    clip_name_tokenizer = None
-    shot_rename = True
-    shot_hierarchy = None
-    shot_add_tasks = None
+    def __init__(self, logger):
+        self.clip_name_tokenizer = []
+        self.shot_rename = {
+            "enabled": False,
+            "shot_rename_template": "",
+        }
+        self.shot_hierarchy = {
+            "enabled": False,
+            "parents": [],
+            "parents_path": "",
+        }
+        self.shot_add_tasks = []
+        self.log = logger
 
-    def __init__(
+    def update_data(
         self,
         clip_name_tokenizer,
         shot_rename,
         shot_hierarchy,
-        shot_add_tasks,
-        logger
+        shot_add_tasks
     ):
         self.clip_name_tokenizer = clip_name_tokenizer
         self.shot_rename = shot_rename
         self.shot_hierarchy = shot_hierarchy
         self.shot_add_tasks = shot_add_tasks
-        self.log = logger
 
     def _rename_template(self, data):
         """Shot renaming function

--- a/client/ayon_core/hosts/traypublisher/api/plugin.py
+++ b/client/ayon_core/hosts/traypublisher/api/plugin.py
@@ -311,7 +311,7 @@ class SettingsCreator(TrayPublishCreator):
     @classmethod
     def from_settings(cls, item_data):
         identifier = item_data["identifier"]
-        family = item_data["family"]
+        family = item_data["product_type"]
         if not identifier:
             identifier = "settings_{}".format(family)
         return type(

--- a/client/ayon_core/hosts/traypublisher/plugins/create/create_editorial.py
+++ b/client/ayon_core/hosts/traypublisher/plugins/create/create_editorial.py
@@ -174,35 +174,28 @@ Supporting publishing new shots to project
 or updating already created. Publishing will create OTIO file.
 """
     icon = "fa.file"
+    product_type_presets = []
 
-    def __init__(
-        self, project_settings, *args, **kwargs
-    ):
-        super(EditorialSimpleCreator, self).__init__(
-            project_settings, *args, **kwargs
-        )
+    def __init__(self, *args, **kwargs):
+        self._shot_metadata_solver = ShotMetadataSolver(self.log)
+        super(EditorialSimpleCreator, self).__init__(*args, **kwargs)
+
+    def apply_settings(self, project_settings):
         editorial_creators = deepcopy(
             project_settings["traypublisher"]["editorial_creators"]
         )
-        # get this creator settings by identifier
-        self._creator_settings = editorial_creators.get(self.identifier)
+        creator_settings = editorial_creators.get(self.identifier)
 
-        clip_name_tokenizer = self._creator_settings["clip_name_tokenizer"]
-        shot_rename = self._creator_settings["shot_rename"]
-        shot_hierarchy = self._creator_settings["shot_hierarchy"]
-        shot_add_tasks = self._creator_settings["shot_add_tasks"]
-
-        self._shot_metadata_solver = ShotMetadataSolver(
-            clip_name_tokenizer,
-            shot_rename,
-            shot_hierarchy,
-            shot_add_tasks,
-            self.log
+        self._shot_metadata_solver.update_data(
+            creator_settings["clip_name_tokenizer"],
+            creator_settings["shot_rename"],
+            creator_settings["shot_hierarchy"],
+            creator_settings["shot_add_tasks"]
         )
-
-        # try to set main attributes from settings
-        if self._creator_settings.get("default_variants"):
-            self.default_variants = self._creator_settings["default_variants"]
+        self.product_type_presets = creator_settings["product_type_presets"]
+        default_variants = creator_settings.get("default_variants")
+        if default_variants:
+            self.default_variants = default_variants
 
     def create(self, subset_name, instance_data, pre_create_data):
         allowed_family_presets = self._get_allowed_family_presets(

--- a/client/ayon_core/hosts/traypublisher/plugins/create/create_editorial.py
+++ b/client/ayon_core/hosts/traypublisher/plugins/create/create_editorial.py
@@ -198,15 +198,18 @@ or updating already created. Publishing will create OTIO file.
             self.default_variants = default_variants
 
     def create(self, subset_name, instance_data, pre_create_data):
-        allowed_family_presets = self._get_allowed_family_presets(
+        allowed_product_type_presets = self._get_allowed_product_type_presets(
             pre_create_data)
 
+        product_types = {
+            item["product_type"]
+            for item in self.product_type_presets
+        }
         clip_instance_properties = {
-            k: v for k, v in pre_create_data.items()
+            k: v
+            for k, v in pre_create_data.items()
             if k != "sequence_filepath_data"
-            if k not in [
-                i["family"] for i in self._creator_settings["family_presets"]
-            ]
+            if k not in product_types
         }
 
         asset_name = instance_data["folderPath"]
@@ -248,7 +251,7 @@ or updating already created. Publishing will create OTIO file.
                 otio_timeline,
                 media_path,
                 clip_instance_properties,
-                allowed_family_presets,
+                allowed_product_type_presets,
                 os.path.basename(seq_path),
                 first_otio_timeline
             )
@@ -348,7 +351,7 @@ or updating already created. Publishing will create OTIO file.
         otio_timeline,
         media_path,
         instance_data,
-        family_presets,
+        product_type_presets,
         sequence_file_name,
         first_otio_timeline=None
     ):
@@ -358,7 +361,7 @@ or updating already created. Publishing will create OTIO file.
             otio_timeline (otio.Timeline): otio timeline object
             media_path (str): media file path string
             instance_data (dict): clip instance data
-            family_presets (list): list of dict settings subset presets
+            product_type_presets (list): list of dict settings subset presets
         """
 
         tracks = [
@@ -404,17 +407,17 @@ or updating already created. Publishing will create OTIO file.
                     "instance_id": None
                 }
 
-                for _fpreset in family_presets:
+                for product_type_preset in product_type_presets:
                     # exclude audio family if no audio stream
                     if (
-                        _fpreset["family"] == "audio"
+                        product_type_preset["product_type"] == "audio"
                         and not media_data.get("audio")
                     ):
                         continue
 
                     instance = self._make_subset_instance(
                         otio_clip,
-                        _fpreset,
+                        product_type_preset,
                         deepcopy(base_instance_data),
                         parenting_data
                     )
@@ -526,7 +529,7 @@ or updating already created. Publishing will create OTIO file.
     def _make_subset_instance(
         self,
         otio_clip,
-        preset,
+        product_type_preset,
         instance_data,
         parenting_data
     ):
@@ -534,16 +537,16 @@ or updating already created. Publishing will create OTIO file.
 
         Args:
             otio_clip (otio.Clip): otio clip object
-            preset (dict): single family preset
+            product_type_preset (dict): single family preset
             instance_data (dict): instance data
             parenting_data (dict): shot instance parent data
 
         Returns:
             CreatedInstance: creator instance object
         """
-        family = preset["family"]
+        family = product_type_preset["product_type"]
         label = self._make_subset_naming(
-            preset,
+            product_type_preset,
             instance_data
         )
         instance_data["label"] = label
@@ -562,11 +565,11 @@ or updating already created. Publishing will create OTIO file.
         else:
             # add review family if defined
             instance_data.update({
-                "outputFileType": preset["output_file_type"],
+                "outputFileType": product_type_preset["output_file_type"],
                 "parent_instance_id": parenting_data["instance_id"],
                 "creator_attributes": {
                     "parent_instance": parenting_data["instance_label"],
-                    "add_review_family": preset.get("review")
+                    "add_review_family": product_type_preset.get("review")
                 }
             })
 
@@ -578,15 +581,11 @@ or updating already created. Publishing will create OTIO file.
 
         return c_instance
 
-    def _make_subset_naming(
-        self,
-        preset,
-        instance_data
-    ):
+    def _make_subset_naming(self, product_type_preset, instance_data):
         """ Subset name maker
 
         Args:
-            preset (dict): single preset item
+            product_type_preset (dict): single preset item
             instance_data (dict): instance data
 
         Returns:
@@ -595,10 +594,10 @@ or updating already created. Publishing will create OTIO file.
         asset_name = instance_data["creator_attributes"]["folderPath"]
 
         variant_name = instance_data["variant"]
-        family = preset["family"]
+        family = product_type_preset["product_type"]
 
         # get variant name from preset or from inheritance
-        _variant_name = preset.get("variant") or variant_name
+        _variant_name = product_type_preset.get("variant") or variant_name
 
         # subset name
         subset_name = "{}{}".format(
@@ -756,7 +755,7 @@ or updating already created. Publishing will create OTIO file.
             "sourceOut": int(source_out)
         }
 
-    def _get_allowed_family_presets(self, pre_create_data):
+    def _get_allowed_product_type_presets(self, pre_create_data):
         """ Filter out allowed family presets.
 
         Args:
@@ -766,10 +765,11 @@ or updating already created. Publishing will create OTIO file.
             list: lit of dict with preset items
         """
         return [
-            {"family": "shot"},
+            {"product_type": "shot"},
             *[
-                preset for preset in self._creator_settings["family_presets"]
-                if pre_create_data[preset["family"]]
+                preset
+                for preset in self.product_type_presets
+                if pre_create_data[preset["product_type"]]
             ]
         ]
 
@@ -846,8 +846,8 @@ or updating already created. Publishing will create OTIO file.
         ]
         # add variants swithers
         attr_defs.extend(
-            BoolDef(_var["family"], label=_var["family"])
-            for _var in self._creator_settings["family_presets"]
+            BoolDef(item["product_type"], label=item["product_type"])
+            for item in self.product_type_presets
         )
         attr_defs.append(UISeparatorDef())
 

--- a/client/ayon_core/settings/ayon_settings.py
+++ b/client/ayon_core/settings/ayon_settings.py
@@ -551,58 +551,6 @@ def _convert_traypublisher_project_settings(ayon_settings, output):
 
     _convert_host_imageio(ayon_traypublisher)
 
-    ayon_editorial_simple = (
-        ayon_traypublisher["editorial_creators"]["editorial_simple"]
-    )
-    # Subset -> Product type conversion
-    if "product_type_presets" in ayon_editorial_simple:
-        family_presets = ayon_editorial_simple.pop("product_type_presets")
-        for item in family_presets:
-            item["family"] = item.pop("product_type")
-        ayon_editorial_simple["family_presets"] = family_presets
-
-    if "shot_metadata_creator" in ayon_editorial_simple:
-        shot_metadata_creator = ayon_editorial_simple.pop(
-            "shot_metadata_creator"
-        )
-        if isinstance(shot_metadata_creator["clip_name_tokenizer"], dict):
-            shot_metadata_creator["clip_name_tokenizer"] = [
-                {"name": "_sequence_", "regex": "(sc\\d{3})"},
-                {"name": "_shot_", "regex": "(sh\\d{3})"},
-            ]
-        ayon_editorial_simple.update(shot_metadata_creator)
-
-    ayon_editorial_simple["clip_name_tokenizer"] = {
-        item["name"]: item["regex"]
-        for item in ayon_editorial_simple["clip_name_tokenizer"]
-    }
-
-    if "shot_subset_creator" in ayon_editorial_simple:
-        ayon_editorial_simple.update(
-            ayon_editorial_simple.pop("shot_subset_creator"))
-    for item in ayon_editorial_simple["shot_hierarchy"]["parents"]:
-        item["type"] = item.pop("parent_type")
-
-    # Simple creators
-    ayon_simple_creators = ayon_traypublisher["simple_creators"]
-    for item in ayon_simple_creators:
-        if "product_type" not in item:
-            break
-        item["family"] = item.pop("product_type")
-
-    shot_add_tasks = ayon_editorial_simple["shot_add_tasks"]
-
-    # TODO: backward compatibility and remove in future
-    if isinstance(shot_add_tasks, dict):
-        shot_add_tasks = []
-
-    # aggregate shot_add_tasks items
-    new_shot_add_tasks = {
-        item["name"]: {"type": item["task_type"]}
-        for item in shot_add_tasks
-    }
-    ayon_editorial_simple["shot_add_tasks"] = new_shot_add_tasks
-
     output["traypublisher"] = ayon_traypublisher
 
 


### PR DESCRIPTION
## Changelog Description
Traypublisher does not need AYON settings conversion.

## Additional info
The simple creators did change only single key, the most changes happened in editorial create logic.

## Testing notes:
1. Run at least one simple creator and publish
2. Create editorial and publish
