### PR TITLE
Chore: Remove local settings function

### DIFF
--- a/client/ayon_core/host/dirmap.py
+++ b/client/ayon_core/host/dirmap.py
@@ -181,6 +181,10 @@ class HostDirmap(object):
                 exclude_locals=False,
                 cached=False)
 
+            # TODO implement
+            # Dirmap is dependent on 'get_site_local_overrides' which
+            #   is not implemented in AYON. The mapping should be received
+            #   from sitesync addon.
             active_overrides = get_site_local_overrides(
                 project_name, active_site)
             remote_overrides = get_site_local_overrides(

--- a/client/ayon_core/lib/applications.py
+++ b/client/ayon_core/lib/applications.py
@@ -16,7 +16,6 @@ from ayon_core.client import get_asset_name_identifier
 from ayon_core.settings import (
     get_system_settings,
     get_project_settings,
-    get_local_settings
 )
 from ayon_core.settings.constants import (
     METADATA_KEYS,
@@ -1528,16 +1527,17 @@ def prepare_app_environments(
 
     # Use environments from local settings
     filtered_local_envs = {}
-    system_settings = data["system_settings"]
-    whitelist_envs = system_settings["general"].get("local_env_white_list")
-    if whitelist_envs:
-        local_settings = get_local_settings()
-        local_envs = local_settings.get("environments") or {}
-        filtered_local_envs = {
-            key: value
-            for key, value in local_envs.items()
-            if key in whitelist_envs
-        }
+    # NOTE Overrides for environment variables are not implemented in AYON.
+    # system_settings = data["system_settings"]
+    # whitelist_envs = system_settings["general"].get("local_env_white_list")
+    # if whitelist_envs:
+    #     local_settings = get_local_settings()
+    #     local_envs = local_settings.get("environments") or {}
+    #     filtered_local_envs = {
+    #         key: value
+    #         for key, value in local_envs.items()
+    #         if key in whitelist_envs
+    #     }
 
     # Apply local environment variables for already existing values
     for key, value in filtered_local_envs.items():

--- a/client/ayon_core/lib/ayon_info.py
+++ b/client/ayon_core/lib/ayon_info.py
@@ -5,7 +5,6 @@ import platform
 import getpass
 import socket
 
-from ayon_core.settings.lib import get_local_settings
 from .execute import get_ayon_launcher_args
 from .local_settings import get_local_site_id
 
@@ -96,7 +95,6 @@ def get_all_current_info():
     return {
         "workstation": get_workstation_info(),
         "env": os.environ.copy(),
-        "local_settings": get_local_settings(),
         "ayon": get_ayon_info(),
     }
 

--- a/client/ayon_core/settings/__init__.py
+++ b/client/ayon_core/settings/__init__.py
@@ -7,7 +7,6 @@ from .lib import (
     get_system_settings,
     get_project_settings,
     get_current_project_settings,
-    get_local_settings,
 )
 from .ayon_settings import get_ayon_settings
 
@@ -20,7 +19,6 @@ __all__ = (
     "get_system_settings",
     "get_project_settings",
     "get_current_project_settings",
-    "get_local_settings",
 
     "get_ayon_settings",
 )

--- a/client/ayon_core/settings/lib.py
+++ b/client/ayon_core/settings/lib.py
@@ -198,8 +198,8 @@ def merge_overrides(source_dict, override_dict):
 def get_site_local_overrides(project_name, site_name, local_settings=None):
     """Site overrides from local settings for passet project and site name.
 
-    Warning:
-        This function is not implemented for AYON.
+    Deprecated:
+        This function is not implemented for AYON and will be removed.
 
     Args:
         project_name (str): For which project are overrides.

--- a/client/ayon_core/settings/lib.py
+++ b/client/ayon_core/settings/lib.py
@@ -48,11 +48,6 @@ def clear_metadata_from_settings(values):
             clear_metadata_from_settings(item)
 
 
-def get_local_settings():
-    # TODO implement ayon implementation
-    return {}
-
-
 def load_openpype_default_settings():
     """Load openpype default settings."""
     return load_jsons_from_dir(DEFAULTS_DIR)

--- a/client/ayon_core/settings/lib.py
+++ b/client/ayon_core/settings/lib.py
@@ -198,39 +198,17 @@ def merge_overrides(source_dict, override_dict):
 def get_site_local_overrides(project_name, site_name, local_settings=None):
     """Site overrides from local settings for passet project and site name.
 
+    Warning:
+        This function is not implemented for AYON.
+
     Args:
         project_name (str): For which project are overrides.
         site_name (str): For which site are overrides needed.
         local_settings (dict): Preloaded local settings. They are loaded
             automatically if not passed.
     """
-    # Check if local settings were passed
-    if local_settings is None:
-        local_settings = get_local_settings()
 
-    output = {}
-
-    # Skip if local settings are empty
-    if not local_settings:
-        return output
-
-    local_project_settings = local_settings.get("projects") or {}
-
-    # Prepare overrides for entered project and for default project
-    project_locals = None
-    if project_name:
-        project_locals = local_project_settings.get(project_name)
-    default_project_locals = local_project_settings.get(DEFAULT_PROJECT_KEY)
-
-    # First load and use local settings from default project
-    if default_project_locals and site_name in default_project_locals:
-        output.update(default_project_locals[site_name])
-
-    # Apply project specific local settings if there are any
-    if project_locals and site_name in project_locals:
-        output.update(project_locals[site_name])
-
-    return output
+    return {}
 
 
 def get_current_project_settings():

--- a/client/ayon_core/tools/experimental_tools/tools_def.py
+++ b/client/ayon_core/tools/experimental_tools/tools_def.py
@@ -1,5 +1,4 @@
 import os
-from ayon_core.settings import get_local_settings
 
 # Constant key under which local settings are stored
 LOCAL_EXPERIMENTAL_KEY = "experimental_tools"
@@ -151,7 +150,10 @@ class ExperimentalTools:
 
     def refresh_availability(self):
         """Reload local settings and check if any tool changed ability."""
-        local_settings = get_local_settings()
+
+        # NOTE AYON does not have implemented settings for experimental
+        #   tools.
+        local_settings = {}
         experimental_settings = (
             local_settings.get(LOCAL_EXPERIMENTAL_KEY)
         ) or {}


### PR DESCRIPTION
## Changelog Description
Removed `get_local_settings` function from `ayon_core.settings`.

## Additional info
Local settings are not implemented in AYON the same way as were in OpenPype. Some of the local settings from OpenPype are at this moment not available in AYON at all, and other ones are stored per addon. It is not possible to easily receive all the values as it was in OpenPype, at least not now, and we have to make full replacement of them in future.

## Testing notes:
There is no visible change.
