### PR TITLE
Chore: Remove system settings concept

### DIFF
--- a/client/ayon_core/hooks/pre_ocio_hook.py
+++ b/client/ayon_core/hooks/pre_ocio_hook.py
@@ -30,7 +30,7 @@ class OCIOEnvHook(PreLaunchHook):
             asset_name=self.data["asset_name"],
             task_name=self.data["task_name"],
             host_name=self.host_name,
-            system_settings=self.data["system_settings"]
+            settings=self.data["project_settings"]
         )
 
         config_data = get_imageio_config(

--- a/client/ayon_core/hosts/flame/api/plugin.py
+++ b/client/ayon_core/hosts/flame/api/plugin.py
@@ -704,7 +704,7 @@ class ClipLoader(LoaderPlugin):
     _mapping = None
     _host_settings = None
 
-    def apply_settings(cls, project_settings, system_settings):
+    def apply_settings(cls, project_settings):
 
         plugin_type_settings = (
             project_settings

--- a/client/ayon_core/hosts/fusion/plugins/load/load_usd.py
+++ b/client/ayon_core/hosts/fusion/plugins/load/load_usd.py
@@ -28,9 +28,8 @@ class FusionLoadUSD(load.LoaderPlugin):
     tool_type = "uLoader"
 
     @classmethod
-    def apply_settings(cls, project_settings, system_settings):
-        super(FusionLoadUSD, cls).apply_settings(project_settings,
-                                                 system_settings)
+    def apply_settings(cls, project_settings):
+        super(FusionLoadUSD, cls).apply_settings(project_settings)
         if cls.enabled:
             # Enable only in Fusion 18.5+
             fusion = get_fusion_module()

--- a/client/ayon_core/hosts/hiero/plugins/load/load_clip.py
+++ b/client/ayon_core/hosts/hiero/plugins/load/load_clip.py
@@ -42,7 +42,7 @@ class LoadClip(phiero.SequenceLoader):
     clip_name_template = "{asset}_{subset}_{representation}"
 
     @classmethod
-    def apply_settings(cls, project_settings, system_settings):
+    def apply_settings(cls, project_settings):
         plugin_type_settings = (
             project_settings
             .get("hiero", {})

--- a/client/ayon_core/hosts/houdini/plugins/publish/validate_unreal_staticmesh_naming.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/validate_unreal_staticmesh_naming.py
@@ -39,7 +39,7 @@ class ValidateUnrealStaticMeshName(pyblish.api.InstancePlugin,
     static_mesh_prefix = ""
 
     @classmethod
-    def apply_settings(cls, project_settings, system_settings):
+    def apply_settings(cls, project_settings):
 
         settings = (
             project_settings["houdini"]["create"]["CreateStaticMesh"]

--- a/client/ayon_core/hosts/maya/api/plugin.py
+++ b/client/ayon_core/hosts/maya/api/plugin.py
@@ -630,8 +630,8 @@ class Loader(LoaderPlugin):
     load_settings = {}  # defined in settings
 
     @classmethod
-    def apply_settings(cls, project_settings, system_settings):
-        super(Loader, cls).apply_settings(project_settings, system_settings)
+    def apply_settings(cls, project_settings):
+        super(Loader, cls).apply_settings(project_settings)
         cls.load_settings = project_settings['maya']['load']
 
     def get_custom_namespace_and_group(self, context, options, loader_key):

--- a/client/ayon_core/hosts/maya/plugins/publish/collect_render.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/collect_render.py
@@ -293,7 +293,7 @@ class CollectMayaRender(pyblish.api.InstancePlugin):
             "colorspaceView": colorspace_data["view"],
         }
 
-        rr_settings = context.data["system_settings"]["royalrender"]
+        rr_settings = context.data["project_settings"]["royalrender"]
         if rr_settings["enabled"]:
             data["rrPathName"] = instance.data.get("rrPathName")
             self.log.debug(data["rrPathName"])

--- a/client/ayon_core/hosts/maya/plugins/publish/extract_look.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/extract_look.py
@@ -104,11 +104,10 @@ class TextureProcessor:
             log = logging.getLogger(self.__class__.__name__)
         self.log = log
 
-    def apply_settings(self, system_settings, project_settings):
+    def apply_settings(self, project_settings):
         """Apply OpenPype system/project settings to the TextureProcessor
 
         Args:
-            system_settings (dict): OpenPype system settings
             project_settings (dict): OpenPype project settings
 
         Returns:
@@ -250,7 +249,7 @@ class MakeTX(TextureProcessor):
         super(MakeTX, self).__init__(log=log)
         self.extra_args = []
 
-    def apply_settings(self, system_settings, project_settings):
+    def apply_settings(self, project_settings):
         # Allow extra maketx arguments from project settings
         args_settings = (
             project_settings["maya"]["publish"]
@@ -488,8 +487,7 @@ class ExtractLook(publish.Extractor):
         }.items():
             if instance.data.get(key, False):
                 processor = Processor(log=self.log)
-                processor.apply_settings(context.data["system_settings"],
-                                         context.data["project_settings"])
+                processor.apply_settings(context.data["project_settings"])
                 processors.append(processor)
 
         if processors:

--- a/client/ayon_core/hosts/substancepainter/api/pipeline.py
+++ b/client/ayon_core/hosts/substancepainter/api/pipeline.py
@@ -14,7 +14,7 @@ import pyblish.api
 from ayon_core.host import HostBase, IWorkfileHost, ILoadHost, IPublishHost
 from ayon_core.settings import (
     get_current_project_settings,
-    get_system_settings
+    get_project_settings,
 )
 
 from ayon_core.pipeline.template_data import get_template_data_with_names
@@ -252,9 +252,9 @@ class SubstanceHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             project_name = self.get_current_project_name()
             asset_name = self.get_current_asset_name()
             task_name = self.get_current_asset_name()
-            system_settings = get_system_settings()
+            project_settings = get_project_settings(project_name)
             formatting_data = get_template_data_with_names(
-                project_name, asset_name, task_name, system_settings
+                project_name, asset_name, task_name, project_settings
             )
             anatomy = Anatomy(project_name)
             formatting_data["root"] = anatomy.roots

--- a/client/ayon_core/hosts/traypublisher/plugins/create/create_colorspace_look.py
+++ b/client/ayon_core/hosts/traypublisher/plugins/create/create_colorspace_look.py
@@ -148,7 +148,7 @@ This creator publishes color space look file (LUT).
             )
         ]
 
-    def apply_settings(self, project_settings, system_settings):
+    def apply_settings(self, project_settings):
         host = self.create_context.host
         host_name = host.name
         project_name = host.get_current_project_name()

--- a/client/ayon_core/hosts/unreal/plugins/load/load_layout_existing.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_layout_existing.py
@@ -33,9 +33,9 @@ class ExistingLayoutLoader(plugin.Loader):
     delete_unmatched_assets = True
 
     @classmethod
-    def apply_settings(cls, project_settings, *args, **kwargs):
+    def apply_settings(cls, project_settings):
         super(ExistingLayoutLoader, cls).apply_settings(
-            project_settings, *args, **kwargs
+            project_settings
         )
         cls.delete_unmatched_assets = (
             project_settings["unreal"]["delete_unmatched_assets"]

--- a/client/ayon_core/lib/applications.py
+++ b/client/ayon_core/lib/applications.py
@@ -13,10 +13,7 @@ import six
 
 from ayon_core import AYON_CORE_ROOT
 from ayon_core.client import get_asset_name_identifier
-from ayon_core.settings import (
-    get_system_settings,
-    get_project_settings,
-)
+from ayon_core.settings import get_project_settings, get_studio_settings
 from .log import Logger
 from .profiles_filtering import filter_profiles
 from .local_settings import get_ayon_username
@@ -405,7 +402,7 @@ class ApplicationManager:
         if self._studio_settings is not None:
             settings = copy.deepcopy(self._studio_settings)
         else:
-            settings = get_system_settings(
+            settings = get_studio_settings(
                 clear_metadata=False, exclude_locals=False
             )
 
@@ -1398,8 +1395,9 @@ class EnvironmentPrepData(dict):
         if data.get("env") is None:
             data["env"] = os.environ.copy()
 
-        if "system_settings" not in data:
-            data["system_settings"] = get_system_settings()
+        project_name = data["project_doct"]["name"]
+        if "project_settings" not in data:
+            data["project_settings"] = get_project_settings(project_name)
 
         super(EnvironmentPrepData, self).__init__(data)
 
@@ -1524,8 +1522,8 @@ def prepare_app_environments(
     # Use environments from local settings
     filtered_local_envs = {}
     # NOTE Overrides for environment variables are not implemented in AYON.
-    # system_settings = data["system_settings"]
-    # whitelist_envs = system_settings["general"].get("local_env_white_list")
+    # project_settings = data["project_settings"]
+    # whitelist_envs = project_settings["general"].get("local_env_white_list")
     # if whitelist_envs:
     #     local_settings = get_local_settings()
     #     local_envs = local_settings.get("environments") or {}
@@ -1689,9 +1687,7 @@ def prepare_context_environments(data, env_group=None, addons_manager=None):
     # Load project specific environments
     project_name = project_doc["name"]
     project_settings = get_project_settings(project_name)
-    system_settings = get_system_settings()
     data["project_settings"] = project_settings
-    data["system_settings"] = system_settings
 
     app = data["app"]
     context_env = {
@@ -1731,7 +1727,7 @@ def prepare_context_environments(data, env_group=None, addons_manager=None):
         )
 
     workdir_data = get_template_data(
-        project_doc, asset_doc, task_name, app.host_name, system_settings
+        project_doc, asset_doc, task_name, app.host_name, project_settings
     )
     data["workdir_data"] = workdir_data
 

--- a/client/ayon_core/modules/deadline/plugins/publish/collect_deadline_server_from_instance.py
+++ b/client/ayon_core/modules/deadline/plugins/publish/collect_deadline_server_from_instance.py
@@ -46,7 +46,7 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
         from maya import cmds
         deadline_settings = (
             render_instance.context.data
-            ["system_settings"]
+            ["project_settings"]
             ["deadline"]
         )
 

--- a/client/ayon_core/modules/deadline/plugins/publish/collect_pools.py
+++ b/client/ayon_core/modules/deadline/plugins/publish/collect_pools.py
@@ -44,7 +44,7 @@ class CollectDeadlinePools(pyblish.api.InstancePlugin,
     secondary_pool = None
 
     @classmethod
-    def apply_settings(cls, project_settings, system_settings):
+    def apply_settings(cls, project_settings):
         # deadline.publish.CollectDeadlinePools
         settings = project_settings["deadline"]["publish"]["CollectDeadlinePools"]  # noqa
         cls.primary_pool = settings.get("primary_pool", None)

--- a/client/ayon_core/modules/deadline/plugins/publish/submit_max_deadline.py
+++ b/client/ayon_core/modules/deadline/plugins/publish/submit_max_deadline.py
@@ -48,7 +48,7 @@ class MaxSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
     group = None
 
     @classmethod
-    def apply_settings(cls, project_settings, system_settings):
+    def apply_settings(cls, project_settings):
         settings = project_settings["deadline"]["publish"]["MaxSubmitDeadline"]  # noqa
 
         # Take some defaults from settings

--- a/client/ayon_core/modules/deadline/plugins/publish/submit_maya_deadline.py
+++ b/client/ayon_core/modules/deadline/plugins/publish/submit_maya_deadline.py
@@ -116,7 +116,7 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
     strict_error_checking = True
 
     @classmethod
-    def apply_settings(cls, project_settings, system_settings):
+    def apply_settings(cls, project_settings):
         settings = project_settings["deadline"]["publish"]["MayaSubmitDeadline"]  # noqa
 
         # Take some defaults from settings

--- a/client/ayon_core/modules/job_queue/addon.py
+++ b/client/ayon_core/modules/job_queue/addon.py
@@ -42,7 +42,7 @@ import copy
 import platform
 
 from ayon_core.addon import AYONAddon, click_wrap
-from ayon_core.settings import get_system_settings
+from ayon_core.settings import get_studio_settings
 
 
 class JobQueueAddon(AYONAddon):
@@ -122,7 +122,7 @@ class JobQueueAddon(AYONAddon):
 
     @classmethod
     def get_jobs_root_from_settings(cls):
-        studio_settings = get_system_settings()
+        studio_settings = get_studio_settings()
         jobs_root_mapping = studio_settings.get(cls.name, {}).get("jobs_root")
         converted_mapping = cls._roots_mapping_conversion(jobs_root_mapping)
 
@@ -152,7 +152,7 @@ class JobQueueAddon(AYONAddon):
 
     @classmethod
     def get_server_url_from_settings(cls):
-        studio_settings = get_system_settings()
+        studio_settings = get_studio_settings()
         return cls.url_conversion(
             studio_settings
             .get(cls.name, {})

--- a/client/ayon_core/modules/timers_manager/plugins/publish/start_timer.py
+++ b/client/ayon_core/modules/timers_manager/plugins/publish/start_timer.py
@@ -1,6 +1,6 @@
 """
 Requires:
-    context -> system_settings
+    context -> project_settings
     context -> ayonAddonsManager
 """
 
@@ -18,8 +18,8 @@ class StartTimer(pyblish.api.ContextPlugin):
             self.log.debug("TimersManager is disabled")
             return
 
-        studio_settings = context.data["system_settings"]
-        if not studio_settings["timers_manager"]["disregard_publishing"]:
+        project_settings = context.data["project_settings"]
+        if not project_settings["timers_manager"]["disregard_publishing"]:
             self.log.debug("Publish is not affecting running timers.")
             return
 

--- a/client/ayon_core/modules/timers_manager/plugins/publish/stop_timer.py
+++ b/client/ayon_core/modules/timers_manager/plugins/publish/stop_timer.py
@@ -1,6 +1,6 @@
 """
 Requires:
-    context -> system_settings
+    context -> project_settings
     context -> ayonAddonsManager
 """
 
@@ -19,8 +19,8 @@ class StopTimer(pyblish.api.ContextPlugin):
             self.log.debug("TimersManager is disabled")
             return
 
-        studio_settings = context.data["system_settings"]
-        if not studio_settings["timers_manager"]["disregard_publishing"]:
+        project_settings = context.data["project_settings"]
+        if not project_settings["timers_manager"]["disregard_publishing"]:
             self.log.debug("Publish is not affecting running timers.")
             return
 

--- a/client/ayon_core/pipeline/context_tools.py
+++ b/client/ayon_core/pipeline/context_tools.py
@@ -460,14 +460,14 @@ def is_representation_from_latest(representation):
     return version_is_latest(project_name, representation["parent"])
 
 
-def get_template_data_from_session(session=None, system_settings=None):
+def get_template_data_from_session(session=None, settings=None):
     """Template data for template fill from session keys.
 
     Args:
         session (Union[Dict[str, str], None]): The Session to use. If not
             provided use the currently active global Session.
-        system_settings (Union[Dict[str, Any], Any]): Prepared system settings.
-            Optional are auto received if not passed.
+        settings (Optional[Dict[str, Any]]): Prepared studio or project
+            settings.
 
     Returns:
         Dict[str, Any]: All available data from session.
@@ -486,15 +486,16 @@ def get_template_data_from_session(session=None, system_settings=None):
         host_name = get_current_host_name()
 
     return get_template_data_with_names(
-        project_name, asset_name, task_name, host_name, system_settings
+        project_name, asset_name, task_name, host_name, settings
     )
 
 
-def get_current_context_template_data(system_settings=None):
+def get_current_context_template_data(settings=None):
     """Prepare template data for current context.
 
     Args:
-        system_settings (Optional[Dict[str, Any]]): Prepared system settings.
+        settings (Optional[Dict[str, Any]]): Prepared studio or
+            project settings.
 
     Returns:
         Dict[str, Any] Template data for current context.
@@ -507,7 +508,7 @@ def get_current_context_template_data(system_settings=None):
     host_name = get_current_host_name()
 
     return get_template_data_with_names(
-        project_name, asset_name, task_name, host_name, system_settings
+        project_name, asset_name, task_name, host_name, settings
     )
 
 

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -16,10 +16,7 @@ from ayon_core.client import (
     get_asset_by_name,
     get_asset_name_identifier,
 )
-from ayon_core.settings import (
-    get_system_settings,
-    get_project_settings
-)
+from ayon_core.settings import get_project_settings
 from ayon_core.lib.attribute_definitions import (
     UnknownDef,
     serialize_attr_defs,
@@ -1774,7 +1771,6 @@ class CreateContext:
 
     def _reset_creator_plugins(self):
         # Prepare settings
-        system_settings = get_system_settings()
         project_settings = get_project_settings(self.project_name)
 
         # Discover and prepare creators
@@ -1812,7 +1808,6 @@ class CreateContext:
 
             creator = creator_class(
                 project_settings,
-                system_settings,
                 self,
                 self.headless
             )

--- a/client/ayon_core/pipeline/create/creator_plugins.py
+++ b/client/ayon_core/pipeline/create/creator_plugins.py
@@ -6,8 +6,8 @@ from abc import ABCMeta, abstractmethod
 
 import six
 
-from ayon_core.settings import get_system_settings, get_project_settings
-from ayon_core.lib import Logger, is_func_signature_supported
+from ayon_core.settings import get_project_settings
+from ayon_core.lib import Logger
 from ayon_core.pipeline.plugin_discover import (
     discover,
     register_plugin,
@@ -201,7 +201,7 @@ class BaseCreator:
     settings_name = None
 
     def __init__(
-        self, project_settings, system_settings, create_context, headless=False
+        self, project_settings, create_context, headless=False
     ):
         # Reference to CreateContext
         self.create_context = create_context
@@ -211,34 +211,7 @@ class BaseCreator:
         # - we may use UI inside processing this attribute should be checked
         self.headless = headless
 
-        expect_system_settings = False
-        if is_func_signature_supported(
-            self.apply_settings, project_settings
-        ):
-            self.apply_settings(project_settings)
-        else:
-            expect_system_settings = True
-            # Backwards compatibility for system settings
-            self.apply_settings(project_settings, system_settings)
-
-        init_use_base = any(
-            self.__class__.__init__ is cls.__init__
-            for cls in {
-                BaseCreator,
-                Creator,
-                HiddenCreator,
-                AutoCreator,
-            }
-        )
-        if not init_use_base or expect_system_settings:
-            self.log.warning((
-                "WARNING: Source - Create plugin {}."
-                " System settings argument will not be passed to"
-                " '__init__' and 'apply_settings' methods in future versions"
-                " of OpenPype. Planned version to drop the support"
-                " is 3.16.6 or 3.17.0. Please contact Ynput core team if you"
-                " need to keep system settings."
-            ).format(self.__class__.__name__))
+        self.apply_settings(project_settings)
 
     @staticmethod
     def _get_settings_values(project_settings, category_name, plugin_name):
@@ -838,11 +811,10 @@ def discover_legacy_creator_plugins():
 
     plugins = discover(LegacyCreator)
     project_name = get_current_project_name()
-    system_settings = get_system_settings()
     project_settings = get_project_settings(project_name)
     for plugin in plugins:
         try:
-            plugin.apply_settings(project_settings, system_settings)
+            plugin.apply_settings(project_settings)
         except Exception:
             log.warning(
                 "Failed to apply settings to creator {}".format(

--- a/client/ayon_core/pipeline/create/legacy_create.py
+++ b/client/ayon_core/pipeline/create/legacy_create.py
@@ -44,7 +44,7 @@ class LegacyCreator(object):
         self.data.update(data or {})
 
     @classmethod
-    def apply_settings(cls, project_settings, system_settings):
+    def apply_settings(cls, project_settings):
         """Apply OpenPype settings to a plugin class."""
 
         host_name = os.environ.get("AYON_HOST_NAME")

--- a/client/ayon_core/pipeline/load/plugins.py
+++ b/client/ayon_core/pipeline/load/plugins.py
@@ -1,7 +1,7 @@
 import os
 import logging
 
-from ayon_core.settings import get_system_settings, get_project_settings
+from ayon_core.settings import get_project_settings
 from ayon_core.pipeline import schema
 from ayon_core.pipeline.plugin_discover import (
     discover,
@@ -37,7 +37,7 @@ class LoaderPlugin(list):
     log.propagate = True
 
     @classmethod
-    def apply_settings(cls, project_settings, system_settings):
+    def apply_settings(cls, project_settings):
         host_name = os.environ.get("AYON_HOST_NAME")
         plugin_type = "load"
         plugin_type_settings = (
@@ -262,11 +262,10 @@ def discover_loader_plugins(project_name=None):
     plugins = discover(LoaderPlugin)
     if not project_name:
         project_name = get_current_project_name()
-    system_settings = get_system_settings()
     project_settings = get_project_settings(project_name)
     for plugin in plugins:
         try:
-            plugin.apply_settings(project_settings, system_settings)
+            plugin.apply_settings(project_settings)
         except Exception:
             log.warning(
                 "Failed to apply settings to loader {}".format(

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -13,12 +13,8 @@ from ayon_core.lib import (
     Logger,
     import_filepath,
     filter_profiles,
-    is_func_signature_supported,
 )
-from ayon_core.settings import (
-    get_project_settings,
-    get_system_settings,
-)
+from ayon_core.settings import get_project_settings
 from ayon_core.pipeline import (
     tempdir,
     Anatomy
@@ -421,8 +417,8 @@ def apply_plugin_settings_automatically(plugin, settings, logger=None):
 def filter_pyblish_plugins(plugins):
     """Pyblish plugin filter which applies AYON settings.
 
-    Apply OpenPype settings on discovered plugins. On plugin with implemented
-    class method 'def apply_settings(cls, project_settings, system_settings)'
+    Apply settings on discovered plugins. On plugin with implemented
+    class method 'def apply_settings(cls, project_settings)'
     is called the method. Default behavior looks for plugin name and current
     host name to look for
 
@@ -440,7 +436,6 @@ def filter_pyblish_plugins(plugins):
     project_name = os.environ.get("AYON_PROJECT_NAME")
 
     project_settings = get_project_settings(project_name)
-    system_settings = get_system_settings()
 
     # iterate over plugins
     for plugin in plugins[:]:
@@ -452,19 +447,7 @@ def filter_pyblish_plugins(plugins):
             # - can be used to target settings from custom settings place
             # - skip default behavior when successful
             try:
-                # Support to pass only project settings
-                # - make sure that both settings are passed, when can be
-                #   - that covers cases when *args are in method parameters
-                both_supported = is_func_signature_supported(
-                    apply_settings_func, project_settings, system_settings
-                )
-                project_supported = is_func_signature_supported(
-                    apply_settings_func, project_settings
-                )
-                if not both_supported and project_supported:
-                    plugin.apply_settings(project_settings)
-                else:
-                    plugin.apply_settings(project_settings, system_settings)
+                plugin.apply_settings(project_settings)
 
             except Exception:
                 log.warning(

--- a/client/ayon_core/pipeline/template_data.py
+++ b/client/ayon_core/pipeline/template_data.py
@@ -1,9 +1,9 @@
 from ayon_core.client import get_project, get_asset_by_name
-from ayon_core.settings import get_system_settings
+from ayon_core.settings import get_studio_settings
 from ayon_core.lib.local_settings import get_ayon_username
 
 
-def get_general_template_data(system_settings=None):
+def get_general_template_data(settings=None):
     """General template data based on system settings or machine.
 
     Output contains formatting keys:
@@ -12,12 +12,12 @@ def get_general_template_data(system_settings=None):
     - 'user'            - User's name using 'get_ayon_username'
 
     Args:
-        system_settings (Dict[str, Any]): System settings.
+        settings (Dict[str, Any]): Studio or project settings.
     """
 
-    if not system_settings:
-        system_settings = get_system_settings()
-    core_settings = system_settings["core"]
+    if not settings:
+        settings = get_studio_settings()
+    core_settings = settings["core"]
     return {
         "studio": {
             "name": core_settings["studio_name"],
@@ -154,7 +154,7 @@ def get_template_data(
     asset_doc=None,
     task_name=None,
     host_name=None,
-    system_settings=None
+    settings=None
 ):
     """Prepare data for templates filling from entered documents and info.
 
@@ -174,14 +174,14 @@ def get_template_data(
         asset_doc (Dict[str, Any]): Mongo document of asset from MongoDB.
         task_name (Union[str, None]): Task name under passed asset.
         host_name (Union[str, None]): Used to fill '{app}' key.
-        system_settings (Union[Dict, None]): Prepared system settings.
+        settings (Union[Dict, None]): Prepared studio or project settings.
             They're queried if not passed (may be slower).
 
     Returns:
         Dict[str, Any]: Data prepared for filling workdir template.
     """
 
-    template_data = get_general_template_data(system_settings)
+    template_data = get_general_template_data(settings)
     template_data.update(get_project_template_data(project_doc))
     if asset_doc:
         template_data.update(get_asset_template_data(
@@ -203,7 +203,7 @@ def get_template_data_with_names(
     asset_name=None,
     task_name=None,
     host_name=None,
-    system_settings=None
+    settings=None
 ):
     """Prepare data for templates filling from entered entity names and info.
 
@@ -218,7 +218,7 @@ def get_template_data_with_names(
         task_name (Union[str, None]): Task name under passed asset.
         host_name (Union[str, None]):Used to fill '{app}' key.
             because workdir template may contain `{app}` key.
-        system_settings (Union[Dict, None]): Prepared system settings.
+        settings (Union[Dict, None]): Prepared studio or project settings.
             They're queried if not passed.
 
     Returns:
@@ -236,5 +236,5 @@ def get_template_data_with_names(
             fields=["name", "data.parents", "data.tasks"]
         )
     return get_template_data(
-        project_doc, asset_doc, task_name, host_name, system_settings
+        project_doc, asset_doc, task_name, host_name, settings
     )

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -27,10 +27,7 @@ from ayon_core.client import (
     get_representations,
     get_ayon_server_api_connection,
 )
-from ayon_core.settings import (
-    get_project_settings,
-    get_system_settings,
-)
+from ayon_core.settings import get_project_settings
 from ayon_core.host import IWorkfileHost, HostBase
 from ayon_core.lib import (
     Logger,
@@ -118,7 +115,6 @@ class AbstractTemplateBuilder(object):
         self._creators_by_name = None
         self._create_context = None
 
-        self._system_settings = None
         self._project_settings = None
 
         self._current_asset_doc = None
@@ -151,12 +147,6 @@ class AbstractTemplateBuilder(object):
             "asset_name": self.current_asset_name,
             "task_name": self.current_task_name
         }
-
-    @property
-    def system_settings(self):
-        if self._system_settings is None:
-            self._system_settings = get_system_settings()
-        return self._system_settings
 
     @property
     def project_settings(self):
@@ -256,7 +246,6 @@ class AbstractTemplateBuilder(object):
         self._linked_asset_docs = None
         self._task_type = None
 
-        self._system_settings = None
         self._project_settings = None
 
         self.clear_shared_data()

--- a/client/ayon_core/plugins/publish/collect_anatomy_context_data.py
+++ b/client/ayon_core/plugins/publish/collect_anatomy_context_data.py
@@ -47,7 +47,7 @@ class CollectAnatomyContextData(pyblish.api.ContextPlugin):
 
     def process(self, context):
         host_name = context.data["hostName"]
-        system_settings = context.data["system_settings"]
+        project_settings = context.data["project_settings"]
         project_entity = context.data["projectEntity"]
         asset_entity = context.data.get("assetEntity")
         task_name = None
@@ -55,7 +55,11 @@ class CollectAnatomyContextData(pyblish.api.ContextPlugin):
             task_name = context.data["task"]
 
         anatomy_data = get_template_data(
-            project_entity, asset_entity, task_name, host_name, system_settings
+            project_entity,
+            asset_entity,
+            task_name,
+            host_name,
+            project_settings
         )
         anatomy_data.update(context.data.get("datetimeData") or {})
 

--- a/client/ayon_core/plugins/publish/collect_settings.py
+++ b/client/ayon_core/plugins/publish/collect_settings.py
@@ -1,8 +1,5 @@
 from pyblish import api
-from ayon_core.settings import (
-    get_current_project_settings,
-    get_system_settings,
-)
+from ayon_core.settings import get_current_project_settings
 
 
 class CollectSettings(api.ContextPlugin):
@@ -13,4 +10,3 @@ class CollectSettings(api.ContextPlugin):
 
     def process(self, context):
         context.data["project_settings"] = get_current_project_settings()
-        context.data["system_settings"] = get_system_settings()

--- a/client/ayon_core/settings/__init__.py
+++ b/client/ayon_core/settings/__init__.py
@@ -1,7 +1,6 @@
 from .lib import (
     get_ayon_settings,
     get_studio_settings,
-    get_system_settings,
     get_project_settings,
     get_general_environments,
     get_current_project_settings,
@@ -11,7 +10,6 @@ from .lib import (
 __all__ = (
     "get_ayon_settings",
     "get_studio_settings",
-    "get_system_settings",
     "get_general_environments",
     "get_project_settings",
     "get_current_project_settings",

--- a/client/ayon_core/settings/lib.py
+++ b/client/ayon_core/settings/lib.py
@@ -163,10 +163,6 @@ def get_studio_settings(*args, **kwargs):
     return _AyonSettingsCache.get_value_by_project(None)
 
 
-# Backward compatibility
-get_system_settings = get_studio_settings
-
-
 def get_project_settings(project_name, *args, **kwargs):
     return _AyonSettingsCache.get_value_by_project(project_name)
 

--- a/client/ayon_core/tools/pyblish_pype/model.py
+++ b/client/ayon_core/tools/pyblish_pype/model.py
@@ -34,8 +34,6 @@ import qtawesome
 from six import text_type
 from .constants import PluginStates, InstanceStates, GroupStates, Roles
 
-from ayon_core.settings import get_system_settings
-
 
 # ItemTypes
 UserType = QtGui.QStandardItem.UserType
@@ -105,12 +103,8 @@ class IntentModel(QtGui.QStandardItemModel):
         self._item_count = 0
         self.default_index = 0
 
-        intent_settings = (
-            get_system_settings()
-            .get("modules", {})
-            .get("ftrack", {})
-            .get("intent", {})
-        )
+        # Intent settings are not available in core addon
+        intent_settings = {}
 
         items = intent_settings.get("items", {})
         if not items:


### PR DESCRIPTION
## Changelog Description
Remove system settings functions and naming from code.

## Additional info
Because there are not 2 types of settings anymore system/project, just settings, we don't need system settings naming anymore. There are studio settings (default studio values) and project settings (with project overrides). Some functions can expect both because the used values are not affected by project overrides (e.g. studio name).

Removed `get_system_settings`. None of `apply_settings` method do support `system_settings` in argument. Key `"system_settings"` is not available in launch hook data and publish data.

## Testing notes:
Everything should be working fine as before.
1. Load plugins should be initializad correctly.
2. Launch hooks should work fine/.
3. Publish plugins should not complain about missing `"system_settings"` key.