### PR TITLE
Bugfix: Maya validate rig contents geometry actually return invalid nodes

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/validate_rig_contents.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_rig_contents.py
@@ -87,9 +87,9 @@ class ValidateRigContents(pyblish.api.InstancePlugin):
         """Validate missing objectsets in rig sets
 
         Args:
-            instance (str): instance
-            required_objsets (list): list of objectset names
-            rig_sets (list): list of rig sets
+            instance (pyblish.api.Instance): instance
+            required_objsets (list[str]): list of objectset names
+            rig_sets (list[str]): list of rig sets
 
         Raises:
             PublishValidationError: When the error is raised, it will show
@@ -109,15 +109,15 @@ class ValidateRigContents(pyblish.api.InstancePlugin):
         Check if all rig set members are within the hierarchy of the rig root
 
         Args:
-            instance (str): instance
-            content (list): list of content from rig sets
+            instance (pyblish.api.Instance): instance
+            content (list[str]): list of content from rig sets
 
         Raises:
             PublishValidationError: It means no dag nodes in
                 the rig instance
 
         Returns:
-            list: invalid hierarchy
+            List[str]: invalid hierarchy
         """
         # Ensure there are at least some transforms or dag nodes
         # in the rig instance
@@ -140,15 +140,13 @@ class ValidateRigContents(pyblish.api.InstancePlugin):
 
     @classmethod
     def validate_geometry(cls, set_members):
-        """
-        Checks if the node types of the set members valid
+        """Checks if the node types of the set members valid
 
         Args:
-            set_members: list of nodes of the controls_set
-            hierarchy: list of nodes which reside under the root node
+            set_members (list[str]): nodes of the out_set
 
         Returns:
-            errors (list)
+            list[str]: Nodes of invalid types.
         """
 
         # Validate all shape types
@@ -166,16 +164,13 @@ class ValidateRigContents(pyblish.api.InstancePlugin):
 
     @classmethod
     def validate_controls(cls, set_members):
-        """
-        Checks if the control set members are allowed node types.
-        Checks if the node types of the set members valid
+        """Checks if the node types of the set members are valid for controls.
 
         Args:
-            set_members: list of nodes of the controls_set
-            hierarchy: list of nodes which reside under the root node
+            set_members (list[str]): list of nodes of the controls_set
 
         Returns:
-            errors (list)
+            list: Controls of disallowed node types.
         """
 
         # Validate control types
@@ -191,7 +186,7 @@ class ValidateRigContents(pyblish.api.InstancePlugin):
         """Get the target objectsets and rig sets nodes
 
         Args:
-            instance (str): instance
+            instance (pyblish.api.Instance): instance
 
         Returns:
             tuple: 2-tuple of list of objectsets,
@@ -249,11 +244,10 @@ class ValidateSkeletonRigContents(ValidateRigContents):
         """Get the target objectsets and rig sets nodes
 
         Args:
-            instance (str): instance
+            instance (pyblish.api.Instance): instance
 
         Returns:
-            tuple: 2-tuple of list of objectsets,
-                list of rig sets nodes
+            tuple: 2-tuple of list of objectsets, list of rig sets nodes
         """
         objectsets = ["skeletonMesh_SET"]
         skeleton_mesh_nodes = instance.data.get("skeleton_mesh", [])

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_rig_contents.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_rig_contents.py
@@ -162,6 +162,8 @@ class ValidateRigContents(pyblish.api.InstancePlugin):
             if cmds.nodeType(shape) not in cls.accepted_output:
                 invalid.append(shape)
 
+        return invalid
+
     @classmethod
     def validate_controls(cls, set_members):
         """


### PR DESCRIPTION
## Changelog Description

Fix geometry validation for rig validator

## Additional info

It was not returning the invalid nodes, so returned None always.
Also - fixed the docstrings.

## Testing notes:

1. Rig validation of geometry node types should work as intended.
