### PR TITLE
Added missing hosts to collect_audio

### DIFF
--- a/client/ayon_core/plugins/publish/collect_audio.py
+++ b/client/ayon_core/plugins/publish/collect_audio.py
@@ -40,7 +40,10 @@ class CollectAudio(pyblish.api.ContextPlugin):
         "webpublisher",
         "aftereffects",
         "flame",
-        "unreal"
+        "unreal",
+        "blender",
+        "houdini",
+        "max",
     ]
 
     audio_product_name = "audioMain"


### PR DESCRIPTION
## Changelog Description
Added missing hosts (Blender, Houdini and Max) to `collect_audio`.

## Testing notes:
1. Load an audio file.
2. Try publishing a review. It should include the audio file.
