### PR TITLE
Chore: Fix last versions getters for ayon api

### DIFF
--- a/client/ayon_core/lib/ayon_connection.py
+++ b/client/ayon_core/lib/ayon_connection.py
@@ -10,6 +10,87 @@ class _Cache:
     initialized = False
 
 
+def _new_get_last_versions(
+    self,
+    project_name,
+    product_ids,
+    active=True,
+    fields=None,
+    own_attributes=False
+):
+    """Query last version entities by product ids.
+
+    Args:
+        project_name (str): Project where to look for representation.
+        product_ids (Iterable[str]): Product ids.
+        active (Optional[bool]): Receive active/inactive entities.
+            Both are returned when 'None' is passed.
+        fields (Optional[Iterable[str]]): fields to be queried
+            for representations.
+        own_attributes (Optional[bool]): Attribute values that are
+            not explicitly set on entity will have 'None' value.
+
+    Returns:
+        dict[str, dict[str, Any]]: Last versions by product id.
+
+    """
+    if fields:
+        fields = set(fields)
+        fields.add("productId")
+
+    versions = self.get_versions(
+        project_name,
+        product_ids=product_ids,
+        latest=True,
+        hero=False,
+        active=active,
+        fields=fields,
+        own_attributes=own_attributes
+    )
+    return {
+        version["productId"]: version
+        for version in versions
+    }
+
+
+def _new_get_last_version_by_product_id(
+    self,
+    project_name,
+    product_id,
+    active=True,
+    fields=None,
+    own_attributes=False
+):
+    """Query last version entity by product id.
+
+    Args:
+        project_name (str): Project where to look for representation.
+        product_id (str): Product id.
+        active (Optional[bool]): Receive active/inactive entities.
+            Both are returned when 'None' is passed.
+        fields (Optional[Iterable[str]]): fields to be queried
+            for representations.
+        own_attributes (Optional[bool]): Attribute values that are
+            not explicitly set on entity will have 'None' value.
+
+    Returns:
+        Union[dict[str, Any], None]: Queried version entity or None.
+
+    """
+    versions = self.get_versions(
+        project_name,
+        product_ids=[product_id],
+        latest=True,
+        hero=False,
+        active=active,
+        fields=fields,
+        own_attributes=own_attributes
+    )
+    for version in versions:
+        return version
+    return None
+
+
 def _new_get_last_version_by_product_name(
     self,
     project_name,
@@ -73,9 +154,15 @@ def initialize_ayon_connection(force=False):
         semver.VersionInfo.parse(ayon_api.__version__).to_tuple()
     )
     # TODO remove mokey patching after when AYON api is safely updated
-    fix_last_version_by_product_name = ayon_api_version < (1, 0, 2)
+    fix_before_1_0_2 = ayon_api_version < (1, 0, 2)
     # Monkey patching to fix 'get_last_version_by_product_name'
-    if fix_last_version_by_product_name:
+    if fix_before_1_0_2:
+        ayon_api.ServerAPI.get_last_versions = (
+            _new_get_last_versions
+        )
+        ayon_api.ServerAPI.get_last_version_by_product_id = (
+            _new_get_last_version_by_product_id
+        )
         ayon_api.ServerAPI.get_last_version_by_product_name = (
             _new_get_last_version_by_product_name
         )
@@ -85,12 +172,22 @@ def initialize_ayon_connection(force=False):
     if ayon_api.is_connection_created():
         con = ayon_api.get_server_api_connection()
         # Monkey patching to fix 'get_last_version_by_product_name'
-        if fix_last_version_by_product_name:
-            def _con_wrapper(*args, **kwargs):
+        if fix_before_1_0_2:
+            def _lvs_wrapper(*args, **kwargs):
+                return _new_get_last_versions(
+                    con, *args, **kwargs
+                )
+            def _lv_by_pi_wrapper(*args, **kwargs):
+                return _new_get_last_version_by_product_id(
+                    con, *args, **kwargs
+                )
+            def _lv_by_pn_wrapper(*args, **kwargs):
                 return _new_get_last_version_by_product_name(
                     con, *args, **kwargs
                 )
-            con.get_last_version_by_product_name = _con_wrapper
+            con.get_last_versions = _lvs_wrapper
+            con.get_last_version_by_product_id = _lv_by_pi_wrapper
+            con.get_last_version_by_product_name = _lv_by_pn_wrapper
         con.set_site_id(site_id)
         con.set_client_version(version)
     else:


### PR DESCRIPTION
## Changelog Description
Monkey patch ayon api functions to fix issue with get last verisons.

## Additional info
Last versions getter are also returning hero version which lead to invalid resolving of latest version. This will be fixed in next release of ayon python api but until that point the methods are monkey patched ([ayon-api PR](https://github.com/ynput/ayon-python-api/pull/129)).

## Testing notes:
1. Scene inventory should show correctly latest version if there is hero version.
