### PR TITLE
Publisher: Promote information to be shown on instance label

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/create/create_render.py
+++ b/client/ayon_core/hosts/maya/plugins/create/create_render.py
@@ -106,3 +106,9 @@ class CreateRenderlayer(plugin.RenderlayerCreator):
                     default=self.render_settings.get("enable_all_lights",
                                                      False))
         ]
+
+    def get_extra_label(self):
+        """A label that can be made custom for a creator"""
+        print("get_extra_label() dir(self)", dir(self))
+        # TODO: How do you get to the instance attributes from here, such as frameStart and frameEnd?
+        return "{}-{}".format(1001, 1010)

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -871,6 +871,7 @@ class CreatedInstance:
         creator_identifier (str): Identifier of creator plugin.
         creator_label (str): Creator plugin label.
         group_label (str): Default group label from creator plugin.
+        extra_label (str): Extra label that can be made custom for a creator
         creator_attr_defs (List[AbstractAttrDef]): Attribute definitions from
             creator.
     """
@@ -897,11 +898,13 @@ class CreatedInstance:
         creator_identifier=None,
         creator_label=None,
         group_label=None,
+        extra_label=None,
         creator_attr_defs=None,
     ):
         if creator is not None:
             creator_identifier = creator.identifier
             group_label = creator.get_group_label()
+            extra_label = creator.get_extra_label()
             creator_label = creator.label
             creator_attr_defs = creator.get_instance_attr_defs()
 
@@ -949,6 +952,7 @@ class CreatedInstance:
         self._data["productName"] = product_name
         self._data["active"] = data.get("active", True)
         self._data["creator_identifier"] = creator_identifier
+        self._data["extra_label"] = extra_label
 
         # Pop from source data all keys that are defined in `_data` before
         #   this moment and through their values away
@@ -1052,6 +1056,11 @@ class CreatedInstance:
         if label:
             return label
         return self._group_label
+
+    @property
+    def extra_label(self):
+        extra_label = self._data.get("extra_label")
+        return extra_label
 
     @property
     def origin_data(self):

--- a/client/ayon_core/pipeline/create/creator_plugins.py
+++ b/client/ayon_core/pipeline/create/creator_plugins.py
@@ -792,6 +792,10 @@ class Creator(BaseCreator):
         """
         return self.pre_create_attr_defs
 
+    def get_extra_label(self):
+        """Extra label that can be made custom for a creator"""
+        return
+
 
 class HiddenCreator(BaseCreator):
     @abstractmethod
@@ -808,6 +812,10 @@ class AutoCreator(BaseCreator):
     def remove_instances(self, instances):
         """Skip removement."""
         pass
+
+    def get_extra_label(self):
+        """Extra label that can be made custom for a creator"""
+        return
 
 
 def discover_creator_plugins(*args, **kwargs):

--- a/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
@@ -496,7 +496,10 @@ class InstanceCardWidget(CardWidget):
             for part in found_parts:
                 replacement = "<b>{}</b>".format(part)
                 label = label.replace(part, replacement)
-
+        # Add the extra label (if any)
+        extra_label = self.instance.extra_label
+        if extra_label:
+            label = "{} - {}".format(label, extra_label)
         self._label_widget.setText(label)
         # HTML text will cause that label start catch mouse clicks
         # - disabling with changing interaction flag


### PR DESCRIPTION
## Changelog Description
We need to be able to display more information on instance label in publisher than just it's name.

![image](https://github.com/ynput/ayon-core/assets/10794257/582c1fb9-363f-4bfd-b7e0-7670cca4279e)
In this case for example renderCompositingMain  could show there also frame range or some badge that review will be created.

What information shown there could be decided by plugins themselves. But how to solve conflicting interests, available ways to show things, etc. is up to the implementation.

## Additional info
Paragraphs of text giving context of additional technical information or code examples.

## Testing notes:
1. start with this step
2. follow this step
