### PR TITLE
Chore: Use folder path in current context

### DIFF
--- a/client/ayon_core/cli_commands.py
+++ b/client/ayon_core/cli_commands.py
@@ -106,7 +106,7 @@ class Commands:
             context = get_global_context()
             env = get_app_environments_for_context(
                 context["project_name"],
-                context["asset_name"],
+                context["folder_path"],
                 context["task_name"],
                 app_full_name,
                 launch_type=LaunchTypes.farm_publish,

--- a/client/ayon_core/hooks/pre_copy_template_workfile.py
+++ b/client/ayon_core/hooks/pre_copy_template_workfile.py
@@ -54,7 +54,7 @@ class CopyTemplateWorkfile(PreLaunchHook):
         self.log.info("Last workfile does not exist.")
 
         project_name = self.data["project_name"]
-        asset_name = self.data["asset_name"]
+        asset_name = self.data["folder_path"]
         task_name = self.data["task_name"]
         host_name = self.application.host_name
 

--- a/client/ayon_core/hooks/pre_global_host_data.py
+++ b/client/ayon_core/hooks/pre_global_host_data.py
@@ -22,7 +22,7 @@ class GlobalHostDataHook(PreLaunchHook):
         app = self.launch_context.application
         temp_data = EnvironmentPrepData({
             "project_name": self.data["project_name"],
-            "asset_name": self.data["asset_name"],
+            "folder_path": self.data["folder_path"],
             "task_name": self.data["task_name"],
 
             "app": app,
@@ -66,7 +66,7 @@ class GlobalHostDataHook(PreLaunchHook):
         project_doc = get_project(project_name)
         self.data["project_doc"] = project_doc
 
-        asset_name = self.data.get("asset_name")
+        asset_name = self.data.get("folder_path")
         if not asset_name:
             self.log.warning(
                 "Asset name was not set. Skipping asset document query."

--- a/client/ayon_core/hooks/pre_ocio_hook.py
+++ b/client/ayon_core/hooks/pre_ocio_hook.py
@@ -27,7 +27,7 @@ class OCIOEnvHook(PreLaunchHook):
 
         template_data = get_template_data_with_names(
             project_name=self.data["project_name"],
-            asset_name=self.data["asset_name"],
+            asset_name=self.data["folder_path"],
             task_name=self.data["task_name"],
             host_name=self.host_name,
             system_settings=self.data["system_settings"]

--- a/client/ayon_core/host/host.py
+++ b/client/ayon_core/host/host.py
@@ -139,7 +139,7 @@ class HostBase(object):
 
         return {
             "project_name": self.get_current_project_name(),
-            "asset_name": self.get_current_asset_name(),
+            "folder_path": self.get_current_asset_name(),
             "task_name": self.get_current_task_name()
         }
 
@@ -161,7 +161,7 @@ class HostBase(object):
         # Use current context to fill the context title
         current_context = self.get_current_context()
         project_name = current_context["project_name"]
-        asset_name = current_context["asset_name"]
+        asset_name = current_context["folder_path"]
         task_name = current_context["task_name"]
         items = []
         if project_name:

--- a/client/ayon_core/host/host.py
+++ b/client/ayon_core/host/host.py
@@ -134,7 +134,7 @@ class HostBase(object):
 
         Returns:
             Dict[str, Union[str, None]]: Context with 3 keys 'project_name',
-                'asset_name' and 'task_name'. All of them can be 'None'.
+                'folder_path' and 'task_name'. All of them can be 'None'.
         """
 
         return {

--- a/client/ayon_core/hosts/aftereffects/api/lib.py
+++ b/client/ayon_core/hosts/aftereffects/api/lib.py
@@ -128,7 +128,7 @@ def set_settings(frames, resolution, comp_ids=None, print_msg=True):
     current_context = get_current_context()
 
     asset_doc = get_asset_by_name(current_context["project_name"],
-                                  current_context["asset_name"])
+                                  current_context["folder_path"])
     settings = get_asset_settings(asset_doc)
 
     msg = ''

--- a/client/ayon_core/hosts/houdini/api/lib.py
+++ b/client/ayon_core/hosts/houdini/api/lib.py
@@ -835,7 +835,7 @@ def get_current_context_template_data_with_asset_data():
 
     context = get_current_context()
     project_name = context["project_name"]
-    asset_name = context["asset_name"]
+    asset_name = context["folder_path"]
     task_name = context["task_name"]
     host_name = get_current_host_name()
 

--- a/client/ayon_core/hosts/nuke/api/lib.py
+++ b/client/ayon_core/hosts/nuke/api/lib.py
@@ -1924,10 +1924,7 @@ class WorkfileSettings(object):
 
         Context._project_doc = project_doc
         self._project_name = project_name
-        self._asset = (
-            kwargs.get("asset_name")
-            or get_current_asset_name()
-        )
+        self._asset = get_current_asset_name()
         self._asset_entity = get_asset_by_name(project_name, self._asset)
         self._root_node = root_node or nuke.root()
         self._nodes = self.get_nodes(nodes=nodes)

--- a/client/ayon_core/hosts/tvpaint/api/pipeline.py
+++ b/client/ayon_core/hosts/tvpaint/api/pipeline.py
@@ -99,7 +99,7 @@ class TVPaintHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             Union[str, None]: Current asset name.
         """
 
-        return self.get_current_context().get("asset_name")
+        return self.get_current_context().get("folder_path")
 
     def get_current_task_name(self):
         """
@@ -115,11 +115,13 @@ class TVPaintHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             return get_global_context()
 
         if "project_name" in context:
+            if "asset_name" in context:
+                context["folder_path"] = context["asset_name"]
             return context
         # This is legacy way how context was stored
         return {
             "project_name": context.get("project"),
-            "asset_name": context.get("asset"),
+            "folder_path": context.get("asset"),
             "task_name": context.get("task")
         }
 

--- a/client/ayon_core/hosts/tvpaint/plugins/load/load_workfile.py
+++ b/client/ayon_core/hosts/tvpaint/plugins/load/load_workfile.py
@@ -58,7 +58,7 @@ class LoadWorkfile(plugin.Loader):
         if not asset_name:
             context = get_current_context()
             project_name = context["project_name"]
-            asset_name = context["asset_name"]
+            asset_name = context["folder_path"]
             task_name = context["task_name"]
 
         template_key = get_workfile_template_key_from_context(

--- a/client/ayon_core/hosts/tvpaint/plugins/publish/collect_workfile_data.py
+++ b/client/ayon_core/hosts/tvpaint/plugins/publish/collect_workfile_data.py
@@ -65,7 +65,7 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
         # Collect and store current context to have reference
         current_context = {
             "project_name": context.data["projectName"],
-            "asset_name": context.data["folderPath"],
+            "folder_path": context.data["folderPath"],
             "task_name": context.data["task"]
         }
         self.log.debug("Current context is: {}".format(current_context))
@@ -77,7 +77,7 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
         if "project" in workfile_context:
             workfile_context = {
                 "project_name": workfile_context.get("project"),
-                "asset_name": workfile_context.get("asset"),
+                "folder_path": workfile_context.get("asset"),
                 "task_name": workfile_context.get("task"),
             }
         # Store workfile context to pyblish context
@@ -85,18 +85,18 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
         if workfile_context:
             # Change current context with context from workfile
             key_map = (
-                ("AYON_FOLDER_PATH", "asset_name"),
+                ("AYON_FOLDER_PATH", "folder_path"),
                 ("AYON_TASK_NAME", "task_name")
             )
             for env_key, key in key_map:
                 os.environ[env_key] = workfile_context[key]
             self.log.info("Context changed to: {}".format(workfile_context))
 
-            asset_name = workfile_context["asset_name"]
+            asset_name = workfile_context["folder_path"]
             task_name = workfile_context["task_name"]
 
         else:
-            asset_name = current_context["asset_name"]
+            asset_name = current_context["folder_path"]
             task_name = current_context["task_name"]
             # Handle older workfiles or workfiles without metadata
             self.log.warning((

--- a/client/ayon_core/hosts/tvpaint/plugins/publish/validate_workfile_metadata.py
+++ b/client/ayon_core/hosts/tvpaint/plugins/publish/validate_workfile_metadata.py
@@ -31,7 +31,7 @@ class ValidateWorkfileMetadata(pyblish.api.ContextPlugin):
 
     actions = [ValidateWorkfileMetadataRepair]
 
-    required_keys = {"project_name", "asset_name", "task_name"}
+    required_keys = {"project_name", "folder_path", "task_name"}
 
     def process(self, context):
         workfile_context = context.data["workfile_context"]

--- a/client/ayon_core/lib/applications.py
+++ b/client/ayon_core/lib/applications.py
@@ -493,7 +493,7 @@ class ApplicationManager:
         """Launch procedure.
 
         For host application it's expected to contain "project_name",
-        "asset_name" and "task_name".
+        "folder_path" and "task_name".
 
         Args:
             app_name (str): Name of application that should be launched.

--- a/client/ayon_core/lib/applications.py
+++ b/client/ayon_core/lib/applications.py
@@ -1410,7 +1410,7 @@ class EnvironmentPrepData(dict):
 
 def get_app_environments_for_context(
     project_name,
-    asset_name,
+    folder_path,
     task_name,
     app_name,
     env_group=None,
@@ -1421,7 +1421,7 @@ def get_app_environments_for_context(
     """Prepare environment variables by context.
     Args:
         project_name (str): Name of project.
-        asset_name (str): Name of asset.
+        folder_path (str): Folder path.
         task_name (str): Name of task.
         app_name (str): Name of application that is launched and can be found
             by ApplicationManager.
@@ -1443,7 +1443,7 @@ def get_app_environments_for_context(
     context = app_manager.create_launch_context(
         app_name,
         project_name=project_name,
-        asset_name=asset_name,
+        folder_path=folder_path,
         task_name=task_name,
         env_group=env_group,
         launch_type=launch_type,

--- a/client/ayon_core/modules/timers_manager/launch_hooks/post_start_timer.py
+++ b/client/ayon_core/modules/timers_manager/launch_hooks/post_start_timer.py
@@ -11,14 +11,14 @@ class PostStartTimerHook(PostLaunchHook):
 
     def execute(self):
         project_name = self.data.get("project_name")
-        asset_name = self.data.get("asset_name")
+        asset_name = self.data.get("folder_path")
         task_name = self.data.get("task_name")
 
         missing_context_keys = set()
         if not project_name:
             missing_context_keys.add("project_name")
         if not asset_name:
-            missing_context_keys.add("asset_name")
+            missing_context_keys.add("folder_path")
         if not task_name:
             missing_context_keys.add("task_name")
 

--- a/client/ayon_core/modules/timers_manager/rest_api.py
+++ b/client/ayon_core/modules/timers_manager/rest_api.py
@@ -45,7 +45,7 @@ class TimersManagerModuleRestApi:
         data = await request.json()
         try:
             project_name = data["project_name"]
-            asset_name = data["asset_name"]
+            asset_name = data["folder_path"]
             task_name = data["task_name"]
         except KeyError:
             msg = (

--- a/client/ayon_core/modules/timers_manager/rest_api.py
+++ b/client/ayon_core/modules/timers_manager/rest_api.py
@@ -50,7 +50,7 @@ class TimersManagerModuleRestApi:
         except KeyError:
             msg = (
                 "Payload must contain fields 'project_name,"
-                " 'asset_name' and 'task_name'"
+                " 'folder_path' and 'task_name'"
             )
             self.log.error(msg)
             return Response(status=400, message=msg)
@@ -71,11 +71,11 @@ class TimersManagerModuleRestApi:
         data = await request.json()
         try:
             project_name = data['project_name']
-            asset_name = data['asset_name']
+            asset_name = data['folder_path']
             task_name = data['task_name']
         except KeyError:
             message = (
-                "Payload must contain fields 'project_name, 'asset_name',"
+                "Payload must contain fields 'project_name, 'folder_path',"
                 " 'task_name'"
             )
             self.log.warning(message)

--- a/client/ayon_core/modules/timers_manager/timers_manager.py
+++ b/client/ayon_core/modules/timers_manager/timers_manager.py
@@ -430,7 +430,7 @@ class TimersManager(
             return
         data = {
             "project_name": project_name,
-            "asset_name": asset_name,
+            "folder_path": asset_name,
             "task_name": task_name
         }
 
@@ -472,7 +472,7 @@ class TimersManager(
 
     def _on_host_task_change(self, event):
         project_name = event["project_name"]
-        asset_name = event["asset_name"]
+        asset_name = event["folder_path"]
         task_name = event["task_name"]
         self.log.debug((
             "Sending message that timer should change to"

--- a/client/ayon_core/pipeline/context_tools.py
+++ b/client/ayon_core/pipeline/context_tools.py
@@ -355,7 +355,7 @@ def get_global_context():
     Example:
         {
             "project_name": "Commercial",
-            "asset_name": "Bunny",
+            "folder_path": "Bunny",
             "task_name": "Animation",
         }
 
@@ -366,7 +366,7 @@ def get_global_context():
 
     return {
         "project_name": os.environ.get("AYON_PROJECT_NAME"),
-        "asset_name": os.environ.get("AYON_FOLDER_PATH"),
+        "folder_path": os.environ.get("AYON_FOLDER_PATH"),
         "task_name": os.environ.get("AYON_TASK_NAME"),
     }
 
@@ -389,7 +389,7 @@ def get_current_asset_name():
     host = registered_host()
     if isinstance(host, HostBase):
         return host.get_current_asset_name()
-    return get_global_context()["asset_name"]
+    return get_global_context()["folder_path"]
 
 
 def get_current_task_name():
@@ -481,7 +481,7 @@ def get_template_data_from_session(session=None, system_settings=None):
     else:
         context = get_current_context()
         project_name = context["project_name"]
-        asset_name = context["asset_name"]
+        asset_name = context["folder_path"]
         task_name = context["task_name"]
         host_name = get_current_host_name()
 
@@ -502,7 +502,7 @@ def get_current_context_template_data(system_settings=None):
 
     context = get_current_context()
     project_name = context["project_name"]
-    asset_name = context["asset_name"]
+    asset_name = context["folder_path"]
     task_name = context["task_name"]
     host_name = get_current_host_name()
 
@@ -573,7 +573,7 @@ def get_custom_workfile_template_from_session(
     else:
         context = get_current_context()
         project_name = context["project_name"]
-        asset_name = context["asset_name"]
+        asset_name = context["folder_path"]
         task_name = context["task_name"]
         host_name = get_current_host_name()
 
@@ -634,7 +634,7 @@ def change_current_context(asset_doc, task_name, template_key=None):
 
     # Convert env keys to human readable keys
     data["project_name"] = project_name
-    data["asset_name"] = get_asset_name_identifier(asset_doc)
+    data["folder_path"] = get_asset_name_identifier(asset_doc)
     data["task_name"] = task_name
     data["workdir_path"] = workdir
 

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -1686,7 +1686,7 @@ class CreateContext:
             host_context = self.host.get_current_context()
             if host_context:
                 project_name = host_context.get("project_name")
-                asset_name = host_context.get("asset_name")
+                asset_name = host_context.get("folder_path")
                 task_name = host_context.get("task_name")
 
         if isinstance(self.host, IWorkfileHost):

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -148,7 +148,7 @@ class AbstractTemplateBuilder(object):
             return self._host.get_current_context()
         return {
             "project_name": self.project_name,
-            "asset_name": self.current_asset_name,
+            "folder_path": self.current_asset_name,
             "task_name": self.current_task_name
         }
 
@@ -1795,7 +1795,7 @@ class PlaceholderCreateMixin(object):
         # create subset name
         context = self._builder.get_current_context()
         project_name = context["project_name"]
-        asset_name = context["asset_name"]
+        asset_name = context["folder_path"]
         task_name = context["task_name"]
 
         if legacy_create:

--- a/client/ayon_core/plugins/publish/collect_current_context.py
+++ b/client/ayon_core/plugins/publish/collect_current_context.py
@@ -29,7 +29,7 @@ class CollectCurrentContext(pyblish.api.ContextPlugin):
             context.data["projectName"] = current_context["project_name"]
 
         if not asset_name:
-            context.data["folderPath"] = current_context["asset_name"]
+            context.data["folderPath"] = current_context["folder_path"]
 
         if not task_name:
             context.data["task"] = current_context["task_name"]

--- a/client/ayon_core/tools/adobe_webserver/app.py
+++ b/client/ayon_core/tools/adobe_webserver/app.py
@@ -82,7 +82,7 @@ class WebServerTool:
 
         context = get_global_context()
         project = context["project_name"]
-        asset = context["asset_name"]
+        asset = context["folder_path"]
         task = context["task_name"]
         log.info("Sending context change to {}-{}-{}".format(project,
                                                              asset,

--- a/client/ayon_core/tools/launcher/models/actions.py
+++ b/client/ayon_core/tools/launcher/models/actions.py
@@ -120,12 +120,12 @@ class ApplicationAction(LauncherAction):
         )
 
         project_name = session["AYON_PROJECT_NAME"]
-        asset_name = session["AYON_FOLDER_PATH"]
+        folder_path = session["AYON_FOLDER_PATH"]
         task_name = session["AYON_TASK_NAME"]
         try:
             self.application.launch(
                 project_name=project_name,
-                asset_name=asset_name,
+                folder_path=folder_path,
                 task_name=task_name,
                 **self.data
             )

--- a/client/ayon_core/tools/loader/control.py
+++ b/client/ayon_core/tools/loader/control.py
@@ -320,7 +320,7 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
             context = get_current_context()
         folder_id = None
         project_name = context.get("project_name")
-        asset_name = context.get("asset_name")
+        asset_name = context.get("folder_path")
         if project_name and asset_name:
             folder = ayon_api.get_folder_by_path(
                 project_name, asset_name, fields=["id"]

--- a/client/ayon_core/tools/sceneinventory/control.py
+++ b/client/ayon_core/tools/sceneinventory/control.py
@@ -69,10 +69,10 @@ class SceneInventoryController:
 
         context = self.get_current_context()
         project_name = context["project_name"]
-        folder_name = context.get("asset_name")
+        folder_path = context.get("folder_path")
         folder_id = None
-        if folder_name:
-            folder = ayon_api.get_folder_by_path(project_name, folder_name)
+        if folder_path:
+            folder = ayon_api.get_folder_by_path(project_name, folder_path)
             if folder:
                 folder_id = folder["id"]
 

--- a/client/ayon_core/tools/workfiles/control.py
+++ b/client/ayon_core/tools/workfiles/control.py
@@ -156,7 +156,7 @@ class BaseWorkfileController(
         self._log = None
 
         self._current_project_name = None
-        self._current_folder_name = None
+        self._current_folder_path = None
         self._current_folder_id = None
         self._current_task_name = None
         self._save_is_enabled = True
@@ -468,12 +468,12 @@ class BaseWorkfileController(
         context = self._get_host_current_context()
 
         project_name = context["project_name"]
-        folder_name = context["asset_name"]
+        folder_path = context["folder_path"]
         task_name = context["task_name"]
         current_file = self.get_current_workfile()
         folder_id = None
-        if folder_name:
-            folder = ayon_api.get_folder_by_path(project_name, folder_name)
+        if folder_path:
+            folder = ayon_api.get_folder_by_path(project_name, folder_path)
             if folder:
                 folder_id = folder["id"]
 
@@ -481,7 +481,7 @@ class BaseWorkfileController(
         self._project_anatomy = None
 
         self._current_project_name = project_name
-        self._current_folder_name = folder_name
+        self._current_folder_path = folder_path
         self._current_folder_id = folder_id
         self._current_task_name = task_name
 
@@ -639,6 +639,7 @@ class BaseWorkfileController(
         return {
             "project_name": project_name,
             "folder_id": folder_id,
+            "folder_path": folder["path"],
             "asset_id": folder_id,
             "asset_name": folder["name"],
             "task_id": task_id,


### PR DESCRIPTION
## Changelog Description
Use `folder_path` instead of `asset_name` in current context and context data.

## Additional info
This is minimalistic PR changing just the keys used when data for context are read or defined.

Breaks backwards compatibility on current context data and launch hooks. Launch hooks don't have access to `asset_name` in data.

## Testing notes:
1. Application can launch on a context.
2. Change of context with workfiles too triggers correct callbacks without issues.
