### PR TITLE
TVPaint: Fix Load Reference Image Update logic

### DIFF
--- a/client/ayon_core/hosts/tvpaint/plugins/load/load_reference_image.py
+++ b/client/ayon_core/hosts/tvpaint/plugins/load/load_reference_image.py
@@ -1,10 +1,7 @@
 import collections
 
 from ayon_core.lib.attribute_definitions import BoolDef
-from ayon_core.pipeline import (
-    get_representation_context,
-    registered_host,
-)
+from ayon_core.pipeline import registered_host
 from ayon_core.hosts.tvpaint.api import plugin
 from ayon_core.hosts.tvpaint.api.lib import (
     get_layers_data,
@@ -218,10 +215,7 @@ class LoadImage(plugin.Loader):
         removed.
         """
 
-        repre_entity = context["representation"]
         # Create new containers first
-        context = get_representation_context(repre_entity["id"])
-
         # Get layer ids from previous container
         old_layer_names = self.get_members_from_container(container)
 


### PR DESCRIPTION
## Changelog Description

Removed redundant logic which was broken anyway, call to `get_representation_context` had wrong arguments

## Additional info

Note: Arguments passed to `get_representation_context` were wrong because it also takes `project_name` as argument

## Testing notes:

1. Update Reference Image in TVPaint should work
