### PR TITLE
Remove 'ObjectId' usage

### DIFF
--- a/client/ayon_core/plugins/publish/collect_input_representations_to_versions.py
+++ b/client/ayon_core/plugins/publish/collect_input_representations_to_versions.py
@@ -1,7 +1,5 @@
 import pyblish.api
 
-from bson.objectid import ObjectId
-
 from ayon_core.client import get_representations
 
 

--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -6,7 +6,6 @@ import datetime
 
 import clique
 import six
-from bson.objectid import ObjectId
 import pyblish.api
 
 from ayon_core.client.operations import (
@@ -988,7 +987,6 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         """
 
         return {
-            "_id": ObjectId(),
             "path": self.get_rootless_path(anatomy, path),
             "size": os.path.getsize(path),
             "hash": source_hash(path),

--- a/client/ayon_core/tools/push_to_project/models/integrate.py
+++ b/client/ayon_core/tools/push_to_project/models/integrate.py
@@ -8,8 +8,6 @@ import sys
 import traceback
 import uuid
 
-from bson.objectid import ObjectId
-
 from ayon_core.client import (
     get_project,
     get_assets,
@@ -1080,7 +1078,6 @@ class ProjectPushItemProcess:
             new_repre_files = []
             for (path, rootless_path) in repre_filepaths:
                 new_repre_files.append({
-                    "_id": ObjectId(),
                     "path": rootless_path,
                     "size": os.path.getsize(path),
                     "hash": source_hash(path),


### PR DESCRIPTION
## Changelog Description
Removed usage of `ObjectId` objects.

## Additional info
The usage is not needed anymore and the dependency `bson` is not already defined in pyproject toml.

## Testing notes:
1. Publish integration should work.
