### PR TITLE
Settings: Host imageio use AYON settings

### DIFF
--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -837,13 +837,13 @@ def get_imageio_config(
 
     if override_global_config:
         config_data = _get_config_data(
-            host_ocio_config["ocio_config"], formatting_data, env
+            host_ocio_config["filepath"], formatting_data, env
         )
     else:
         # get config path from global
         config_global = imageio_global["ocio_config"]
         config_data = _get_config_data(
-            config_global["ocio_config"], formatting_data, env
+            config_global["filepath"], formatting_data, env
         )
 
     if not config_data:

--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -254,7 +254,7 @@ def get_imageio_file_rules_colorspace_from_filepath(
 
     # match file rule from path
     colorspace_name = None
-    for file_rule in file_rules.values():
+    for file_rule in file_rules:
         pattern = file_rule["pattern"]
         extension = file_rule["ext"]
         ext_match = re.match(
@@ -281,7 +281,7 @@ def get_config_file_rules_colorspace_from_filepath(config_path, filepath):
         filepath (str): path leading to a file
 
     Returns:
-        Any[str, None]: matching colorspace name
+        Union[str, None]: matching colorspace name
     """
     if not compatibility_check():
         # python environment is not compatible with PyOpenColorIO
@@ -837,13 +837,13 @@ def get_imageio_config(
 
     if override_global_config:
         config_data = _get_config_data(
-            host_ocio_config["filepath"], formatting_data, env
+            host_ocio_config["ocio_config"], formatting_data, env
         )
     else:
         # get config path from global
         config_global = imageio_global["ocio_config"]
         config_data = _get_config_data(
-            config_global["filepath"], formatting_data, env
+            config_global["ocio_config"], formatting_data, env
         )
 
     if not config_data:
@@ -918,27 +918,12 @@ def get_imageio_file_rules(project_name, host_name, project_settings=None):
                                            Defaults to None.
 
     Returns:
-        dict: file rules data
+        list[dict[str, Any]]: file rules data
     """
     project_settings = project_settings or get_project_settings(project_name)
 
     imageio_global, imageio_host = _get_imageio_settings(
         project_settings, host_name)
-
-    # get file rules from global and host_name
-    frules_global = imageio_global["file_rules"]
-    activate_global_rules = (
-        frules_global.get("activate_global_file_rules", False)
-        # TODO: remove this in future - backward compatibility
-        or frules_global.get("enabled")
-    )
-    global_rules = frules_global["rules"]
-
-    if not activate_global_rules:
-        log.info(
-            "Colorspace global file rules are disabled."
-        )
-        global_rules = {}
 
     # host is optional, some might not have any settings
     frules_host = imageio_host.get("file_rules", {})
@@ -949,8 +934,24 @@ def get_imageio_file_rules(project_name, host_name, project_settings=None):
         # TODO: remove this in future - backward compatibility
         activate_host_rules = frules_host.get("enabled", False)
 
-    # return host rules if activated or global rules
-    return frules_host["rules"] if activate_host_rules else global_rules
+    if activate_host_rules:
+        return frules_host["rules"]
+
+    # get file rules from global and host_name
+    frules_global = imageio_global["file_rules"]
+    activate_global_rules = (
+        frules_global.get("activate_global_file_rules", False)
+        # TODO: remove this in future - backward compatibility
+        or frules_global.get("enabled")
+    )
+
+    if not activate_global_rules:
+        log.info(
+            "Colorspace global file rules are disabled."
+        )
+        return []
+
+    return frules_global["rules"]
 
 
 def get_remapped_colorspace_to_native(

--- a/client/ayon_core/settings/ayon_settings.py
+++ b/client/ayon_core/settings/ayon_settings.py
@@ -52,26 +52,6 @@ def _convert_color(color_value):
     return color_value
 
 
-def _convert_host_imageio(host_settings):
-    if "imageio" not in host_settings:
-        return
-
-    # --- imageio ---
-    ayon_imageio = host_settings["imageio"]
-    # TODO remove when fixed on server
-    if "ocio_config" in ayon_imageio["ocio_config"]:
-        ayon_imageio["ocio_config"]["filepath"] = (
-            ayon_imageio["ocio_config"].pop("ocio_config")
-        )
-    # Convert file rules
-    imageio_file_rules = ayon_imageio["file_rules"]
-    new_rules = {}
-    for rule in imageio_file_rules["rules"]:
-        name = rule.pop("name")
-        new_rules[name] = rule
-    imageio_file_rules["rules"] = new_rules
-
-
 def _convert_general(ayon_settings, output, default_settings):
     output["core"] = ayon_settings["core"]
     version_check_interval = (
@@ -242,7 +222,6 @@ def _convert_blender_project_settings(ayon_settings, output):
     if "blender" not in ayon_settings:
         return
     ayon_blender = ayon_settings["blender"]
-    _convert_host_imageio(ayon_blender)
 
     output["blender"] = ayon_blender
 
@@ -252,7 +231,6 @@ def _convert_celaction_project_settings(ayon_settings, output):
         return
 
     ayon_celaction = ayon_settings["celaction"]
-    _convert_host_imageio(ayon_celaction)
 
     output["celaction"] = ayon_celaction
 
@@ -263,7 +241,6 @@ def _convert_flame_project_settings(ayon_settings, output):
 
     ayon_flame = ayon_settings["flame"]
 
-    _convert_host_imageio(ayon_flame)
     output["flame"] = ayon_flame
 
 
@@ -272,7 +249,6 @@ def _convert_fusion_project_settings(ayon_settings, output):
         return
 
     ayon_fusion = ayon_settings["fusion"]
-    _convert_host_imageio(ayon_fusion)
 
     output["fusion"] = ayon_fusion
 
@@ -283,8 +259,6 @@ def _convert_maya_project_settings(ayon_settings, output):
 
     ayon_maya = ayon_settings["maya"]
 
-    _convert_host_imageio(ayon_maya)
-
     output["maya"] = ayon_maya
 
 
@@ -293,8 +267,6 @@ def _convert_3dsmax_project_settings(ayon_settings, output):
         return
 
     ayon_max = ayon_settings["max"]
-
-    _convert_host_imageio(ayon_max)
 
     output["max"] = ayon_max
 
@@ -442,7 +414,6 @@ def _convert_nuke_project_settings(ayon_settings, output):
 
     # --- ImageIO ---
     # NOTE 'monitorOutLut' is maybe not yet in v3 (ut should be)
-    _convert_host_imageio(ayon_nuke)
     ayon_imageio = ayon_nuke["imageio"]
 
     # workfile
@@ -491,7 +462,6 @@ def _convert_hiero_project_settings(ayon_settings, output):
         return
 
     ayon_hiero = ayon_settings["hiero"]
-    _convert_host_imageio(ayon_hiero)
 
     new_gui_filters = {}
     for item in ayon_hiero.pop("filters", []):
@@ -521,7 +491,6 @@ def _convert_photoshop_project_settings(ayon_settings, output):
         return
 
     ayon_photoshop = ayon_settings["photoshop"]
-    _convert_host_imageio(ayon_photoshop)
     output["photoshop"] = ayon_photoshop
 
 
@@ -530,7 +499,6 @@ def _convert_substancepainter_project_settings(ayon_settings, output):
         return
 
     ayon_substance_painter = ayon_settings["substancepainter"]
-    _convert_host_imageio(ayon_substance_painter)
     output["substancepainter"] = ayon_substance_painter
 
 
@@ -539,7 +507,6 @@ def _convert_tvpaint_project_settings(ayon_settings, output):
         return
 
     ayon_tvpaint = ayon_settings["tvpaint"]
-    _convert_host_imageio(ayon_tvpaint)
     output["tvpaint"] = ayon_tvpaint
 
 
@@ -549,8 +516,6 @@ def _convert_traypublisher_project_settings(ayon_settings, output):
 
     ayon_traypublisher = ayon_settings["traypublisher"]
 
-    _convert_host_imageio(ayon_traypublisher)
-
     output["traypublisher"] = ayon_traypublisher
 
 
@@ -559,7 +524,6 @@ def _convert_webpublisher_project_settings(ayon_settings, output):
         return
 
     ayon_webpublisher = ayon_settings["webpublisher"]
-    _convert_host_imageio(ayon_webpublisher)
 
     ayon_publish = ayon_webpublisher["publish"]
 
@@ -646,7 +610,6 @@ def _convert_global_project_settings(ayon_settings, output, default_settings):
 
     ayon_core = ayon_settings["core"]
 
-    _convert_host_imageio(ayon_core)
     # Publish conversion
     ayon_publish = ayon_core["publish"]
 
@@ -830,7 +793,6 @@ def convert_project_settings(ayon_settings, default_settings):
     for key in exact_match:
         if key in ayon_settings:
             output[key] = ayon_settings[key]
-            _convert_host_imageio(output[key])
 
     _convert_blender_project_settings(ayon_settings, output)
     _convert_celaction_project_settings(ayon_settings, output)


### PR DESCRIPTION
## Changelog Description
Imageio settings in hosts does not require conversion.

## Additional info
The changes should be affecting only settings that are used in `colorspace.py`. Modified `colorspace.py` to use AYON data structure. I'm not sure if there is a host which is using directly imageio settings that are handled by `colorspace.py`? I couldn't find any.

## Testing notes:
I need help with testing notes as I don't know what it in fact affects. Probably validate if imageio is used correctly during publishing?