### PR TITLE
3dsMax: Remove workfile instance is not possible

### DIFF
--- a/client/ayon_core/hosts/max/plugins/create/create_workfile.py
+++ b/client/ayon_core/hosts/max/plugins/create/create_workfile.py
@@ -98,21 +98,6 @@ class CreateWorkfile(plugin.MaxCreatorBase, AutoCreator):
                 created_inst.data_to_store()
             )
 
-    def remove_instances(self, instances):
-        """Remove specified instance from the scene.
-
-        This is only removing `id` parameter so instance is no longer
-        instance, because it might contain valuable data for artist.
-
-        """
-        for instance in instances:
-            instance_node = rt.GetNodeByName(
-                instance.data.get("instance_node"))
-            if instance_node:
-                rt.Delete(instance_node)
-
-            self._remove_instance_from_context(instance)
-
     def create_node(self, product_name):
         if rt.getNodeByName(product_name):
             node = rt.getNodeByName(product_name)


### PR DESCRIPTION
## Changelog Description
Removing `remove instances` function in 3dsmax workfile creator

## Additional info
It does not make sense to remove workfile instance created with auto creator.

## Testing notes:
1. Launch Max
2. Create Workfile
3. removing instances should be gone.
