### PR TITLE
Core: Headless publish failing without GL lib

### DIFF
--- a/client/ayon_core/cli_commands.py
+++ b/client/ayon_core/cli_commands.py
@@ -67,8 +67,6 @@ class Commands:
             install_ayon_plugins,
             get_global_context,
         )
-        from ayon_core.tools.utils.host_tools import show_publish
-        from ayon_core.tools.utils.lib import qt_app_context
 
         # Register target and host
         import pyblish.api
@@ -134,6 +132,8 @@ class Commands:
             print(plugin)
 
         if gui:
+            from ayon_core.tools.utils.host_tools import show_publish
+            from ayon_core.tools.utils.lib import qt_app_context
             with qt_app_context():
                 show_publish()
         else:


### PR DESCRIPTION
## Changelog Description
The imports of openpype.tools.utils.host_tools.__init__.py were throwing an error due to trying to import QtWidgets unnecessarily.

> [!NOTE]
> This is port of community PR to OpenPype - https://github.com/ynput/OpenPype/pull/6205

## Testing notes:
1. Run a headless publish in a farm worker that doesn't have libGL