### PR TITLE
Publisher: Change scrollbar stylesheet to avoid issues on resize

### DIFF
--- a/client/ayon_core/style/style.css
+++ b/client/ayon_core/style/style.css
@@ -1067,6 +1067,38 @@ PixmapButton:disabled {
     font-size: 13pt;
 }
 
+#PublisherVerticalScrollArea QScrollBar {
+    background: transparent;
+    margin: 0;
+    border: none;
+}
+
+#PublisherVerticalScrollArea QScrollBar:horizontal {
+    height: 10px;
+    margin: 0;
+}
+
+#PublisherVerticalScrollArea QScrollBar:vertical {
+    width: 10px;
+    margin: 0;
+}
+
+#PublisherVerticalScrollArea QScrollBar::handle {
+    background: {color:bg-scroll-handle};
+    border-radius: 4px;
+    margin: 1px;
+}
+
+#PublisherVerticalScrollArea QScrollBar::handle:horizontal {
+    min-width: 20px;
+    min-height: 8px;
+}
+
+#PublisherVerticalScrollArea QScrollBar::handle:vertical {
+    min-height: 20px;
+    min-width: 8px;
+}
+
 ValidationArtistMessage QLabel {
     font-size: 20pt;
     font-weight: bold;

--- a/client/ayon_core/tools/publisher/widgets/report_page.py
+++ b/client/ayon_core/tools/publisher/widgets/report_page.py
@@ -56,6 +56,8 @@ class VerticalScrollArea(QtWidgets.QScrollArea):
         self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
         self.setLayoutDirection(QtCore.Qt.RightToLeft)
 
+        self.setObjectName("PublisherVerticalScrollArea")
+
         self.setAttribute(QtCore.Qt.WA_TranslucentBackground)
         # Background of scrollbar will be transparent
         scrollbar_bg = self.verticalScrollBar().parent()


### PR DESCRIPTION
## Changelog Description
Fix issue with infinite expanding of publisher UI.

## Detailed issue description
There is scroll area showing error labels with instance view, when this scroll area height gets bigger that it shows scroll bar the widget is forced to resize to width of the content widget and scroll bar width. The issue is that with specific stylesheets may some DCCs misuse widths of the widgets. The handle may have backend width 14px but the real width in UI is 10px, in that exact case the window will start to exponentially grow because we're resizing it.

### How to replicate
It happens in Substance painter, where I faked 3 instance validators to raise `ValidationError` (you can somehow make them fail). The idea is that you have to make the list of validation errors height enough so scroll bar can be shown.
![image](https://github.com/ynput/ayon-core/assets/43494761/e5f957e4-38b0-49ba-a6e5-7d37028dc39c)
When the scrollbar is visible, the window should not start to expand. 

## Change
The scroll bar for that wiget was modified to have different stylesheet which does not affect the width, but has almost none margins. In this case it is probably not a big issue as it is on left side of the view.

## Testing notes:
1. Launch substance painter.
2. Make sure there are instnaces that will cause a lot of validation errors so it is possible to see scroll bar when window is resized.
3. The window does not expand.