### PR TITLE
Maya Settings: Extract Camera bake attributes title fix + add description

### DIFF
--- a/server_addon/maya/server/settings/publishers.py
+++ b/server_addon/maya/server/settings/publishers.py
@@ -322,7 +322,9 @@ class ExtractCameraAlembicModel(BaseSettingsModel):
     optional: bool = SettingsField(title="Optional")
     active: bool = SettingsField(title="Active")
     bake_attributes: str = SettingsField(
-        "[]", title="Base Attributes", widget="textarea"
+        "[]", title="Bake Attributes", widget="textarea",
+        description="List of attributes that will be included in the alembic "
+                    "export.",
     )
 
     @validator("bake_attributes")

--- a/server_addon/maya/server/settings/publishers.py
+++ b/server_addon/maya/server/settings/publishers.py
@@ -315,16 +315,13 @@ class ExtractMayaSceneRawModel(BaseSettingsModel):
 
 
 class ExtractCameraAlembicModel(BaseSettingsModel):
-    """
-    List of attributes that will be added to the baked alembic camera. Needs to be written in python list syntax.
-    """
     enabled: bool = SettingsField(title="ExtractCameraAlembic")
     optional: bool = SettingsField(title="Optional")
     active: bool = SettingsField(title="Active")
     bake_attributes: str = SettingsField(
         "[]", title="Bake Attributes", widget="textarea",
         description="List of attributes that will be included in the alembic "
-                    "export.",
+                    "camera export. Needs to be written as a JSON list.",
     )
 
     @validator("bake_attributes")


### PR DESCRIPTION
## Changelog Description

Settings for Maya Extract Camera "bake attributes" should now be labeled correctly and have a description.
## Additional info

I did not bump the server addon version because it's cosmetics only for the settings. So it's fine it only starts showing in future releases.

## Testing notes:
1. Settings for Maya Extract Camera "bake attributes" should now be labeled correctly and have a description.