### PR TITLE
Don't use "modules" subkey in system settings

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/collect_render.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/collect_render.py
@@ -293,9 +293,7 @@ class CollectMayaRender(pyblish.api.InstancePlugin):
             "colorspaceView": colorspace_data["view"],
         }
 
-        rr_settings = (
-            context.data["system_settings"]["modules"]["royalrender"]
-        )
+        rr_settings = context.data["system_settings"]["royalrender"]
         if rr_settings["enabled"]:
             data["rrPathName"] = instance.data.get("rrPathName")
             self.log.debug(data["rrPathName"])

--- a/client/ayon_core/modules/timers_manager/plugins/publish/start_timer.py
+++ b/client/ayon_core/modules/timers_manager/plugins/publish/start_timer.py
@@ -18,8 +18,8 @@ class StartTimer(pyblish.api.ContextPlugin):
             self.log.debug("TimersManager is disabled")
             return
 
-        modules_settings = context.data["system_settings"]["modules"]
-        if not modules_settings["timers_manager"]["disregard_publishing"]:
+        studio_settings = context.data["system_settings"]
+        if not studio_settings["timers_manager"]["disregard_publishing"]:
             self.log.debug("Publish is not affecting running timers.")
             return
 

--- a/client/ayon_core/modules/timers_manager/plugins/publish/stop_timer.py
+++ b/client/ayon_core/modules/timers_manager/plugins/publish/stop_timer.py
@@ -19,8 +19,8 @@ class StopTimer(pyblish.api.ContextPlugin):
             self.log.debug("TimersManager is disabled")
             return
 
-        modules_settings = context.data["system_settings"]["modules"]
-        if not modules_settings["timers_manager"]["disregard_publishing"]:
+        studio_settings = context.data["system_settings"]
+        if not studio_settings["timers_manager"]["disregard_publishing"]:
             self.log.debug("Publish is not affecting running timers.")
             return
 


### PR DESCRIPTION
## Changelog Description
Fixed places where subkey `"modules"` from system settings was used.

## Additional info
I'm not sure if maya should know how to get royal render root, but that's question for a different PR.

## Testing notes:
1. Launch of application should not crash because of missing `"modules"` key in system settings
