### PR TITLE
Addons: Change color types back to their previous type

### DIFF
--- a/client/ayon_core/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/client/ayon_core/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -31,7 +31,7 @@ class ExtractSequence(pyblish.api.Extractor):
     families = ["review", "render"]
 
     # Modifiable with settings
-    review_bg = [255, 255, 255, 255]
+    review_bg = [255, 255, 255, 1.0]
 
     def process(self, instance):
         self.log.info(

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -387,14 +387,22 @@ class ExtractReviewOutputDefModel(BaseSettingsModel):
             "Crop input overscan. See the documentation for more information."
         )
     )
-    overscan_color: ColorRGB_uint8 = SettingsField(
-        (0, 0, 0),
+    overscan_color: ColorRGBA_uint8 = SettingsField(
+        (0, 0, 0, 0.0),
         title="Overscan color",
         description=(
             "Overscan color is used when input aspect ratio is not"
             " same as output aspect ratio."
         )
     )
+    # overscan_color: ColorRGB_uint8 = SettingsField(
+    #     (0, 0, 0),
+    #     title="Overscan color",
+    #     description=(
+    #         "Overscan color is used when input aspect ratio is not"
+    #         " same as output aspect ratio."
+    #     )
+    # )
     width: int = SettingsField(
         0,
         ge=0,
@@ -901,7 +909,8 @@ DEFAULT_PUBLISH_VALUES = {
                             "single_frame_filter": "single_frame"
                         },
                         "overscan_crop": "",
-                        "overscan_color": [0, 0, 0],
+                        # "overscan_color": [0, 0, 0],
+                        "overscan_color": [0, 0, 0, 0.0],
                         "width": 1920,
                         "height": 1080,
                         "scale_pixel_aspect": True,
@@ -946,7 +955,8 @@ DEFAULT_PUBLISH_VALUES = {
                             "single_frame_filter": "multi_frame"
                         },
                         "overscan_crop": "",
-                        "overscan_color": [0, 0, 0],
+                        # "overscan_color": [0, 0, 0],
+                        "overscan_color": [0, 0, 0, 0.0],
                         "width": 0,
                         "height": 0,
                         "scale_pixel_aspect": True,

--- a/server_addon/maya/server/settings/loaders.py
+++ b/server_addon/maya/server/settings/loaders.py
@@ -3,70 +3,86 @@ from ayon_server.types import ColorRGB_float
 
 
 class ColorsSetting(BaseSettingsModel):
-    model: ColorRGB_float = SettingsField(
-        (0.82, 0.52, 0.12),
-        title="Model:"
-    )
-    rig: ColorRGB_float = SettingsField(
-        (0.23, 0.89, 0.92),
-        title="Rig:"
-    )
-    pointcache: ColorRGB_float = SettingsField(
-        (0.37, 0.82, 0.12),
-        title="Pointcache:"
-    )
-    animation: ColorRGB_float = SettingsField(
-        (0.37, 0.82, 0.12),
-        title="Animation:"
-    )
-    ass: ColorRGB_float = SettingsField(
-        (0.98, 0.53, 0.21),
-        title="Arnold StandIn:"
-    )
-    camera: ColorRGB_float = SettingsField(
-        (0.53, 0.45, 0.96),
-        title="Camera:"
-    )
-    fbx: ColorRGB_float = SettingsField(
-        (0.84, 0.65, 1.0),
-        title="FBX:"
-    )
-    mayaAscii: ColorRGB_float = SettingsField(
-        (0.26, 0.68, 1.0),
-        title="Maya Ascii:"
-    )
-    mayaScene: ColorRGB_float = SettingsField(
-        (0.26, 0.68, 1.0),
-        title="Maya Scene:"
-    )
-    setdress: ColorRGB_float = SettingsField(
-        (1.0, 0.98, 0.35),
-        title="Set Dress:"
-    )
-    layout: ColorRGB_float = SettingsField(
-        (1.0, 0.98, 0.35),
-        title="Layout:"
-    )
-    vdbcache: ColorRGB_float = SettingsField(
-        (0.98, 0.21, 0.0),
-        title="VDB Cache:"
-    )
-    vrayproxy: ColorRGB_float = SettingsField(
-        (1.0, 0.59, 0.05),
-        title="VRay Proxy:"
-    )
-    vrayscene_layer: ColorRGB_float = SettingsField(
-        (1.0, 0.59, 0.05),
-        title="VRay Scene:"
-    )
-    yeticache: ColorRGB_float = SettingsField(
-        (0.39, 0.81, 0.86),
-        title="Yeti Cache:"
-    )
-    yetiRig: ColorRGB_float = SettingsField(
-        (0.0, 0.80, 0.49),
-        title="Yeti Rig:"
-    )
+    model: ColorRGBA_uint8 = SettingsField(
+        (209, 132, 30, 1.0), title="Model:")
+    rig: ColorRGBA_uint8 = SettingsField(
+        (59, 226, 235, 1.0), title="Rig:")
+    pointcache: ColorRGBA_uint8 = SettingsField(
+        (94, 209, 30, 1.0), title="Pointcache:")
+    animation: ColorRGBA_uint8 = SettingsField(
+        (94, 209, 30, 1.0), title="Animation:")
+    ass: ColorRGBA_uint8 = SettingsField(
+        (249, 135, 53, 1.0), title="Arnold StandIn:")
+    camera: ColorRGBA_uint8 = SettingsField(
+        (136, 114, 244, 1.0), title="Camera:")
+    fbx: ColorRGBA_uint8 = SettingsField(
+        (215, 166, 255, 1.0), title="FBX:")
+    mayaAscii: ColorRGBA_uint8 = SettingsField(
+        (67, 174, 255, 1.0), title="Maya Ascii:")
+    mayaScene: ColorRGBA_uint8 = SettingsField(
+        (67, 174, 255, 1.0), title="Maya Scene:")
+    setdress: ColorRGBA_uint8 = SettingsField(
+        (255, 250, 90, 1.0), title="Set Dress:")
+    layout: ColorRGBA_uint8 = SettingsField((
+        255, 250, 90, 1.0), title="Layout:")
+    vdbcache: ColorRGBA_uint8 = SettingsField(
+        (249, 54, 0, 1.0), title="VDB Cache:")
+    vrayproxy: ColorRGBA_uint8 = SettingsField(
+        (255, 150, 12, 1.0), title="VRay Proxy:")
+    vrayscene_layer: ColorRGBA_uint8 = SettingsField(
+        (255, 150, 12, 1.0), title="VRay Scene:")
+    yeticache: ColorRGBA_uint8 = SettingsField(
+        (99, 206, 220, 1.0), title="Yeti Cache:")
+    yetiRig: ColorRGBA_uint8 = SettingsField(
+        (0, 205, 125, 1.0), title="Yeti Rig:")
+    # model: ColorRGB_float = SettingsField(
+    #     (0.82, 0.52, 0.12), title="Model:"
+    # )
+    # rig: ColorRGB_float = SettingsField(
+    #     (0.23, 0.89, 0.92), title="Rig:"
+    # )
+    # pointcache: ColorRGB_float = SettingsField(
+    #     (0.37, 0.82, 0.12), title="Pointcache:"
+    # )
+    # animation: ColorRGB_float = SettingsField(
+    #     (0.37, 0.82, 0.12), title="Animation:"
+    # )
+    # ass: ColorRGB_float = SettingsField(
+    #     (0.98, 0.53, 0.21), title="Arnold StandIn:"
+    # )
+    # camera: ColorRGB_float = SettingsField(
+    #     (0.53, 0.45, 0.96), title="Camera:"
+    # )
+    # fbx: ColorRGB_float = SettingsField(
+    #     (0.84, 0.65, 1.0), title="FBX:"
+    # )
+    # mayaAscii: ColorRGB_float = SettingsField(
+    #     (0.26, 0.68, 1.0), title="Maya Ascii:"
+    # )
+    # mayaScene: ColorRGB_float = SettingsField(
+    #     (0.26, 0.68, 1.0), title="Maya Scene:"
+    # )
+    # setdress: ColorRGB_float = SettingsField(
+    #     (1.0, 0.98, 0.35), title="Set Dress:"
+    # )
+    # layout: ColorRGB_float = SettingsField(
+    #     (1.0, 0.98, 0.35), title="Layout:"
+    # )
+    # vdbcache: ColorRGB_float = SettingsField(
+    #     (0.98, 0.21, 0.0), title="VDB Cache:"
+    # )
+    # vrayproxy: ColorRGB_float = SettingsField(
+    #     (1.0, 0.59, 0.05), title="VRay Proxy:"
+    # )
+    # vrayscene_layer: ColorRGB_float = SettingsField(
+    #     (1.0, 0.59, 0.05), title="VRay Scene:"
+    # )
+    # yeticache: ColorRGB_float = SettingsField(
+    #     (0.39, 0.81, 0.86), title="Yeti Cache:"
+    # )
+    # yetiRig: ColorRGB_float = SettingsField(
+    #     (0.0, 0.80, 0.49), title="Yeti Rig:"
+    # )
 
 
 class ReferenceLoaderModel(BaseSettingsModel):
@@ -99,22 +115,38 @@ class LoadersModel(BaseSettingsModel):
 
 DEFAULT_LOADERS_SETTING = {
     "colors": {
-        "model": [0.82, 0.52, 0.12],
-        "rig": [0.23, 0.89, 0.92],
-        "pointcache": [0.37, 0.82, 0.12],
-        "animation": [0.37, 0.82, 0.12],
-        "ass": [0.98, 0.53, 0.21],
-        "camera":[0.53, 0.45, 0.96],
-        "fbx": [0.84, 0.65, 1.0],
-        "mayaAscii": [0.26, 0.68, 1.0],
-        "mayaScene": [0.26, 0.68, 1.0],
-        "setdress": [1.0, 0.98, 0.35],
-        "layout": [1.0, 0.98, 0.35],
-        "vdbcache": [0.98, 0.21, 0.0],
-        "vrayproxy": [1.0, 0.59, 0.05],
-        "vrayscene_layer": [1.0, 0.59, 0.05],
-        "yeticache": [0.39, 0.81, 0.86],
-        "yetiRig": [0.0, 0.80, 0.49],
+        "model": [209, 132, 30, 1.0],
+        "rig": [59, 226, 235, 1.0],
+        "pointcache": [94, 209, 30, 1.0],
+        "animation": [94, 209, 30, 1.0],
+        "ass": [249, 135, 53, 1.0],
+        "camera": [136, 114, 244, 1.0],
+        "fbx": [215, 166, 255, 1.0],
+        "mayaAscii": [67, 174, 255, 1.0],
+        "mayaScene": [67, 174, 255, 1.0],
+        "setdress": [255, 250, 90, 1.0],
+        "layout": [255, 250, 90, 1.0],
+        "vdbcache": [249, 54, 0, 1.0],
+        "vrayproxy": [255, 150, 12, 1.0],
+        "vrayscene_layer": [255, 150, 12, 1.0],
+        "yeticache": [99, 206, 220, 1.0],
+        "yetiRig": [0, 205, 125, 1.0]
+        # "model": [0.82, 0.52, 0.12],
+        # "rig": [0.23, 0.89, 0.92],
+        # "pointcache": [0.37, 0.82, 0.12],
+        # "animation": [0.37, 0.82, 0.12],
+        # "ass": [0.98, 0.53, 0.21],
+        # "camera":[0.53, 0.45, 0.96],
+        # "fbx": [0.84, 0.65, 1.0],
+        # "mayaAscii": [0.26, 0.68, 1.0],
+        # "mayaScene": [0.26, 0.68, 1.0],
+        # "setdress": [1.0, 0.98, 0.35],
+        # "layout": [1.0, 0.98, 0.35],
+        # "vdbcache": [0.98, 0.21, 0.0],
+        # "vrayproxy": [1.0, 0.59, 0.05],
+        # "vrayscene_layer": [1.0, 0.59, 0.05],
+        # "yeticache": [0.39, 0.81, 0.86],
+        # "yetiRig": [0.0, 0.80, 0.49],
     },
     "reference_loader": {
         "namespace": "{folder[name]}_{product[name]}_##_",

--- a/server_addon/maya/server/settings/publish_playblast.py
+++ b/server_addon/maya/server/settings/publish_playblast.py
@@ -6,7 +6,7 @@ from ayon_server.settings import (
     ensure_unique_names,
     task_types_enum,
 )
-from ayon_server.types import ColorRGB_float
+from ayon_server.types import ColorRGBA_uint8, ColorRGB_float
 
 
 def hardware_falloff_enum():
@@ -54,18 +54,27 @@ class DisplayOptionsSetting(BaseSettingsModel):
     override_display: bool = SettingsField(
         True, title="Override display options"
     )
-    background: ColorRGB_float = SettingsField(
-        (0.5, 0.5, 0.5), title="Background Color"
+    background: ColorRGBA_uint8 = SettingsField(
+        (125, 125, 125, 1.0), title="Background Color"
     )
+    # background: ColorRGB_float = SettingsField(
+    #     (0.5, 0.5, 0.5), title="Background Color"
+    # )
     displayGradient: bool = SettingsField(
         True, title="Display background gradient"
     )
-    backgroundTop: ColorRGB_float = SettingsField(
-        (0.5, 0.5, 0.5), title="Background Top"
+    backgroundTop: ColorRGBA_uint8 = SettingsField(
+        (125, 125, 125, 1.0), title="Background Top"
     )
-    backgroundBottom: ColorRGB_float = SettingsField(
-        (0.5, 0.5, 0.5), title="Background Bottom"
+    backgroundBottom: ColorRGBA_uint8 = SettingsField(
+        (125, 125, 125, 1.0), title="Background Bottom"
     )
+    # backgroundTop: ColorRGB_float = SettingsField(
+    #     (0.5, 0.5, 0.5), title="Background Top"
+    # )
+    # backgroundBottom: ColorRGB_float = SettingsField(
+    #     (0.5, 0.5, 0.5), title="Background Bottom"
+    # )
 
 
 class GenericSetting(BaseSettingsModel):
@@ -282,21 +291,12 @@ DEFAULT_PLAYBLAST_SETTING = {
         },
         "DisplayOptions": {
             "override_display": True,
-            "background": [
-                0.5,
-                0.5,
-                0.5
-            ],
-            "backgroundBottom": [
-                0.5,
-                0.5,
-                0.5
-            ],
-            "backgroundTop": [
-                0.5,
-                0.5,
-                0.5
-            ],
+            "background": [125, 125, 125, 1.0],
+            "backgroundBottom": [125, 125, 125, 1.0],
+            "backgroundTop": [125, 125, 125, 1.0],
+            # "background": [0.5, 0.5, 0.5],
+            # "backgroundBottom": [0.5, 0.5, 0.5],
+            # "backgroundTop": [0.5, 0.5, 0.5],
             "displayGradient": True
         },
         "Generic": {

--- a/server_addon/tvpaint/server/settings/publish_plugins.py
+++ b/server_addon/tvpaint/server/settings/publish_plugins.py
@@ -1,5 +1,5 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
-from ayon_server.types import ColorRGB_uint8
+from ayon_server.types import ColorRGBA_uint8, ColorRGB_uint8
 
 
 class CollectRenderInstancesModel(BaseSettingsModel):
@@ -10,10 +10,12 @@ class CollectRenderInstancesModel(BaseSettingsModel):
 
 class ExtractSequenceModel(BaseSettingsModel):
     """Review BG color is used for whole scene review and for thumbnails."""
-    # TODO Use alpha color
-    review_bg: ColorRGB_uint8 = SettingsField(
-        (255, 255, 255),
+    review_bg: ColorRGBA_uint8 = SettingsField(
+        (255, 255, 255, 1.0),
         title="Review BG color")
+    # review_bg: ColorRGB_uint8 = SettingsField(
+    #     (255, 255, 255),
+    #     title="Review BG color")
 
 
 class ValidatePluginModel(BaseSettingsModel):
@@ -100,7 +102,8 @@ DEFAULT_PUBLISH_SETTINGS = {
         "ignore_render_pass_transparency": False
     },
     "ExtractSequence": {
-        "review_bg": [255, 255, 255]
+        # "review_bg": [255, 255, 255]
+        "review_bg": [255, 255, 255, 1.0]
     },
     "ValidateProjectSettings": {
         "enabled": True,


### PR DESCRIPTION
## Changelog Description
Fix issue with conversion of settings overrides after [PR](https://github.com/ynput/ayon-core/pull/20).

## Additional info
The issue is that conversion between the color types cannot happen automatically and conversion of overrides for specific version of addon is not yet implemented for addons (I though it is). The biggest difference from current values is that alpha is not used or is used float instead of int, all cases are already handled in code so it is really just change of types in settings. Keeping addon versions as their current version should be what they really are.

New types in models were just commented out as preparation for moment when the conversion of overrides will be working on addons.

## Testing notes:
1. Create server addons packages.
2. Upload them to server.
3. Try to convert existing overrides to new versions.
