### PR TITLE
Houdini: use product name n product type (follow up PR)

### DIFF
--- a/client/ayon_core/hosts/houdini/api/plugin.py
+++ b/client/ayon_core/hosts/houdini/api/plugin.py
@@ -271,8 +271,8 @@ class HoudiniCreator(NewCreator, HoudiniCreatorBase):
     def imprint(self, node, values, update=False):
         # Never store instance node and instance id since that data comes
         # from the node's path
-        if "AYONProductName" in values:
-            values["productName"] = values.pop("AYONProductName")
+        if "productName" in values:
+            values["AYONProductName"] = values.pop("productName")
         values.pop("instance_node", None)
         values.pop("instance_id", None)
         imprint(node, values, update=update)

--- a/client/ayon_core/hosts/houdini/plugins/create/create_workfile.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_workfile.py
@@ -67,7 +67,7 @@ class CreateWorkfile(plugin.HoudiniCreatorBase, AutoCreator):
             )
             current_instance["folderPath"] = asset_name
             current_instance["task"] = task_name
-            current_instance["productName"] = product_name
+            current_instance["AYONProductName"] = product_name
 
         # write workfile information to context container.
         op_ctx = hou.node(CONTEXT_CONTAINER)

--- a/client/ayon_core/hosts/houdini/plugins/publish/validate_subset_name.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/validate_subset_name.py
@@ -56,7 +56,7 @@ class ValidateSubsetName(pyblish.api.InstancePlugin,
         # Check product name
         asset_doc = instance.data["assetEntity"]
         product_name = get_product_name(
-            instance.context.data["projctName"],
+            instance.context.data["projectName"],
             asset_doc,
             instance.data["task"],
             instance.context.data["hostName"],


### PR DESCRIPTION
## Changelog Description
A separate PR for dealing with Houdini for https://github.com/ynput/ayon-core/pull/113 

## Additional info 1
The new `productName` Key conflicts with `Karma ROP`. 
So, instead we are going to use `AYONProductName` 
The caveat is using  `AYONProductName`  when creating instances but reading its value as `productName` when collecting instances.


## Additional info 2
I don't sure if we should provide a convert legacy code in this PR.

## Testing notes:
From the main PR:
- Open Houdini and try all create plugin and publish. Validated output if can be loaded.
- Open Houdini with workfile that does have instances before this PR and publish them.