### PR TITLE
Clockify: Use AYON settings

### DIFF
--- a/client/ayon_core/modules/clockify/clockify_module.py
+++ b/client/ayon_core/modules/clockify/clockify_module.py
@@ -2,22 +2,27 @@ import os
 import threading
 import time
 
-from ayon_core.modules import OpenPypeModule, ITrayModule, IPluginPaths
+from ayon_core.modules import AYONAddon, ITrayModule, IPluginPaths
 from ayon_core.client import get_asset_by_name
 
 from .constants import CLOCKIFY_FTRACK_USER_PATH, CLOCKIFY_FTRACK_SERVER_PATH
 
 
-class ClockifyModule(OpenPypeModule, ITrayModule, IPluginPaths):
+class ClockifyModule(AYONAddon, ITrayModule, IPluginPaths):
     name = "clockify"
 
-    def initialize(self, modules_settings):
-        clockify_settings = modules_settings[self.name]
-        self.enabled = clockify_settings["enabled"]
-        self.workspace_name = clockify_settings["workspace_name"]
+    def initialize(self, studio_settings):
+        enabled = self.name in studio_settings
+        workspace_name = None
+        if enabled:
+            clockify_settings = studio_settings[self.name]
+            workspace_name = clockify_settings["workspace_name"]
 
-        if self.enabled and not self.workspace_name:
-            raise Exception("Clockify Workspace is not set in settings.")
+        if enabled and workspace_name:
+            self.log.warning("Clockify Workspace is not set in settings.")
+            enabled = False
+        self.enabled = enabled
+        self.workspace_name = workspace_name
 
         self.timer_manager = None
         self.MessageWidgetClass = None

--- a/client/ayon_core/settings/ayon_settings.py
+++ b/client/ayon_core/settings/ayon_settings.py
@@ -76,19 +76,6 @@ def _convert_kitsu_system_settings(
     output["modules"]["kitsu"] = kitsu_settings
 
 
-def _convert_clockify_system_settings(
-    ayon_settings, output, addon_versions, default_settings
-):
-    enabled = addon_versions.get("clockify") is not None
-    clockify_settings = default_settings["modules"]["clockify"]
-    clockify_settings["enabled"] = enabled
-    if enabled:
-        clockify_settings["workspace_name"] = (
-            ayon_settings["clockify"]["workspace_name"]
-        )
-    output["modules"]["clockify"] = clockify_settings
-
-
 def _convert_deadline_system_settings(
     ayon_settings, output, addon_versions, default_settings
 ):
@@ -127,7 +114,6 @@ def _convert_modules_system(
     # TODO add 'enabled' values
     for func in (
         _convert_kitsu_system_settings,
-        _convert_clockify_system_settings,
         _convert_deadline_system_settings,
         _convert_royalrender_system_settings,
     ):
@@ -135,6 +121,7 @@ def _convert_modules_system(
 
     for key in {
         "timers_manager",
+        "clockify",
     }:
         if addon_versions.get(key):
             output[key] = ayon_settings


### PR DESCRIPTION
## Changelog Description
Clockify addon can use AYON settings.

## Additional info
Removed clockify addon settings conversion. Clockify addon is using `AYONAddon` as base class. If workspace name is not set, the addon is just disabled (this can be enhanced in future).

## Testing notes:
1. Clockify addon is enabled/disabled based on selected version in bundle
2. Settings from clockify addon are propagated
