### PR TITLE
Houdini: Camera loader allow switching folders/products

### DIFF
--- a/client/ayon_core/hosts/houdini/plugins/load/load_camera.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_camera.py
@@ -167,6 +167,9 @@ class CameraLoader(load.LoaderPlugin):
 
         temp_camera.destroy()
 
+    def switch(self, container, context):
+        self.update(container, context)
+
     def remove(self, container):
 
         node = container["node"]

--- a/client/ayon_core/hosts/houdini/plugins/load/load_camera.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_camera.py
@@ -198,7 +198,6 @@ class CameraLoader(load.LoaderPlugin):
     def _match_maya_render_mask(self, camera):
         """Workaround to match Maya render mask in Houdini"""
 
-        # print("Setting match maya render mask ")
         parm = camera.parm("aperture")
         expression = parm.expression()
         expression = expression.replace("return ", "aperture = ")


### PR DESCRIPTION
## Changelog Description

Camera loader allow switching folders/products via scene inventory (manage).

## Additional info

Also removed redundant comment.

## Testing notes:

1. Switch folder should work for Camera loader in Houdini