### PR TITLE
Re-add outputName to _rename_in_representation

### DIFF
--- a/client/ayon_core/plugins/publish/extract_color_transcode.py
+++ b/client/ayon_core/plugins/publish/extract_color_transcode.py
@@ -257,6 +257,7 @@ class ExtractOIIOTranscode(publish.Extractor):
             return
 
         new_repre["ext"] = output_extension
+        new_repre["outputName"] = output_name
 
         renamed_files = []
         for file_name in files_to_convert:


### PR DESCRIPTION
## Changelog Description
This PR simply adds `new_repre["outputName"] = output_name` inside the `_rename_in_representation` function.
Without this if a user would like to add eg {colorspace} to a name preset it wouldn't be found, so you can't have two oiio outputs as the second one would try and overwrite the first publish.

## Additional info
This bug was found by @jakubjezek001 under the hackinton but I'm submitting it as we fixed in on my ayon instance.

## Testing notes:
1. add <_{colorspace}> to your render name preset
2. add two oiio conversion presets
3. publish a render

Without this fix you'll get an error that it can't publish an already published product. With the fix + _{colorspace} added to the name Ayon will be able to publish the new oiio products with new correct output names.
