### PR TITLE
Nuke: Use correct dirmap key

### DIFF
--- a/client/ayon_core/hosts/nuke/api/pipeline.py
+++ b/client/ayon_core/hosts/nuke/api/pipeline.py
@@ -179,7 +179,7 @@ def add_nuke_callbacks():
     nuke.addOnScriptLoad(WorkfileSettings().set_context_settings)
 
 
-    if nuke_settings["nuke_dirmap"]["enabled"]:
+    if nuke_settings["dirmap"]["enabled"]:
         log.info("Added Nuke's dir-mapping callback ...")
         # Add dirmap for file paths.
         nuke.addFilenameFilter(dirmap_file_name_filter)


### PR DESCRIPTION
## Changelog Description
Nuke's dirmap is stored under `"dirmap"` instead of `"nuke_dirmap"`.

## Testing notes:
1. Nuke should not complain about missing `"nuke_dirmap"` key on launch
