### PR TITLE
General: fix wrong assignment

### DIFF
--- a/client/ayon_core/client/conversion_utils.py
+++ b/client/ayon_core/client/conversion_utils.py
@@ -908,7 +908,7 @@ def convert_create_version_to_v4(version, con):
         converted_version["attrib"] = attribs
 
     if data:
-        converted_version["data"] = attribs
+        converted_version["data"] = data
 
     return converted_version
 
@@ -951,7 +951,7 @@ def convert_create_hero_version_to_v4(hero_version, project_name, con):
         converted_version["attrib"] = attribs
 
     if data:
-        converted_version["data"] = attribs
+        converted_version["data"] = data
 
     return converted_version
 


### PR DESCRIPTION
## Changelog Description
Without it additional values from data (as author) couldnt be passed through.

## Additional info
It seems as obvious typo/wrong assignment.

## Testing notes:
This would be a bit difficult as even if this is fixed, there is probably additional bug in server backend.  I noticed this when I was trying to push through different `author` than currently logged in in Webpublisher (that would be for services some `service` bogus account). 
I want to store the original author (and I set it into `context.data["user"]`), but it was not getting through. Now I think it is getting through, but server doesn't recognize it either.

But this seems like a required step to figure out server issue.

