### PR TITLE
Bugfix: Houdini Karma/Mantra collectors wrong indentation

### DIFF
--- a/client/ayon_core/hosts/houdini/plugins/publish/collect_karma_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/collect_karma_rop.py
@@ -41,23 +41,23 @@ class CollectKarmaROPRenderProducts(pyblish.api.InstancePlugin):
             instance.data["chunkSize"] = chunk_size
             self.log.debug("Chunk Size: %s" % chunk_size)
 
-            default_prefix = evalParmNoFrame(rop, "picture")
-            render_products = []
+        default_prefix = evalParmNoFrame(rop, "picture")
+        render_products = []
 
-            # Default beauty AOV
-            beauty_product = self.get_render_product_name(
-                prefix=default_prefix, suffix=None
-            )
-            render_products.append(beauty_product)
+        # Default beauty AOV
+        beauty_product = self.get_render_product_name(
+            prefix=default_prefix, suffix=None
+        )
+        render_products.append(beauty_product)
 
-            files_by_aov = {
-                "beauty": self.generate_expected_files(instance,
-                                                       beauty_product)
-            }
+        files_by_aov = {
+            "beauty": self.generate_expected_files(instance,
+                                                   beauty_product)
+        }
 
-            filenames = list(render_products)
-            instance.data["files"] = filenames
-            instance.data["renderProducts"] = colorspace.ARenderProduct()
+        filenames = list(render_products)
+        instance.data["files"] = filenames
+        instance.data["renderProducts"] = colorspace.ARenderProduct()
 
         for product in render_products:
             self.log.debug("Found render product: %s" % product)

--- a/client/ayon_core/hosts/houdini/plugins/publish/collect_mantra_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/collect_mantra_rop.py
@@ -41,57 +41,57 @@ class CollectMantraROPRenderProducts(pyblish.api.InstancePlugin):
             instance.data["chunkSize"] = chunk_size
             self.log.debug("Chunk Size: %s" % chunk_size)
 
-            default_prefix = evalParmNoFrame(rop, "vm_picture")
-            render_products = []
+        default_prefix = evalParmNoFrame(rop, "vm_picture")
+        render_products = []
 
-            # Store whether we are splitting the render job (export + render)
-            split_render = bool(rop.parm("soho_outputmode").eval())
-            instance.data["splitRender"] = split_render
-            export_prefix = None
-            export_products = []
-            if split_render:
-                export_prefix = evalParmNoFrame(
-                    rop, "soho_diskfile", pad_character="0"
-                )
-                beauty_export_product = self.get_render_product_name(
-                    prefix=export_prefix,
-                    suffix=None)
-                export_products.append(beauty_export_product)
-                self.log.debug(
-                    "Found export product: {}".format(beauty_export_product)
-                )
-                instance.data["ifdFile"] = beauty_export_product
-                instance.data["exportFiles"] = list(export_products)
-
-            # Default beauty AOV
-            beauty_product = self.get_render_product_name(
-                prefix=default_prefix, suffix=None
+        # Store whether we are splitting the render job (export + render)
+        split_render = bool(rop.parm("soho_outputmode").eval())
+        instance.data["splitRender"] = split_render
+        export_prefix = None
+        export_products = []
+        if split_render:
+            export_prefix = evalParmNoFrame(
+                rop, "soho_diskfile", pad_character="0"
             )
-            render_products.append(beauty_product)
+            beauty_export_product = self.get_render_product_name(
+                prefix=export_prefix,
+                suffix=None)
+            export_products.append(beauty_export_product)
+            self.log.debug(
+                "Found export product: {}".format(beauty_export_product)
+            )
+            instance.data["ifdFile"] = beauty_export_product
+            instance.data["exportFiles"] = list(export_products)
 
-            files_by_aov = {
-                "beauty": self.generate_expected_files(instance,
-                                                       beauty_product)
-            }
+        # Default beauty AOV
+        beauty_product = self.get_render_product_name(
+            prefix=default_prefix, suffix=None
+        )
+        render_products.append(beauty_product)
 
-            aov_numbers = rop.evalParm("vm_numaux")
-            if aov_numbers > 0:
-                # get the filenames of the AOVs
-                for i in range(1, aov_numbers + 1):
-                    var = rop.evalParm("vm_variable_plane%d" % i)
-                    if var:
-                        aov_name = "vm_filename_plane%d" % i
-                        aov_boolean = "vm_usefile_plane%d" % i
-                        aov_enabled = rop.evalParm(aov_boolean)
-                        has_aov_path = rop.evalParm(aov_name)
-                        if has_aov_path and aov_enabled == 1:
-                            aov_prefix = evalParmNoFrame(rop, aov_name)
-                            aov_product = self.get_render_product_name(
-                                prefix=aov_prefix, suffix=None
-                            )
-                            render_products.append(aov_product)
+        files_by_aov = {
+            "beauty": self.generate_expected_files(instance,
+                                                   beauty_product)
+        }
 
-                            files_by_aov[var] = self.generate_expected_files(instance, aov_product)     # noqa
+        aov_numbers = rop.evalParm("vm_numaux")
+        if aov_numbers > 0:
+            # get the filenames of the AOVs
+            for i in range(1, aov_numbers + 1):
+                var = rop.evalParm("vm_variable_plane%d" % i)
+                if var:
+                    aov_name = "vm_filename_plane%d" % i
+                    aov_boolean = "vm_usefile_plane%d" % i
+                    aov_enabled = rop.evalParm(aov_boolean)
+                    has_aov_path = rop.evalParm(aov_name)
+                    if has_aov_path and aov_enabled == 1:
+                        aov_prefix = evalParmNoFrame(rop, aov_name)
+                        aov_product = self.get_render_product_name(
+                            prefix=aov_prefix, suffix=None
+                        )
+                        render_products.append(aov_product)
+
+                        files_by_aov[var] = self.generate_expected_files(instance, aov_product)     # noqa
 
         for product in render_products:
             self.log.debug("Found render product: %s" % product)


### PR DESCRIPTION
## Changelog Description

Fix indendations

## Additional info

These would've broken in the case the "chunkSize" parm did not exist because `render_products` and `files_by_aov` would have been undefined variables.

## Testing notes:

1. Publish Karma ROP instance
2. Publish Mantra ROP instance

(Also test instances without the `chunkSize` parm, likely from older legacy instances - but maybe best to reproduce by removing the parms manually?)
