### PR TITLE
Maya: Fix missing import in Maya addon

### DIFF
--- a/server_addon/maya/server/settings/loaders.py
+++ b/server_addon/maya/server/settings/loaders.py
@@ -1,5 +1,5 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
-from ayon_server.types import ColorRGB_float
+from ayon_server.types import ColorRGB_float, ColorRGBA_uint8
 
 
 class ColorsSetting(BaseSettingsModel):


### PR DESCRIPTION
## Changelog Description
Add missing `ColorRGBA_uint8` import in maya addon.
