### PR TITLE
Max: Use instance.data["productName"] instead of instance.context.data["subset"] in validate model name

### DIFF
--- a/client/ayon_core/hosts/max/plugins/publish/validate_model_name.py
+++ b/client/ayon_core/hosts/max/plugins/publish/validate_model_name.py
@@ -103,7 +103,7 @@ class ValidateModelName(pyblish.api.InstancePlugin,
         invalid = False
         compare = {
             "project": instance.context.data["projectName"],
-            "asset": instance.context.data["folderPath"],
+            "asset": instance.data["folderPath"],
             "subset": instance.data["productName"]
         }
         for key, required_value in compare.items():

--- a/client/ayon_core/hosts/max/plugins/publish/validate_model_name.py
+++ b/client/ayon_core/hosts/max/plugins/publish/validate_model_name.py
@@ -100,11 +100,12 @@ class ValidateModelName(pyblish.api.InstancePlugin,
             return obj
 
         # Validate regex groups
+        cls.log.debug(instance.data["productName"])
         invalid = False
         compare = {
             "project": instance.context.data["projectName"],
             "asset": instance.context.data["folderPath"],
-            "subset": instance.name,
+            "subset": instance.data["productName"],
         }
         for key, required_value in compare.items():
             if key in regex.groupindex:

--- a/client/ayon_core/hosts/max/plugins/publish/validate_model_name.py
+++ b/client/ayon_core/hosts/max/plugins/publish/validate_model_name.py
@@ -100,12 +100,11 @@ class ValidateModelName(pyblish.api.InstancePlugin,
             return obj
 
         # Validate regex groups
-        cls.log.debug(instance.data["productName"])
         invalid = False
         compare = {
             "project": instance.context.data["projectName"],
             "asset": instance.context.data["folderPath"],
-            "subset": instance.data["productName"],
+            "subset": instance.data["productName"]
         }
         for key, required_value in compare.items():
             if key in regex.groupindex:

--- a/client/ayon_core/hosts/max/plugins/publish/validate_model_name.py
+++ b/client/ayon_core/hosts/max/plugins/publish/validate_model_name.py
@@ -104,7 +104,7 @@ class ValidateModelName(pyblish.api.InstancePlugin,
         compare = {
             "project": instance.context.data["projectName"],
             "asset": instance.context.data["folderPath"],
-            "subset": instance.context.data["subset"],
+            "subset": instance.name,
         }
         for key, required_value in compare.items():
             if key in regex.groupindex:


### PR DESCRIPTION
## Changelog Description
In AYON, there is no `instance.context.data["subset"]`. This PR is to replace the use of this with instance name on validate model name
## Additional info
n/a

## Testing notes:
1. Launch Max
2. Create Model Instance
3. Enable `Validate Model Name`
4. It should validate subset correctly if the validation regex sets to subset-related param.