### PR TITLE
Blender: Improve Validate Workfile Saved message 

### DIFF
--- a/client/ayon_core/hosts/blender/plugins/publish/validate_file_saved.py
+++ b/client/ayon_core/hosts/blender/plugins/publish/validate_file_saved.py
@@ -37,7 +37,8 @@ class ValidateFileSaved(pyblish.api.ContextPlugin,
         if not context.data["currentFile"]:
             # File has not been saved at all and has no filename
             raise PublishValidationError(
-                "Current file is empty. Save the file before continuing."
+                "Current workfile has not been saved yet.\n"
+                "Save the workfile before continuing."
             )
 
         # Do not validate workfile has unsaved changes if only instances


### PR DESCRIPTION
## Changelog Description

Tweak clarity of the message that is about the workfile being unsaved… - not being 'empty'.

## Additional info

n/a

## Testing notes:

1. Publish from Blender, do not save - hit the validation error
2. Message should be understandable by artists
