### PR TITLE
Use new package structure

### DIFF
--- a/package.py
+++ b/package.py
@@ -5,4 +5,7 @@ version = "0.2.1-dev.1"
 client_dir = "ayon_core"
 
 plugin_for = ["ayon_server"]
-ayon_version = ">=1.0.3,<2.0.0"
+requires = [
+   "~ayon_server-1.0.3+<2.0.0",
+]
+

--- a/server_addon/applications/server/__init__.py
+++ b/server_addon/applications/server/__init__.py
@@ -92,8 +92,9 @@ class ApplicationsAddon(BaseServerAddon):
     settings_model = ApplicationsAddonSettings
 
     async def get_default_settings(self):
-        applications_path = os.path.join(self.addon_dir, "applications.json")
-        tools_path = os.path.join(self.addon_dir, "tools.json")
+        server_dir = os.path.join(self.addon_dir, "server")
+        applications_path = os.path.join(server_dir, "applications.json")
+        tools_path = os.path.join(server_dir, "tools.json")
         default_values = copy.deepcopy(DEFAULT_VALUES)
         with open(applications_path, "r") as stream:
             default_values.update(json.load(stream))

--- a/server_addon/create_ayon_addons.py
+++ b/server_addon/create_ayon_addons.py
@@ -40,6 +40,11 @@ IGNORED_HOSTS = [
 
 IGNORED_MODULES = []
 
+PACKAGE_PY_TEMPLATE = """name = "{addon_name}"
+version = "{addon_version}"
+plugin_for = ["ayon_server"]
+"""
+
 
 class ZipFileLongPaths(zipfile.ZipFile):
     """Allows longer paths in zip files.
@@ -145,24 +150,11 @@ def create_addon_zip(
     addon_name: str,
     addon_version: str,
     keep_source: bool,
-    rez_package: bool,
 ):
     zip_filepath = output_dir / f"{addon_name}-{addon_version}.zip"
 
-    if rez_package:
-        zip_filepath = output_dir / f"{addon_name}-{addon_version}-rez.zip"
-
     addon_output_dir = output_dir / addon_name / addon_version
     with ZipFileLongPaths(zip_filepath, "w", zipfile.ZIP_DEFLATED) as zipf:
-        # TODO: Decide if we want to keep this for first pass checking without
-        # executing any python. Otherwiseh we can be removed
-        zipf.writestr(
-            "manifest.json",
-            json.dumps({
-                "addon_name": addon_name,
-                "addon_version": addon_version
-            })
-        )
         # Add client code content to zip
         src_root = os.path.normpath(str(addon_output_dir.absolute()))
         src_root_offset = len(src_root) + 1
@@ -174,14 +166,9 @@ def create_addon_zip(
             for filename in filenames:
                 src_path = os.path.join(root, filename)
                 if rel_root:
-                    dst_path = os.path.join("addon", rel_root, filename)
-                    if rez_package:
-                        dst_path = os.path.join(rel_root, filename)
+                    dst_path = os.path.join(rel_root, filename)
                 else:
-                    dst_path = os.path.join("addon", filename)
-
-                    if rez_package:
-                        dst_path = filename
+                    dst_path = filename
 
                 zipf.write(src_path, dst_path)
 
@@ -194,9 +181,7 @@ def create_addon_package(
     output_dir: Path,
     create_zip: bool,
     keep_source: bool,
-    rez_package: bool,
 ):
-    server_dir = addon_dir / "server"
     addon_version = get_addon_version(addon_dir)
 
     addon_output_dir = output_dir / addon_dir.name / addon_version
@@ -205,37 +190,22 @@ def create_addon_package(
     addon_output_dir.mkdir(parents=True)
 
     # Copy server content
-    if not rez_package:
-        src_root = os.path.normpath(str(server_dir.absolute()))
-        src_root_offset = len(src_root) + 1
-        for root, _, filenames in os.walk(str(server_dir)):
-            dst_root = addon_output_dir
-            if root != src_root:
-                rel_root = root[src_root_offset:]
-                dst_root = dst_root / rel_root
+    package_py = addon_output_dir / "package.py"
+    package_py_content = PACKAGE_PY_TEMPLATE.format(
+        addon_name=addon_dir.name, addon_version=addon_version
+    )
 
-            dst_root.mkdir(parents=True, exist_ok=True)
-            for filename in filenames:
-                src_path = os.path.join(root, filename)
-                shutil.copy(src_path, str(dst_root))
-    else:
-        package_py = addon_output_dir / "package.py"
+    with open(package_py, "w+") as pkg_py:
+        pkg_py.write(package_py_content)
 
-        with open(package_py, "w+") as pkg_py:
-            pkg_py.write(
-                f"""name = "{addon_dir.name}"
-version = "{addon_version}"
-plugin_for = ["ayon_server"]
-build_command = "python {{root}}/rezbuild.py"
-"""
-            )
-        shutil.copytree(
-            server_dir, addon_output_dir / "server", dirs_exist_ok=True
-        )
+    server_dir = addon_dir / "server"
+    shutil.copytree(
+        server_dir, addon_output_dir / "server", dirs_exist_ok=True
+    )
 
     if create_zip:
         create_addon_zip(
-            output_dir, addon_dir.name, addon_version, keep_source, rez_package
+            output_dir, addon_dir.name, addon_version, keep_source
         )
 
 
@@ -245,7 +215,6 @@ def main(
     keep_source=False,
     clear_output_dir=False,
     addons=None,
-    rez_package=False,
 ):
     current_dir = Path(os.path.dirname(os.path.abspath(__file__)))
     root_dir = current_dir.parent
@@ -280,7 +249,7 @@ def main(
             continue
 
         create_addon_package(
-            addon_dir, output_dir, create_zip, keep_source, rez_package
+            addon_dir, output_dir, create_zip, keep_source
         )
 
         print(f"- package '{addon_dir.name}' created")
@@ -330,13 +299,6 @@ if __name__ == "__main__":
         action="append",
         help="Limit addon creation to given addon name",
     )
-    parser.add_argument(
-        "-r",
-        "--rez",
-        dest="rez_package",
-        action="store_true",
-        help="Make it a Rez-compatible package",
-    )
 
     args = parser.parse_args(sys.argv[1:])
     main(
@@ -345,5 +307,4 @@ if __name__ == "__main__":
         args.keep_sources,
         args.clear_output_dir,
         args.addons,
-        args.rez_package,
     )


### PR DESCRIPTION
This commit will modify the `python` script that allows us to quickly generate packages for `ayon-backend` ingestion, either by copying them to the `rez` repo (not advised) or installing them via the `ayon-frontend` by uploading the resulting `zip`s of the script.

## Changelog Description
This is a PR that will allow us to then test the functionality of this `ayon-backend` PR: https://github.com/ynput/ayon-backend/pull/29

Instead of creating a folder structure at this step, we delegate it to the `rezbuild.py` on the `ayon-backend` which expects the `package.py` and the usual folder structure  of the addon source code (https://github.com/ynput/ayon-addon-template), thus this step is greatly simplified where we only copy the contents of the addon, add a `package.py` and zip them up. 

* 4113ff7bf0 Add `rez` packages generation for `server_addons` Allow to generate `rez` compatible packages for the `server_addons`, will create a `package.py` which then is also included in the `.zip`.

* 0744c27c91 `package.py` Ensure we require the correct `ayon_server` version For more info on `rez` package requests syntax check: https://rez.readthedocs.io/en/latest/basic_concepts.html#package-requests-concept


## Testing notes:
1. Clone this branch
2. Run `python server_addon/create_ayon_addons.py -r`
3.  Confirm `zip` archives have been generated in `ayon-core/server_addon/packages` ending in `-rez.zip` and should have the `package.py` at the root of the zip alongside the `manifest.json`.
4. If you are running the backend with the rez implementation: Install the addon, enable it and make sure it is able to initialize.