### PR TITLE
Bugfix: Maya Load Vray Proxy fix import

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/load/load_vrayproxy.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_vrayproxy.py
@@ -7,9 +7,9 @@ loader will use them instead of native vray vrmesh format.
 """
 import os
 
-from ayon_api import get_representation_by_name
 import maya.cmds as cmds
 
+import ayon_api
 from ayon_core.settings import get_project_settings
 from ayon_core.pipeline import (
     load,


### PR DESCRIPTION
## Changelog Description

- Fix refactored import so function call is correct.

## Additional info

Otherwise the error is:
```python
During load error happened on Product: "modelMain" Representation: "abc" Version: 29

Error message: name 'ayon_api' is not defined

Traceback (most recent call last):
  File "E:\dev\ayon-core\client\ayon_core\tools\loader\models\actions.py", line 740, in _load_representations_by_loader
    load_with_repre_context(
  File "E:\dev\ayon-core\client\ayon_core\pipeline\load\utils.py", line 323, in load_with_repre_context
    return loader.load(repre_context, name, namespace, options)
  File "E:\dev\ayon-core\client\ayon_core\hosts\maya\plugins\load\load_vrayproxy.py", line 55, in load
    filename = self._get_abc(
  File "E:\dev\ayon-core\client\ayon_core\hosts\maya\plugins\load\load_vrayproxy.py", line 192, in _get_abc
    abc_rep = ayon_api.get_representation_by_name(
NameError: name 'ayon_api' is not defined
```

## Testing notes:

1. Run Load V-Ray Proxy in Maya
