### PR TITLE
Bugfix: Switch Folder dialog, fix `fields` for getting last versions

### DIFF
--- a/client/ayon_core/tools/sceneinventory/switch_dialog/dialog.py
+++ b/client/ayon_core/tools/sceneinventory/switch_dialog/dialog.py
@@ -240,7 +240,7 @@ class SwitchAssetDialog(QtWidgets.QDialog):
         return ayon_api.get_last_versions(
             project_name,
             product_ids,
-            fields={"id", "folderId", "version"}
+            fields={"id", "productId", "version"}
         )
 
     def _on_show_timer(self):


### PR DESCRIPTION
## Changelog Description

Fix `fields` for getting last versions.

## Additional info

Should fix this error:
```python
# Traceback (most recent call last):
#   File "E:\dev\ayon-core\client\ayon_core\tools\sceneinventory\switch_dialog\dialog.py", line 384, in _combobox_value_changed
#     self.refresh()
#   File "E:\dev\ayon-core\client\ayon_core\tools\sceneinventory\switch_dialog\dialog.py", line 183, in refresh
#     repre_values = sorted(self._representations_box_values())
#   File "E:\dev\ayon-core\client\ayon_core\tools\sceneinventory\switch_dialog\dialog.py", line 856, in _representations_box_values
#     last_versions_by_product_id = self.find_last_versions([product_id])
#   File "E:\dev\ayon-core\client\ayon_core\tools\sceneinventory\switch_dialog\dialog.py", line 240, in find_last_versions
#     return ayon_api.get_last_versions(
#   File "C:\Program Files\Ynput\AYON 1.0.2\dependencies\ayon_api\_api.py", line 885, in get_last_versions
#     return con.get_last_versions(*args, **kwargs)
#   File "C:\Program Files\Ynput\AYON 1.0.2\dependencies\ayon_api\server_api.py", line 4796, in get_last_versions
#     return {
#   File "C:\Program Files\Ynput\AYON 1.0.2\dependencies\ayon_api\server_api.py", line 4796, in <dictcomp>
#     return {
#   File "C:\Program Files\Ynput\AYON 1.0.2\dependencies\ayon_api\server_api.py", line 4564, in get_versions
#     for parsed_data in query.continuous_query(self):
#   File "C:\Program Files\Ynput\AYON 1.0.2\dependencies\ayon_api\graphql.py", line 380, in continuous_query
#     raise GraphQlQueryFailed(
# ayon_api.exceptions.GraphQlQueryFailed: GraphQl query Failed: Cannot query field 'folderId' on type 'VersionNode'. (Line 7 Column 11)
```
Reported on [discord](https://discord.com/channels/517362899170230292/517382145552154634/1219774549394981005)

## Testing notes:

1. Switch Folder dialog should work
2. No errors should be logged or printed.
