### PR TITLE
Deadline: Use AYON settings

### DIFF
--- a/client/ayon_core/modules/deadline/deadline_module.py
+++ b/client/ayon_core/modules/deadline/deadline_module.py
@@ -4,7 +4,7 @@ import six
 import sys
 
 from ayon_core.lib import requests_get, Logger
-from ayon_core.modules import OpenPypeModule, IPluginPaths
+from ayon_core.modules import AYONAddon, IPluginPaths
 
 
 class DeadlineWebserviceError(Exception):
@@ -13,28 +13,28 @@ class DeadlineWebserviceError(Exception):
     """
 
 
-class DeadlineModule(OpenPypeModule, IPluginPaths):
+class DeadlineModule(AYONAddon, IPluginPaths):
     name = "deadline"
 
-    def __init__(self, manager, settings):
-        self.deadline_urls = {}
-        super(DeadlineModule, self).__init__(manager, settings)
-
-    def initialize(self, modules_settings):
+    def initialize(self, studio_settings):
         # This module is always enabled
-        deadline_settings = modules_settings[self.name]
-        self.enabled = deadline_settings["enabled"]
-        deadline_url = deadline_settings.get("DEADLINE_REST_URL")
-        if deadline_url:
-            self.deadline_urls = {"default": deadline_url}
-        else:
-            self.deadline_urls = deadline_settings.get("deadline_urls")  # noqa: E501
+        deadline_urls = {}
+        enabled = self.name in studio_settings
+        if enabled:
+            deadline_settings = studio_settings[self.name]
+            deadline_urls = {
+                url_item["name"]: url_item["value"]
+                for url_item in deadline_settings["deadline_urls"]
+            }
 
-        if not self.deadline_urls:
-            self.enabled = False
-            self.log.warning(("default Deadline Webservice URL "
-                              "not specified. Disabling module."))
-            return
+        if enabled and not deadline_urls:
+            enabled = False
+            self.log.warning((
+                "Deadline Webservice URLs are not specified. Disabling addon."
+            ))
+
+        self.enabled = enabled
+        self.deadline_urls = deadline_urls
 
     def get_plugin_paths(self):
         """Deadline plugin paths."""

--- a/client/ayon_core/modules/deadline/plugins/publish/collect_deadline_server_from_instance.py
+++ b/client/ayon_core/modules/deadline/plugins/publish/collect_deadline_server_from_instance.py
@@ -47,11 +47,11 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
         deadline_settings = (
             render_instance.context.data
             ["system_settings"]
-            ["modules"]
             ["deadline"]
         )
 
         default_server = render_instance.context.data["defaultDeadline"]
+        # QUESTION How and where is this is set? Should be removed?
         instance_server = render_instance.data.get("deadlineServers")
         if not instance_server:
             self.log.debug("Using default server.")
@@ -64,7 +64,10 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
                 asString=True
             )
 
-        default_servers = deadline_settings["deadline_urls"]
+        default_servers = {
+            url_item["name"]: url_item["value"]
+            for url_item in deadline_settings["deadline_urls"]
+        }
         project_servers = (
             render_instance.context.data
             ["project_settings"]

--- a/client/ayon_core/settings/ayon_settings.py
+++ b/client/ayon_core/settings/ayon_settings.py
@@ -62,22 +62,6 @@ def _convert_general(ayon_settings, output, default_settings):
     }
 
 
-def _convert_deadline_system_settings(
-    ayon_settings, output, addon_versions, default_settings
-):
-    enabled = addon_versions.get("deadline") is not None
-    deadline_settings = default_settings["modules"]["deadline"]
-    deadline_settings["enabled"] = enabled
-    if enabled:
-        ayon_deadline = ayon_settings["deadline"]
-        deadline_settings["deadline_urls"] = {
-            item["name"]: item["value"]
-            for item in ayon_deadline["deadline_urls"]
-        }
-
-    output["modules"]["deadline"] = deadline_settings
-
-
 def _convert_royalrender_system_settings(
     ayon_settings, output, addon_versions, default_settings
 ):
@@ -99,7 +83,6 @@ def _convert_modules_system(
     # TODO add all modules
     # TODO add 'enabled' values
     for func in (
-        _convert_deadline_system_settings,
         _convert_royalrender_system_settings,
     ):
         func(ayon_settings, output, addon_versions, default_settings)
@@ -107,6 +90,7 @@ def _convert_modules_system(
     for key in {
         "timers_manager",
         "clockify",
+        "deadline",
     }:
         if addon_versions.get(key):
             output[key] = ayon_settings


### PR DESCRIPTION
## Changelog Description
Deadline addon can use AYON settings.

## Additional info
Modified how 'deadline_urls' are used. It will require more work in future PRs as there were found inconsistencies across the codebase related to deadline urls.

## Testing notes:
1. Submit to deadline should work.
2. Farm jobs should work.
