### PR TITLE
Add trigger workflow to sync issues with ClickUp

### DIFF
--- a/.github/workflows/issue_to_clickup_trigger.yml
+++ b/.github/workflows/issue_to_clickup_trigger.yml
@@ -1,0 +1,28 @@
+name: Sync Issues to ClickUp [trigger]
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue-number:
+        required: true
+  issues:
+    types: [labeled]
+
+
+jobs:
+  call-ci-tools-issue-sync:
+    if: github.event.inputs.issue-number != '' || github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'backlog')
+    uses: ynput/ci-tools/.github/workflows/issue_to_clickup_ref.yml@main
+    with:
+      # issue number should be taken either from inputs or from the event
+      issue-number: ${{ github.event.inputs.issue-number || github.event.issue.number }}
+      repo-owner: ${{ github.event.repository.owner.login }}
+      repo-name: ${{ github.event.repository.name }}
+    secrets:
+      token: ${{ secrets.YNPUT_BOT_TOKEN }}
+      cu_api_key: ${{ secrets.CLICKUP_API_KEY }}
+      cu_team_id: ${{ secrets.CLICKUP_TEAM_ID }}
+      cu_folder_id: ${{ secrets.CLICKUP_FOLDER_ID }}
+      cu_list_id: ${{ secrets.CLICKUP_LIST_ID }}
+      cu_field_domain_id: ${{ secrets.CLICKUP_DOMAIN_FIELD_ID }}
+      cu_field_type_id: ${{ secrets.CLICKUP_ISSUETYPE_FIELD_ID }}


### PR DESCRIPTION
- Added a trigger workflow to sync GitHub issues with ClickUp
- Triggered by manual dispatch or labeled issue event
