### PR TITLE
3dsMax: Retaining Viewport Layout during Preview

### DIFF
--- a/client/ayon_core/hosts/max/api/preview_animation.py
+++ b/client/ayon_core/hosts/max/api/preview_animation.py
@@ -39,7 +39,7 @@ def viewport_layout_and_camera(camera, layout="layout_1"):
     review_camera = rt.getNodeByName(camera)
 
     try:
-        if rt.viewport.getLayout()!=rt.name(layout):
+        if rt.viewport.getLayout() != rt.name(layout):
             rt.execute("max tool maximize")
             needs_maximise = 1
         rt.viewport.setCamera(review_camera)

--- a/client/ayon_core/hosts/max/api/preview_animation.py
+++ b/client/ayon_core/hosts/max/api/preview_animation.py
@@ -31,23 +31,26 @@ def viewport_layout_and_camera(camera, layout="layout_1"):
         layout (str): layout to use in viewport, defaults to `layout_1`
             Use None to not change viewport layout during context.
     """
+    needs_maximise = 0
+    # Set to first active non extended viewport
+    rt.viewport.activeViewportEx(1)
     original_camera = rt.viewport.getCamera()
-    original_layout = rt.viewport.getLayout()
-    if not original_camera:
-        # if there is no original camera
-        # use the current camera as original
-        original_camera = rt.getNodeByName(camera)
+    original_type = rt.viewport.getType()
     review_camera = rt.getNodeByName(camera)
+
     try:
-        if layout is not None:
-            layout = rt.Name(layout)
-            if rt.viewport.getLayout() != layout:
-                rt.viewport.setLayout(layout)
+        if rt.viewport.getLayout()!=rt.name(layout):
+            rt.execute("max tool maximize")
+            needs_maximise = 1
         rt.viewport.setCamera(review_camera)
         yield
     finally:
-        rt.viewport.setLayout(original_layout)
-        rt.viewport.setCamera(original_camera)
+        if needs_maximise == 1:
+            rt.execute("max tool maximize")
+        if original_type == rt.Name("view_camera"):
+            rt.viewport.setCamera(original_camera)
+        else:
+            rt.viewport.setType(original_type)
 
 
 @contextlib.contextmanager

--- a/client/ayon_core/hosts/max/plugins/publish/validate_extended_viewport.py
+++ b/client/ayon_core/hosts/max/plugins/publish/validate_extended_viewport.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+import pyblish.api
+from ayon_core.pipeline import PublishValidationError
+from pymxs import runtime as rt
+
+
+class ValidateExtendedViewport(pyblish.api.InstancePlugin):
+    """Validate if the first viewport is an extended viewport."""
+
+    order = pyblish.api.ValidatorOrder
+    families = ["review"]
+    hosts = ["max"]
+    label = "Validate Extended Viewport"
+
+    def process(self, instance):
+        try:
+            rt.viewport.activeViewportEx(1)
+        except RuntimeError:
+            raise PublishValidationError(
+                "Please make sure one viewport is not an extended viewport", title=self.label)
+

--- a/client/ayon_core/hosts/max/plugins/publish/validate_extended_viewport.py
+++ b/client/ayon_core/hosts/max/plugins/publish/validate_extended_viewport.py
@@ -4,7 +4,7 @@ from ayon_core.pipeline import PublishValidationError
 from pymxs import runtime as rt
 
 
-class ValidateExtendedViewport(pyblish.api.InstancePlugin):
+class ValidateExtendedViewport(pyblish.api.ContextPlugin):
     """Validate if the first viewport is an extended viewport."""
 
     order = pyblish.api.ValidatorOrder
@@ -12,7 +12,7 @@ class ValidateExtendedViewport(pyblish.api.InstancePlugin):
     hosts = ["max"]
     label = "Validate Extended Viewport"
 
-    def process(self, instance):
+    def process(self, context):
         try:
             rt.viewport.activeViewportEx(1)
         except RuntimeError:

--- a/client/ayon_core/hosts/max/plugins/publish/validate_extended_viewport.py
+++ b/client/ayon_core/hosts/max/plugins/publish/validate_extended_viewport.py
@@ -17,8 +17,13 @@ class ValidateExtendedViewport(pyblish.api.ContextPlugin):
             rt.viewport.activeViewportEx(1)
         except RuntimeError:
             raise PublishValidationError(
-                "Please make sure at least one viewport is not an extended viewport but a 3dsmax supported viewport "
-                "i.e camera/persp/orthographic view. To rectify it, please go to view in the top menubar, "
-                "go to Views -> Viewports Configuration -> layout and right click on one of the panels to change "
-                "it.", title=self.label)
+                "Please make sure one viewport is not an extended viewport",
+                description = (
+                        "Please make sure at least one viewport is not an "
+                        "extended viewport but a 3dsmax supported viewport "
+                        "i.e camera/persp/orthographic view.\n\n"
+                        "To rectify it, please go to view in the top menubar, "
+                        "go to Views -> Viewports Configuration -> Layout and "
+                        "right click on one of the panels to change it."
+                ))
 

--- a/client/ayon_core/hosts/max/plugins/publish/validate_extended_viewport.py
+++ b/client/ayon_core/hosts/max/plugins/publish/validate_extended_viewport.py
@@ -17,5 +17,8 @@ class ValidateExtendedViewport(pyblish.api.InstancePlugin):
             rt.viewport.activeViewportEx(1)
         except RuntimeError:
             raise PublishValidationError(
-                "Please make sure one viewport is not an extended viewport", title=self.label)
+                "Please make sure at least one viewport is not an extended viewport but a 3dsmax supported viewport "
+                "i.e camera/persp/orthographic view. To rectify it, please go to view in the top menubar, "
+                "go to Views -> Viewports Configuration -> layout and right click on one of the panels to change "
+                "it.", title=self.label)
 


### PR DESCRIPTION
Retaining 3dsMax Viewport layout and checking for non-extended viewport for preview

## Changelog Problem
Previously, when doing a preview in 3ds max, the top left viewport would always be changed to the review camera view.
Even if it is a non camera view. Like a top or a right view.
It also doesn't like it if the top left viewport is an extended viewport (like a redshift renderview)
If another viewport (not the top left) is an extended viewport, the process of switching layouts remove all extended viewports.

## Changelog Description
Instead of switching layouts and switching back, we maximize the first non-extended viewport to do the review.
We store the camera as well as the type and switch it back to it's original camera or type when the preview is done.
We then un-maximize it if we had to maximize it before.

Added a validator to also make sure that there is a valid viewport that can be used for review and not have extended viewports occupying every available view.

## Testing notes for retaining layout:
1. Have a viewport layout, it could be a camera, orthographic, or extended viewport
2. Create a review
3. Make sure the layout before and after the review are the same.

## Testing notes for validator:
1) Switch every available viewport into an extended viewport
2) Validate and see if it errors.
