### PR TITLE
RoyalRender: Remove project settings conversion

### DIFF
--- a/client/ayon_core/settings/ayon_settings.py
+++ b/client/ayon_core/settings/ayon_settings.py
@@ -133,24 +133,9 @@ def convert_system_settings(ayon_settings, default_settings, addon_versions):
 
 
 # --------- Project settings ---------
-def _convert_royalrender_project_settings(ayon_settings, output):
-    if "royalrender" not in ayon_settings:
-        return
-    ayon_royalrender = ayon_settings["royalrender"]
-    rr_paths = ayon_royalrender.get("selected_rr_paths", [])
-
-    output["royalrender"] = {
-        "publish": ayon_royalrender["publish"],
-        "rr_paths": rr_paths,
-    }
-
-
 def convert_project_settings(ayon_settings, default_settings):
     default_settings = copy.deepcopy(default_settings)
     output = {}
-
-    _convert_royalrender_project_settings(ayon_settings, output)
-
     for key, value in ayon_settings.items():
         if key not in output:
             output[key] = value


### PR DESCRIPTION
## Changelog Description
Removed RoyalRender project settings conversion.

## Additional info
Forgot to remove the conversion in https://github.com/ynput/ayon-core/pull/77.

## Testing notes:
1. RR paths should be collected correctly.
