### PR TITLE
Publisher: Double click at instance switch to publish tab

### DIFF
--- a/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
@@ -534,6 +534,8 @@ class InstanceCardView(AbstractInstanceView):
     Wrapper of all widgets in card view.
     """
 
+    double_clicked = QtCore.Signal()
+
     def __init__(self, controller, parent):
         super(InstanceCardView, self).__init__(parent)
 
@@ -577,6 +579,9 @@ class InstanceCardView(AbstractInstanceView):
             QtWidgets.QSizePolicy.Minimum,
             self.sizePolicy().verticalPolicy()
         )
+
+    def mouseDoubleClickEvent(self, event):
+        self.double_clicked.emit()
 
     def sizeHint(self):
         """Modify sizeHint based on visibility of scroll bars."""
@@ -715,6 +720,7 @@ class InstanceCardView(AbstractInstanceView):
                 )
                 group_widget.active_changed.connect(self._on_active_changed)
                 group_widget.selected.connect(self._on_widget_selection)
+                # group_widget.double_clicked.connect(self._on_widget_double_clicked)
                 self._content_layout.insertWidget(widget_idx, group_widget)
                 self._widgets_by_group[group_name] = group_widget
 
@@ -824,6 +830,11 @@ class InstanceCardView(AbstractInstanceView):
             self._select_item_extend_to(instance_id, group_name, new_widget)
 
         self.selection_changed.emit()
+
+    # def _on_widget_double_clicked(self):
+    #     print("_on_widget_double_clicked")
+    #     widgets = self._get_selected_widgets()
+    #     print(widgets)
 
     def _select_item_clear(self, instance_id, group_name, new_widget):
         """Select specific item by instance id and clear previous selection.

--- a/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
@@ -581,7 +581,8 @@ class InstanceCardView(AbstractInstanceView):
         )
 
     def mouseDoubleClickEvent(self, event):
-        self.double_clicked.emit()
+        if event.button() == QtCore.Qt.LeftButton:
+            self.double_clicked.emit()
 
     def sizeHint(self):
         """Modify sizeHint based on visibility of scroll bars."""

--- a/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
@@ -720,7 +720,6 @@ class InstanceCardView(AbstractInstanceView):
                 )
                 group_widget.active_changed.connect(self._on_active_changed)
                 group_widget.selected.connect(self._on_widget_selection)
-                # group_widget.double_clicked.connect(self._on_widget_double_clicked)
                 self._content_layout.insertWidget(widget_idx, group_widget)
                 self._widgets_by_group[group_name] = group_widget
 
@@ -830,11 +829,6 @@ class InstanceCardView(AbstractInstanceView):
             self._select_item_extend_to(instance_id, group_name, new_widget)
 
         self.selection_changed.emit()
-
-    # def _on_widget_double_clicked(self):
-    #     print("_on_widget_double_clicked")
-    #     widgets = self._get_selected_widgets()
-    #     print(widgets)
 
     def _select_item_clear(self, instance_id, group_name, new_widget):
         """Select specific item by instance id and clear previous selection.

--- a/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
@@ -52,6 +52,7 @@ class SelectionTypes:
 class BaseGroupWidget(QtWidgets.QWidget):
     selected = QtCore.Signal(str, str, str)
     removed_selected = QtCore.Signal()
+    double_clicked = QtCore.Signal()
 
     def __init__(self, group_name, parent):
         super(BaseGroupWidget, self).__init__(parent)
@@ -192,6 +193,7 @@ class ConvertorItemsGroupWidget(BaseGroupWidget):
                 else:
                     widget = ConvertorItemCardWidget(item, self)
                     widget.selected.connect(self._on_widget_selection)
+                    widget.double_clicked(self.double_clicked)
                     self._widgets_by_id[item.id] = widget
                     self._content_layout.insertWidget(widget_idx, widget)
                 widget_idx += 1
@@ -254,6 +256,7 @@ class InstanceGroupWidget(BaseGroupWidget):
                     )
                     widget.selected.connect(self._on_widget_selection)
                     widget.active_changed.connect(self._on_active_changed)
+                    widget.double_clicked.connect(self.double_clicked)
                     self._widgets_by_id[instance.id] = widget
                     self._content_layout.insertWidget(widget_idx, widget)
                 widget_idx += 1
@@ -271,6 +274,7 @@ class CardWidget(BaseClickableFrame):
     # Group identifier of card
     # - this must be set because if send when mouse is released with card id
     _group_identifier = None
+    double_clicked = QtCore.Signal()
 
     def __init__(self, parent):
         super(CardWidget, self).__init__(parent)
@@ -278,6 +282,11 @@ class CardWidget(BaseClickableFrame):
 
         self._selected = False
         self._id = None
+
+    def mouseDoubleClickEvent(self, event):
+        super(CardWidget, self).mouseDoubleClickEvent(event)
+        if self._is_valid_double_click(event):
+            self.double_clicked.emit()
 
     @property
     def id(self):
@@ -311,6 +320,9 @@ class CardWidget(BaseClickableFrame):
             selection_type = SelectionTypes.extend
 
         self.selected.emit(self._id, self._group_identifier, selection_type)
+
+    def _is_valid_double_click(self, event):
+        return True
 
 
 class ContextCardWidget(CardWidget):
@@ -527,6 +539,15 @@ class InstanceCardWidget(CardWidget):
     def _on_expend_clicked(self):
         self._set_expanded()
 
+    def _is_valid_double_click(self, event):
+        widget = self.childAt(event.pos())
+        if (
+            widget is self._active_checkbox
+            or widget is self._expand_btn
+        ):
+            return False
+        return True
+
 
 class InstanceCardView(AbstractInstanceView):
     """Publish access to card view.
@@ -579,10 +600,6 @@ class InstanceCardView(AbstractInstanceView):
             QtWidgets.QSizePolicy.Minimum,
             self.sizePolicy().verticalPolicy()
         )
-
-    def mouseDoubleClickEvent(self, event):
-        if event.button() == QtCore.Qt.LeftButton:
-            self.double_clicked.emit()
 
     def sizeHint(self):
         """Modify sizeHint based on visibility of scroll bars."""
@@ -721,6 +738,7 @@ class InstanceCardView(AbstractInstanceView):
                 )
                 group_widget.active_changed.connect(self._on_active_changed)
                 group_widget.selected.connect(self._on_widget_selection)
+                group_widget.double_clicked.connect(self.double_clicked)
                 self._content_layout.insertWidget(widget_idx, group_widget)
                 self._widgets_by_group[group_name] = group_widget
 
@@ -761,6 +779,7 @@ class InstanceCardView(AbstractInstanceView):
 
         widget = ContextCardWidget(self._content_widget)
         widget.selected.connect(self._on_widget_selection)
+        widget.double_clicked.connect(self.double_clicked)
 
         self._context_widget = widget
 
@@ -784,6 +803,7 @@ class InstanceCardView(AbstractInstanceView):
                 CONVERTOR_ITEM_GROUP, self._content_widget
             )
             group_widget.selected.connect(self._on_widget_selection)
+            group_widget.double_clicked.connect(self.double_clicked)
             self._content_layout.insertWidget(1, group_widget)
             self._convertor_items_group = group_widget
 

--- a/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
@@ -425,6 +425,9 @@ class InstanceListView(AbstractInstanceView):
 
     This is public access to and from list view.
     """
+
+    double_clicked = QtCore.Signal()
+
     def __init__(self, controller, parent):
         super(InstanceListView, self).__init__(parent)
 
@@ -473,6 +476,9 @@ class InstanceListView(AbstractInstanceView):
         self._proxy_model = proxy_model
 
         self._active_toggle_enabled = True
+
+    def mouseDoubleClickEvent(self, event):
+        self.double_clicked.emit()
 
     def _on_expand(self, index):
         self._update_widget_expand_state(index, True)

--- a/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
@@ -379,7 +379,7 @@ class InstanceTreeView(QtWidgets.QTreeView):
         "double click" as 2x "single click".
         """
         if event.button() != QtCore.Qt.LeftButton:
-            return
+            return False
 
         pressed_group_index = None
         pos_index = self.indexAt(event.pos())
@@ -388,13 +388,17 @@ class InstanceTreeView(QtWidgets.QTreeView):
 
         self._pressed_group_index = pressed_group_index
 
+        return True
+
     def mousePressEvent(self, event):
-        self._mouse_press(event)
-        super(InstanceTreeView, self).mousePressEvent(event)
+        handled = self._mouse_press(event)
+        if handled:
+            super(InstanceTreeView, self).mousePressEvent(event)
 
     def mouseDoubleClickEvent(self, event):
-        self._mouse_press(event)
-        super(InstanceTreeView, self).mouseDoubleClickEvent(event)
+        handled = self._mouse_press(event)
+        if handled:
+            super(InstanceTreeView, self).mouseDoubleClickEvent(event)
 
     def _mouse_release(self, event, pressed_index):
         if event.button() != QtCore.Qt.LeftButton:

--- a/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
@@ -457,7 +457,7 @@ class InstanceListView(AbstractInstanceView):
         instance_view.collapsed.connect(self._on_collapse)
         instance_view.expanded.connect(self._on_expand)
         instance_view.toggle_requested.connect(self._on_toggle_request)
-        instance_view.doubleClicked.connect(self._on_double_clicked)
+        instance_view.doubleClicked.connect(self.double_clicked)
 
         self._group_items = {}
         self._group_widgets = {}
@@ -477,9 +477,6 @@ class InstanceListView(AbstractInstanceView):
         self._proxy_model = proxy_model
 
         self._active_toggle_enabled = True
-
-    def _on_double_clicked(self, event):
-        self.double_clicked.emit()
 
     def _on_expand(self, index):
         self._update_widget_expand_state(index, True)

--- a/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
@@ -397,9 +397,9 @@ class InstanceTreeView(QtWidgets.QTreeView):
             super(InstanceTreeView, self).mousePressEvent(event)
 
     def mouseDoubleClickEvent(self, event):
-        self.double_clicked.emit()
         handled = self._mouse_press(event)
         if handled:
+            self.double_clicked.emit()
             super(InstanceTreeView, self).mouseDoubleClickEvent(event)
 
     def _mouse_release(self, event, pressed_index):

--- a/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
@@ -457,6 +457,7 @@ class InstanceListView(AbstractInstanceView):
         instance_view.collapsed.connect(self._on_collapse)
         instance_view.expanded.connect(self._on_expand)
         instance_view.toggle_requested.connect(self._on_toggle_request)
+        instance_view.doubleClicked.connect(self._on_double_clicked)
 
         self._group_items = {}
         self._group_widgets = {}
@@ -477,7 +478,7 @@ class InstanceListView(AbstractInstanceView):
 
         self._active_toggle_enabled = True
 
-    def mouseDoubleClickEvent(self, event):
+    def _on_double_clicked(self, event):
         self.double_clicked.emit()
 
     def _on_expand(self, index):

--- a/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
@@ -317,6 +317,7 @@ class InstanceListGroupWidget(QtWidgets.QFrame):
 class InstanceTreeView(QtWidgets.QTreeView):
     """View showing instances and their groups."""
     toggle_requested = QtCore.Signal(int)
+    double_clicked = QtCore.Signal()
 
     def __init__(self, *args, **kwargs):
         super(InstanceTreeView, self).__init__(*args, **kwargs)
@@ -396,6 +397,7 @@ class InstanceTreeView(QtWidgets.QTreeView):
             super(InstanceTreeView, self).mousePressEvent(event)
 
     def mouseDoubleClickEvent(self, event):
+        self.double_clicked.emit()
         handled = self._mouse_press(event)
         if handled:
             super(InstanceTreeView, self).mouseDoubleClickEvent(event)
@@ -461,7 +463,7 @@ class InstanceListView(AbstractInstanceView):
         instance_view.collapsed.connect(self._on_collapse)
         instance_view.expanded.connect(self._on_expand)
         instance_view.toggle_requested.connect(self._on_toggle_request)
-        instance_view.doubleClicked.connect(self.double_clicked)
+        instance_view.double_clicked.connect(self.double_clicked)
 
         self._group_items = {}
         self._group_widgets = {}

--- a/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
@@ -393,7 +393,7 @@ class InstanceTreeView(QtWidgets.QTreeView):
         "double click" as 2x "single click".
         """
         if event.button() != QtCore.Qt.LeftButton:
-            return False
+            return
 
         pressed_group_index = None
         pos_index = self.indexAt(event.pos())
@@ -401,8 +401,6 @@ class InstanceTreeView(QtWidgets.QTreeView):
             pressed_group_index = pos_index
 
         self._pressed_group_index = pressed_group_index
-
-        return True
 
     def mousePressEvent(self, event):
         self._mouse_press(event)

--- a/client/ayon_core/tools/publisher/widgets/overview_widget.py
+++ b/client/ayon_core/tools/publisher/widgets/overview_widget.py
@@ -18,6 +18,7 @@ class OverviewWidget(QtWidgets.QFrame):
     instance_context_changed = QtCore.Signal()
     create_requested = QtCore.Signal()
     convert_requested = QtCore.Signal()
+    publish_tab_requested = QtCore.Signal()
 
     anim_end_value = 200
     anim_duration = 200
@@ -114,13 +115,13 @@ class OverviewWidget(QtWidgets.QFrame):
             self._on_product_change
         )
         product_list_view.double_clicked.connect(
-            self._on_double_clicked
+            self.publish_tab_requested
         )
         product_view_cards.selection_changed.connect(
             self._on_product_change
         )
         product_view_cards.double_clicked.connect(
-            self._on_double_clicked
+            self.publish_tab_requested
         )
         # Active instances changed
         product_list_view.active_changed.connect(
@@ -298,10 +299,6 @@ class OverviewWidget(QtWidgets.QFrame):
         self._product_attributes_widget.set_current_instances(
             instances, context_selected, convertor_identifiers
         )
-
-    def _on_double_clicked(self):
-        from ayon_core.tools.utils import host_tools
-        host_tools.show_publisher(tab="publish")
 
     def _on_active_changed(self):
         if self._refreshing_instances:

--- a/client/ayon_core/tools/publisher/widgets/overview_widget.py
+++ b/client/ayon_core/tools/publisher/widgets/overview_widget.py
@@ -113,8 +113,14 @@ class OverviewWidget(QtWidgets.QFrame):
         product_list_view.selection_changed.connect(
             self._on_product_change
         )
+        product_list_view.double_clicked.connect(
+            self._on_double_clicked
+        )
         product_view_cards.selection_changed.connect(
             self._on_product_change
+        )
+        product_view_cards.double_clicked.connect(
+            self._on_double_clicked
         )
         # Active instances changed
         product_list_view.active_changed.connect(
@@ -292,6 +298,10 @@ class OverviewWidget(QtWidgets.QFrame):
         self._product_attributes_widget.set_current_instances(
             instances, context_selected, convertor_identifiers
         )
+
+    def _on_double_clicked(self):
+        from ayon_core.tools.utils import host_tools
+        host_tools.show_publisher(tab="publish")
 
     def _on_active_changed(self):
         if self._refreshing_instances:

--- a/client/ayon_core/tools/publisher/window.py
+++ b/client/ayon_core/tools/publisher/window.py
@@ -258,6 +258,9 @@ class PublisherWindow(QtWidgets.QDialog):
         overview_widget.convert_requested.connect(
             self._on_convert_requested
         )
+        overview_widget.publish_tab_requested.connect(
+            self._go_to_publish_tab
+        )
 
         save_btn.clicked.connect(self._on_save_clicked)
         reset_btn.clicked.connect(self._on_reset_clicked)


### PR DESCRIPTION
## Description
Double click on instances under `Create` tab changes tab to `Publish`.

### Additional information
The double click is ignored if happens on checkbox or button. Double click on instances group does not change the tab either.

**Additional context**
![image](https://github.com/ynput/ayon-core/assets/10794257/9ee793ff-b75b-4848-bc59-8db119a98e4e)

Source issue description https://github.com/ynput/OpenPype/issues/4567