### PR TITLE
Experimental Dialog: Reduced filtering hosts for publisher

### DIFF
--- a/client/ayon_core/tools/experimental_tools/tools_def.py
+++ b/client/ayon_core/tools/experimental_tools/tools_def.py
@@ -89,9 +89,13 @@ class ExperimentalTools:
                 "New publisher",
                 "Combined creation and publishing into one tool.",
                 self._show_publisher,
-                hosts_filter=["blender", "maya", "nuke", "celaction", "flame",
-                              "fusion", "harmony", "hiero", "resolve",
-                              "tvpaint", "unreal"]
+                hosts_filter=[
+                    "celaction",
+                    "flame",
+                    "harmony",
+                    "hiero",
+                    "resolve",
+                ]
             )
         ]
 


### PR DESCRIPTION
## Changelog Description
Filtering of publisher as experimental host was reduced to "celaction", "flame", "harmony", "hiero" and "resolve", all other hosts are already using it.