### PR TITLE
RoyalRender: Fix addon name in package.py

### DIFF
--- a/server_addon/create_ayon_addons.py
+++ b/server_addon/create_ayon_addons.py
@@ -191,8 +191,11 @@ def create_addon_package(
 
     # Copy server content
     package_py = addon_output_dir / "package.py"
+    addon_name = addon_dir.name
+    if addon_name == "royal_render":
+        addon_name = "royalrender"
     package_py_content = PACKAGE_PY_TEMPLATE.format(
-        addon_name=addon_dir.name, addon_version=addon_version
+        addon_name=addon_name, addon_version=addon_version
     )
 
     with open(package_py, "w+") as pkg_py:


### PR DESCRIPTION
## Changelog Description
Addon name in package.py does match with real addon name.

## Additional info
The mismatching addon name cause issues when addon is loaded in bundle.

## Testing notes:
1. Create addons packages
2. Upload royal render package to server
3. Add the addon to bundle
4. The bundle should work correctly and royal render should allow to change settings
