### PR TITLE
Bugfix/houdini default renderproduct name

### DIFF
--- a/client/ayon_core/hosts/houdini/plugins/publish/collect_vray_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/collect_vray_rop.py
@@ -67,7 +67,7 @@ class CollectVrayROPRenderProducts(pyblish.api.InstancePlugin):
         beauty_product = self.get_render_product_name(default_prefix)
         render_products.append(beauty_product)
         files_by_aov = {
-            "RGB Color": self.generate_expected_files(instance,
+            "": self.generate_expected_files(instance,
                                                       beauty_product)}
 
         if instance.data.get("RenderElement", True):
@@ -75,7 +75,9 @@ class CollectVrayROPRenderProducts(pyblish.api.InstancePlugin):
             if render_element:
                 for aov, renderpass in render_element.items():
                     render_products.append(renderpass)
-                    files_by_aov[aov] = self.generate_expected_files(instance, renderpass)          # noqa
+                    files_by_aov[aov] = self.generate_expected_files(
+                        instance, renderpass)
+
 
         for product in render_products:
             self.log.debug("Found render product: %s" % product)


### PR DESCRIPTION
## Changelog Description
This is fixing key name for default render products in VRay. Original name `RGB Color` caused issues during job submission.

## Additional info
Fixing error like:

```
ayon_api.exceptions.GraphQlQueryFailed: GraphQl query Failed: Name 'render_ropMainRGB Color' does not match regex '^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$' on item 'project/products' (Line 3 Column 5)
```

## Testing notes:
1. Run Houdini with Vray for Houdini
2. Create VRay ROP and publish

[Ported From OpenPype [6083](https://github.com/ynput/OpenPype/pull/6083) ]