### PR TITLE
Tools: Move asset icon functions to assets widget

### DIFF
--- a/client/ayon_core/tools/publisher/widgets/assets_widget.py
+++ b/client/ayon_core/tools/publisher/widgets/assets_widget.py
@@ -5,13 +5,13 @@ from qtpy import QtWidgets, QtCore, QtGui
 from ayon_core.tools.utils import (
     PlaceholderLineEdit,
     RecursiveSortFilterProxyModel,
-    get_asset_icon,
 )
 from ayon_core.tools.utils.assets_widget import (
     SingleSelectAssetsWidget,
     ASSET_ID_ROLE,
     ASSET_NAME_ROLE,
     ASSET_PATH_ROLE,
+    get_asset_icon,
 )
 
 

--- a/client/ayon_core/tools/utils/__init__.py
+++ b/client/ayon_core/tools/utils/__init__.py
@@ -37,10 +37,6 @@ from .lib import (
     get_qt_app,
     get_ayon_qt_app,
     get_openpype_qt_app,
-    get_asset_icon,
-    get_asset_icon_by_name,
-    get_asset_icon_name_from_doc,
-    get_asset_icon_color_from_doc,
 )
 
 from .models import (
@@ -100,10 +96,6 @@ __all__ = (
     "get_qt_app",
     "get_ayon_qt_app",
     "get_openpype_qt_app",
-    "get_asset_icon",
-    "get_asset_icon_by_name",
-    "get_asset_icon_name_from_doc",
-    "get_asset_icon_color_from_doc",
 
     "RecursiveSortFilterProxyModel",
 

--- a/client/ayon_core/tools/utils/assets_widget.py
+++ b/client/ayon_core/tools/utils/assets_widget.py
@@ -57,23 +57,6 @@ def _get_asset_icon_color(asset_doc):
     return get_default_entity_icon_color()
 
 
-def get_asset_icon_by_name(icon_name, icon_color, has_children=False):
-    if not icon_name:
-        icon_name = get_default_asset_icon_name(has_children)
-
-    if icon_color:
-        icon_color = QtGui.QColor(icon_color)
-    else:
-        icon_color = get_default_entity_icon_color()
-    icon = get_qta_icon_by_name_and_color(icon_name, icon_color)
-    if icon is not None:
-        return icon
-    return get_qta_icon_by_name_and_color(
-        get_default_asset_icon_name(has_children),
-        icon_color
-    )
-
-
 def _get_asset_icon_name(asset_doc, has_children=True):
     icon_name = _get_asset_icon_name_from_doc(asset_doc)
     if icon_name:

--- a/client/ayon_core/tools/utils/assets_widget.py
+++ b/client/ayon_core/tools/utils/assets_widget.py
@@ -32,26 +32,26 @@ ASSET_UNDERLINE_COLORS_ROLE = QtCore.Qt.UserRole + 4
 ASSET_PATH_ROLE = QtCore.Qt.UserRole + 5
 
 
-def get_default_asset_icon_name(has_children):
+def _get_default_asset_icon_name(has_children):
     if has_children:
         return "fa.folder"
     return "fa.folder-o"
 
 
-def get_asset_icon_color_from_doc(asset_doc):
+def _get_asset_icon_color_from_doc(asset_doc):
     if asset_doc:
         return asset_doc["data"].get("color")
     return None
 
 
-def get_asset_icon_name_from_doc(asset_doc):
+def _get_asset_icon_name_from_doc(asset_doc):
     if asset_doc:
         return asset_doc["data"].get("icon")
     return None
 
 
-def get_asset_icon_color(asset_doc):
-    icon_color = get_asset_icon_color_from_doc(asset_doc)
+def _get_asset_icon_color(asset_doc):
+    icon_color = _get_asset_icon_color_from_doc(asset_doc)
     if icon_color:
         return icon_color
     return get_default_entity_icon_color()
@@ -74,16 +74,16 @@ def get_asset_icon_by_name(icon_name, icon_color, has_children=False):
     )
 
 
-def get_asset_icon_name(asset_doc, has_children=True):
-    icon_name = get_asset_icon_name_from_doc(asset_doc)
+def _get_asset_icon_name(asset_doc, has_children=True):
+    icon_name = _get_asset_icon_name_from_doc(asset_doc)
     if icon_name:
         return icon_name
-    return get_default_asset_icon_name(has_children)
+    return _get_default_asset_icon_name(has_children)
 
 
 def get_asset_icon(asset_doc, has_children=False):
-    icon_name = get_asset_icon_name(asset_doc, has_children)
-    icon_color = get_asset_icon_color(asset_doc)
+    icon_name = _get_asset_icon_name(asset_doc, has_children)
+    icon_color = _get_asset_icon_color(asset_doc)
 
     return get_qta_icon_by_name_and_color(icon_name, icon_color)
 

--- a/client/ayon_core/tools/utils/assets_widget.py
+++ b/client/ayon_core/tools/utils/assets_widget.py
@@ -65,6 +65,20 @@ def _get_asset_icon_name(asset_doc, has_children=True):
 
 
 def get_asset_icon(asset_doc, has_children=False):
+    """Get asset icon.
+
+    Deprecated:
+        This function will be removed in future releases. Use on your own
+            risk.
+
+    Args:
+        asset_doc (dict): Asset document.
+        has_children (Optional[bool]): Asset has children assets.
+
+    Returns:
+        QIcon: Asset icon.
+
+    """
     icon_name = _get_asset_icon_name(asset_doc, has_children)
     icon_color = _get_asset_icon_color(asset_doc)
 

--- a/client/ayon_core/tools/utils/assets_widget.py
+++ b/client/ayon_core/tools/utils/assets_widget.py
@@ -10,6 +10,7 @@ from ayon_core.client import (
 )
 from ayon_core.style import (
     get_default_tools_icon_color,
+    get_default_entity_icon_color,
 )
 from ayon_core.tools.flickcharm import FlickCharm
 
@@ -21,7 +22,7 @@ from .widgets import PlaceholderLineEdit
 from .models import RecursiveSortFilterProxyModel
 from .lib import (
     DynamicQThread,
-    get_asset_icon
+    get_qta_icon_by_name_and_color
 )
 
 ASSET_ID_ROLE = QtCore.Qt.UserRole + 1
@@ -29,6 +30,62 @@ ASSET_NAME_ROLE = QtCore.Qt.UserRole + 2
 ASSET_LABEL_ROLE = QtCore.Qt.UserRole + 3
 ASSET_UNDERLINE_COLORS_ROLE = QtCore.Qt.UserRole + 4
 ASSET_PATH_ROLE = QtCore.Qt.UserRole + 5
+
+
+def get_default_asset_icon_name(has_children):
+    if has_children:
+        return "fa.folder"
+    return "fa.folder-o"
+
+
+def get_asset_icon_color_from_doc(asset_doc):
+    if asset_doc:
+        return asset_doc["data"].get("color")
+    return None
+
+
+def get_asset_icon_name_from_doc(asset_doc):
+    if asset_doc:
+        return asset_doc["data"].get("icon")
+    return None
+
+
+def get_asset_icon_color(asset_doc):
+    icon_color = get_asset_icon_color_from_doc(asset_doc)
+    if icon_color:
+        return icon_color
+    return get_default_entity_icon_color()
+
+
+def get_asset_icon_by_name(icon_name, icon_color, has_children=False):
+    if not icon_name:
+        icon_name = get_default_asset_icon_name(has_children)
+
+    if icon_color:
+        icon_color = QtGui.QColor(icon_color)
+    else:
+        icon_color = get_default_entity_icon_color()
+    icon = get_qta_icon_by_name_and_color(icon_name, icon_color)
+    if icon is not None:
+        return icon
+    return get_qta_icon_by_name_and_color(
+        get_default_asset_icon_name(has_children),
+        icon_color
+    )
+
+
+def get_asset_icon_name(asset_doc, has_children=True):
+    icon_name = get_asset_icon_name_from_doc(asset_doc)
+    if icon_name:
+        return icon_name
+    return get_default_asset_icon_name(has_children)
+
+
+def get_asset_icon(asset_doc, has_children=False):
+    icon_name = get_asset_icon_name(asset_doc, has_children)
+    icon_color = get_asset_icon_color(asset_doc)
+
+    return get_qta_icon_by_name_and_color(icon_name, icon_color)
 
 
 class _AssetsView(TreeViewSpinner, DeselectableTreeView):

--- a/client/ayon_core/tools/utils/lib.py
+++ b/client/ayon_core/tools/utils/lib.py
@@ -234,62 +234,6 @@ def get_qta_icon_by_name_and_color(icon_name, icon_color):
     return icon
 
 
-def get_asset_icon_name(asset_doc, has_children=True):
-    icon_name = get_asset_icon_name_from_doc(asset_doc)
-    if icon_name:
-        return icon_name
-    return get_default_asset_icon_name(has_children)
-
-
-def get_asset_icon_color(asset_doc):
-    icon_color = get_asset_icon_color_from_doc(asset_doc)
-    if icon_color:
-        return icon_color
-    return get_default_entity_icon_color()
-
-
-def get_default_asset_icon_name(has_children):
-    if has_children:
-        return "fa.folder"
-    return "fa.folder-o"
-
-
-def get_asset_icon_name_from_doc(asset_doc):
-    if asset_doc:
-        return asset_doc["data"].get("icon")
-    return None
-
-
-def get_asset_icon_color_from_doc(asset_doc):
-    if asset_doc:
-        return asset_doc["data"].get("color")
-    return None
-
-
-def get_asset_icon_by_name(icon_name, icon_color, has_children=False):
-    if not icon_name:
-        icon_name = get_default_asset_icon_name(has_children)
-
-    if icon_color:
-        icon_color = QtGui.QColor(icon_color)
-    else:
-        icon_color = get_default_entity_icon_color()
-    icon = get_qta_icon_by_name_and_color(icon_name, icon_color)
-    if icon is not None:
-        return icon
-    return get_qta_icon_by_name_and_color(
-        get_default_asset_icon_name(has_children),
-        icon_color
-    )
-
-
-def get_asset_icon(asset_doc, has_children=False):
-    icon_name = get_asset_icon_name(asset_doc, has_children)
-    icon_color = get_asset_icon_color(asset_doc)
-
-    return get_qta_icon_by_name_and_color(icon_name, icon_color)
-
-
 def get_default_task_icon(color=None):
     if color is None:
         color = get_default_entity_icon_color()


### PR DESCRIPTION
## Changelog Description
The functions should not be used anywhere else than in assets widget at this moment, moving them to assets widget which is marked as deprecated should make it cleaner that they should not be used.

## Testing notes:
Just a technical change of functions and related imports.