### PR TITLE
Chore: Simple OpenPype to AYON changes

### DIFF
--- a/client/ayon_core/addon/README.md
+++ b/client/ayon_core/addon/README.md
@@ -89,4 +89,4 @@ AYON addons should contain separated logic of specific kind of implementation, s
 
 ### TrayAddonsManager
 - inherits from `AddonsManager`
-- has specific implementation for Pype Tray tool and handle `ITrayAddon` methods
+- has specific implementation for AYON Tray and handle `ITrayAddon` methods

--- a/client/ayon_core/addon/README.md
+++ b/client/ayon_core/addon/README.md
@@ -27,7 +27,7 @@ AYON addons should contain separated logic of specific kind of implementation, s
 - default interfaces are defined in `interfaces.py`
 
 ## IPluginPaths
-- addon wants to add directory path/s to avalon or publish plugins
+- addon wants to add directory path/s to publish, load, create or inventory plugins
 - addon must implement `get_plugin_paths` which must return dictionary with possible keys `"publish"`, `"load"`, `"create"` or `"actions"`
  - each key may contain list or string with a path to directory with plugins
 

--- a/client/ayon_core/addon/base.py
+++ b/client/ayon_core/addon/base.py
@@ -741,7 +741,7 @@ class AddonsManager:
 
         addon_classes = []
         for module in openpype_modules:
-            # Go through globals in `pype.modules`
+            # Go through globals in `ayon_core.modules`
             for name in dir(module):
                 modules_item = getattr(module, name, None)
                 # Filter globals that are not classes which inherit from

--- a/client/ayon_core/hosts/flame/api/__init__.py
+++ b/client/ayon_core/hosts/flame/api/__init__.py
@@ -1,5 +1,5 @@
 """
-OpenPype Autodesk Flame api
+AYON Autodesk Flame api
 """
 from .constants import (
     COLOR_MAP,

--- a/client/ayon_core/hosts/flame/api/constants.py
+++ b/client/ayon_core/hosts/flame/api/constants.py
@@ -1,14 +1,14 @@
 
 """
-OpenPype Flame api constances
+AYON Flame api constances
 """
-# OpenPype marker workflow variables
+# AYON marker workflow variables
 MARKER_NAME = "OpenPypeData"
 MARKER_DURATION = 0
 MARKER_COLOR = "cyan"
 MARKER_PUBLISH_DEFAULT = False
 
-# OpenPype color definitions
+# AYON color definitions
 COLOR_MAP = {
     "red": (1.0, 0.0, 0.0),
     "orange": (1.0, 0.5, 0.0),

--- a/client/ayon_core/hosts/flame/api/pipeline.py
+++ b/client/ayon_core/hosts/flame/api/pipeline.py
@@ -38,12 +38,12 @@ def install():
     pyblish.register_plugin_path(PUBLISH_PATH)
     register_loader_plugin_path(LOAD_PATH)
     register_creator_plugin_path(CREATE_PATH)
-    log.info("OpenPype Flame plug-ins registered ...")
+    log.info("AYON Flame plug-ins registered ...")
 
     # register callback for switching publishable
     pyblish.register_callback("instanceToggled", on_pyblish_instance_toggled)
 
-    log.info("OpenPype Flame host installed ...")
+    log.info("AYON Flame host installed ...")
 
 
 def uninstall():
@@ -57,7 +57,7 @@ def uninstall():
     # register callback for switching publishable
     pyblish.deregister_callback("instanceToggled", on_pyblish_instance_toggled)
 
-    log.info("OpenPype Flame host uninstalled ...")
+    log.info("AYON Flame host uninstalled ...")
 
 
 def containerise(flame_clip_segment,

--- a/client/ayon_core/hosts/flame/api/plugin.py
+++ b/client/ayon_core/hosts/flame/api/plugin.py
@@ -38,7 +38,7 @@ class CreatorWidget(QtWidgets.QDialog):
             | QtCore.Qt.WindowCloseButtonHint
             | QtCore.Qt.WindowStaysOnTopHint
         )
-        self.setWindowTitle(name or "Pype Creator Input")
+        self.setWindowTitle(name or "AYON Creator Input")
         self.resize(500, 700)
 
         # Where inputs and labels are set

--- a/client/ayon_core/hosts/flame/api/scripts/wiretap_com.py
+++ b/client/ayon_core/hosts/flame/api/scripts/wiretap_com.py
@@ -61,7 +61,7 @@ class WireTapCom(object):
 
     def get_launch_args(
             self, project_name, project_data, user_name, *args, **kwargs):
-        """Forming launch arguments for OpenPype launcher.
+        """Forming launch arguments for AYON launcher.
 
         Args:
             project_name (str): name of project

--- a/client/ayon_core/hosts/flame/api/utils.py
+++ b/client/ayon_core/hosts/flame/api/utils.py
@@ -124,7 +124,7 @@ def setup(env=None):
     # synchronize resolve utility scripts
     _sync_utility_scripts(env)
 
-    log.info("Flame OpenPype wrapper has been installed")
+    log.info("Flame AYON wrapper has been installed")
 
 
 def get_flame_version():

--- a/client/ayon_core/hosts/flame/api/utils.py
+++ b/client/ayon_core/hosts/flame/api/utils.py
@@ -11,7 +11,7 @@ log = Logger.get_logger(__name__)
 def _sync_utility_scripts(env=None):
     """ Synchronizing basic utlility scripts for flame.
 
-    To be able to run start OpenPype within Flame we have to copy
+    To be able to run start AYON within Flame we have to copy
     all utility_scripts and additional FLAME_SCRIPT_DIR into
     `/opt/Autodesk/shared/python`. This will be always synchronizing those
     folders.

--- a/client/ayon_core/hosts/flame/hooks/pre_flame_setup.py
+++ b/client/ayon_core/hosts/flame/hooks/pre_flame_setup.py
@@ -72,7 +72,7 @@ class FlamePrelaunch(PreLaunchHook):
         project_data = {
             "Name": project_entity["name"],
             "Nickname": project_entity["code"],
-            "Description": "Created by OpenPype",
+            "Description": "Created by AYON",
             "SetupDir": project_entity["name"],
             "FrameWidth": int(width),
             "FrameHeight": int(height),

--- a/client/ayon_core/hosts/flame/startup/openpype_babypublisher/modules/panel_app.py
+++ b/client/ayon_core/hosts/flame/startup/openpype_babypublisher/modules/panel_app.py
@@ -79,7 +79,7 @@ class FlameBabyPublisherPanel(object):
 
         # creating ui
         self.window.setMinimumSize(1500, 600)
-        self.window.setWindowTitle('OpenPype: Baby-publisher')
+        self.window.setWindowTitle('AYON: Baby-publisher')
         self.window.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
         self.window.setAttribute(QtCore.Qt.WA_DeleteOnClose)
         self.window.setFocusPolicy(QtCore.Qt.StrongFocus)

--- a/client/ayon_core/hosts/flame/startup/openpype_babypublisher/openpype_babypublisher.py
+++ b/client/ayon_core/hosts/flame/startup/openpype_babypublisher/openpype_babypublisher.py
@@ -31,7 +31,7 @@ def scope_sequence(selection):
 def get_media_panel_custom_ui_actions():
     return [
         {
-            "name": "OpenPype: Baby-publisher",
+            "name": "AYON: Baby-publisher",
             "actions": [
                 {
                     "name": "Create Shots",

--- a/client/ayon_core/hosts/flame/startup/openpype_in_flame.py
+++ b/client/ayon_core/hosts/flame/startup/openpype_in_flame.py
@@ -12,7 +12,7 @@ from ayon_core.pipeline import (
 
 
 def openpype_install():
-    """Registering OpenPype in context
+    """Registering AYON in context
     """
     install_host(opfapi)
     print("Registered host: {}".format(registered_host()))

--- a/client/ayon_core/hosts/flame/startup/openpype_in_flame.py
+++ b/client/ayon_core/hosts/flame/startup/openpype_in_flame.py
@@ -28,7 +28,7 @@ def exeption_handler(exctype, value, _traceback):
         tb (str): traceback to show
     """
     import traceback
-    msg = "OpenPype: Python exception {} in {}".format(value, exctype)
+    msg = "AYON: Python exception {} in {}".format(value, exctype)
     mbox = QtWidgets.QMessageBox()
     mbox.setText(msg)
     mbox.setDetailedText(

--- a/client/ayon_core/hosts/fusion/api/__init__.py
+++ b/client/ayon_core/hosts/fusion/api/__init__.py
@@ -15,7 +15,7 @@ from .lib import (
     comp_lock_and_undo_chunk
 )
 
-from .menu import launch_openpype_menu
+from .menu import launch_ayon_menu
 
 
 __all__ = [
@@ -35,5 +35,5 @@ __all__ = [
     "comp_lock_and_undo_chunk",
 
     # menu
-    "launch_openpype_menu",
+    "launch_ayon_menu",
 ]

--- a/client/ayon_core/hosts/fusion/api/menu.py
+++ b/client/ayon_core/hosts/fusion/api/menu.py
@@ -125,7 +125,7 @@ class OpenPypeMenu(QtWidgets.QWidget):
         self._pulse = FusionPulse(parent=self)
         self._pulse.start()
 
-        # Detect Fusion events as OpenPype events
+        # Detect Fusion events as AYON events
         self._event_handler = FusionEventHandler(parent=self)
         self._event_handler.start()
 

--- a/client/ayon_core/hosts/fusion/api/menu.py
+++ b/client/ayon_core/hosts/fusion/api/menu.py
@@ -28,9 +28,9 @@ self = sys.modules[__name__]
 self.menu = None
 
 
-class OpenPypeMenu(QtWidgets.QWidget):
+class AYONMenu(QtWidgets.QWidget):
     def __init__(self, *args, **kwargs):
-        super(OpenPypeMenu, self).__init__(*args, **kwargs)
+        super(AYONMenu, self).__init__(*args, **kwargs)
 
         self.setObjectName(f"{MENU_LABEL}Menu")
 
@@ -174,16 +174,16 @@ class OpenPypeMenu(QtWidgets.QWidget):
         set_current_context_framerange()
 
 
-def launch_openpype_menu():
+def launch_ayon_menu():
     app = get_qt_app()
 
-    pype_menu = OpenPypeMenu()
+    ayon_menu = AYONMenu()
 
     stylesheet = load_stylesheet()
-    pype_menu.setStyleSheet(stylesheet)
+    ayon_menu.setStyleSheet(stylesheet)
 
-    pype_menu.show()
-    self.menu = pype_menu
+    ayon_menu.show()
+    self.menu = ayon_menu
 
     result = app.exec_()
     print("Shutting down..")

--- a/client/ayon_core/hosts/fusion/api/pipeline.py
+++ b/client/ayon_core/hosts/fusion/api/pipeline.py
@@ -70,7 +70,7 @@ class FusionHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     name = "fusion"
 
     def install(self):
-        """Install fusion-specific functionality of OpenPype.
+        """Install fusion-specific functionality of AYON.
 
         This is where you install menus and register families, data
         and loaders into fusion.
@@ -177,7 +177,7 @@ def on_after_open(event):
     if any_outdated_containers():
         log.warning("Scene has outdated content.")
 
-        # Find OpenPype menu to attach to
+        # Find AYON menu to attach to
         from . import menu
 
         def _on_show_scene_inventory():
@@ -326,9 +326,9 @@ class FusionEventThread(QtCore.QThread):
 
 
 class FusionEventHandler(QtCore.QObject):
-    """Emits OpenPype events based on Fusion events captured in a QThread.
+    """Emits AYON events based on Fusion events captured in a QThread.
 
-    This will emit the following OpenPype events based on Fusion actions:
+    This will emit the following AYON events based on Fusion actions:
         save: Comp_Save, Comp_SaveAs
         open: Comp_Opened
         new: Comp_New
@@ -374,7 +374,7 @@ class FusionEventHandler(QtCore.QObject):
         self._event_thread.stop()
 
     def _on_event(self, event):
-        """Handle Fusion events to emit OpenPype events"""
+        """Handle Fusion events to emit AYON events"""
         if not event:
             return
 

--- a/client/ayon_core/hosts/fusion/deploy/MenuScripts/README.md
+++ b/client/ayon_core/hosts/fusion/deploy/MenuScripts/README.md
@@ -1,6 +1,6 @@
-### OpenPype deploy MenuScripts
+### AYON deploy MenuScripts
 
 Note that this `MenuScripts` is not an official Fusion folder.
-OpenPype only uses this folder in `{fusion}/deploy/` to trigger the OpenPype menu actions.
+AYON only uses this folder in `{fusion}/deploy/` to trigger the AYON menu actions.
 
 They are used in the actions defined in `.fu` files in `{fusion}/deploy/Config`.

--- a/client/ayon_core/hosts/fusion/deploy/MenuScripts/launch_menu.py
+++ b/client/ayon_core/hosts/fusion/deploy/MenuScripts/launch_menu.py
@@ -35,7 +35,7 @@ def main(env):
     log = Logger.get_logger(__name__)
     log.info(f"Registered host: {registered_host()}")
 
-    menu.launch_openpype_menu()
+    menu.launch_ayon_menu()
 
     # Initiate a QTimer to check if Fusion is still alive every X interval
     # If Fusion is not found - kill itself

--- a/client/ayon_core/hosts/fusion/hooks/pre_fusion_profile_hook.py
+++ b/client/ayon_core/hosts/fusion/hooks/pre_fusion_profile_hook.py
@@ -19,7 +19,7 @@ class FusionCopyPrefsPrelaunch(PreLaunchHook):
     Prepares local Fusion profile directory, copies existing Fusion profile.
     This also sets FUSION MasterPrefs variable, which is used
     to apply Master.prefs file to override some Fusion profile settings to:
-        - enable the OpenPype menu
+        - enable the AYON menu
         - force Python 3 over Python 2
         - force English interface
     Master.prefs is defined in openpype/hosts/fusion/deploy/fusion_shared.prefs

--- a/client/ayon_core/hosts/fusion/hooks/pre_fusion_setup.py
+++ b/client/ayon_core/hosts/fusion/hooks/pre_fusion_setup.py
@@ -13,7 +13,7 @@ from ayon_core.hosts.fusion import (
 
 class FusionPrelaunch(PreLaunchHook):
     """
-    Prepares OpenPype Fusion environment.
+    Prepares AYON Fusion environment.
     Requires correct Python home variable to be defined in the environment
     settings for Fusion to point at a valid Python 3 build for Fusion.
     Python3 versions that are supported by Fusion:

--- a/client/ayon_core/hosts/harmony/api/README.md
+++ b/client/ayon_core/hosts/harmony/api/README.md
@@ -204,7 +204,7 @@ class CreateComposite(harmony.Creator):
 
     name = "compositeDefault"
     label = "Composite"
-    product_type = "mindbender.template"
+    product_type = "template"
 
     def __init__(self, *args, **kwargs):
         super(CreateComposite, self).__init__(*args, **kwargs)
@@ -221,7 +221,7 @@ class CreateRender(harmony.Creator):
 
     name = "writeDefault"
     label = "Write"
-    product_type = "mindbender.imagesequence"
+    product_type = "render"
     node_type = "WRITE"
 
     def __init__(self, *args, **kwargs):
@@ -304,7 +304,7 @@ class ExtractImage(pyblish.api.InstancePlugin):
     label = "Extract Image Sequence"
     order = pyblish.api.ExtractorOrder
     hosts = ["harmony"]
-    families = ["mindbender.imagesequence"]
+    families = ["render"]
 
     def process(self, instance):
         project_path = harmony.send(
@@ -582,8 +582,16 @@ class ImageSequenceLoader(load.LoaderPlugin):
     """Load images
     Stores the imported asset in a container named after the asset.
     """
-    product_types = {"mindbender.imagesequence"}
+    product_types = {
+        "shot",
+        "render",
+        "image",
+        "plate",
+        "reference",
+        "review",
+    }
     representations = ["*"]
+    extensions = {"jpeg", "png", "jpg"}
 
     def load(self, context, name=None, namespace=None, data=None):
         files = []

--- a/client/ayon_core/hosts/hiero/api/plugin.py
+++ b/client/ayon_core/hosts/hiero/api/plugin.py
@@ -45,7 +45,7 @@ class CreatorWidget(QtWidgets.QDialog):
             | QtCore.Qt.WindowCloseButtonHint
             | QtCore.Qt.WindowStaysOnTopHint
         )
-        self.setWindowTitle(name or "Pype Creator Input")
+        self.setWindowTitle(name or "AYON Creator Input")
         self.resize(500, 700)
 
         # Where inputs and labels are set

--- a/client/ayon_core/hosts/hiero/plugins/create/create_shot_clip.py
+++ b/client/ayon_core/hosts/hiero/plugins/create/create_shot_clip.py
@@ -16,7 +16,7 @@ class CreateShotClip(phiero.Creator):
 
     gui_tracks = [track.name()
                   for track in phiero.get_current_sequence().videoTracks()]
-    gui_name = "Pype publish attributes creator"
+    gui_name = "AYON publish attributes creator"
     gui_info = "Define sequential rename and fill hierarchy data."
     gui_inputs = {
         "renameHierarchy": {

--- a/client/ayon_core/hosts/houdini/api/plugin.py
+++ b/client/ayon_core/hosts/houdini/api/plugin.py
@@ -19,10 +19,6 @@ from ayon_core.lib import BoolDef
 from .lib import imprint, read, lsattr, add_self_publish_button
 
 
-class OpenPypeCreatorError(CreatorError):
-    pass
-
-
 class Creator(LegacyCreator):
     """Creator plugin to create instances in Houdini
 
@@ -92,8 +88,8 @@ class Creator(LegacyCreator):
 
         except hou.Error as er:
             six.reraise(
-                OpenPypeCreatorError,
-                OpenPypeCreatorError("Creator error: {}".format(er)),
+                CreatorError,
+                CreatorError("Creator error: {}".format(er)),
                 sys.exc_info()[2])
 
 
@@ -209,8 +205,8 @@ class HoudiniCreator(NewCreator, HoudiniCreatorBase):
 
         except hou.Error as er:
             six.reraise(
-                OpenPypeCreatorError,
-                OpenPypeCreatorError("Creator error: {}".format(er)),
+                CreatorError,
+                CreatorError("Creator error: {}".format(er)),
                 sys.exc_info()[2])
 
     def lock_parameters(self, node, parameters):

--- a/client/ayon_core/hosts/houdini/plugins/create/create_hda.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_hda.py
@@ -2,6 +2,7 @@
 """Creator plugin for creating publishable Houdini Digital Assets."""
 import ayon_api
 
+from ayon_core.pipeline import CreatorError
 from ayon_core.hosts.houdini.api import plugin
 import hou
 
@@ -52,7 +53,7 @@ class CreateHDA(plugin.HoudiniCreator):
             # if node type has not its definition, it is not user
             # created hda. We test if hda can be created from the node.
             if not to_hda.canCreateDigitalAsset():
-                raise plugin.OpenPypeCreatorError(
+                raise CreatorError(
                     "cannot create hda from node {}".format(to_hda))
 
             hda_node = to_hda.createDigitalAsset(
@@ -61,7 +62,7 @@ class CreateHDA(plugin.HoudiniCreator):
             )
             hda_node.layoutChildren()
         elif self._check_existing(folder_path, node_name):
-            raise plugin.OpenPypeCreatorError(
+            raise CreatorError(
                 ("product {} is already published with different HDA"
                  "definition.").format(node_name))
         else:

--- a/client/ayon_core/hosts/houdini/plugins/create/create_redshift_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_redshift_rop.py
@@ -2,6 +2,7 @@
 """Creator plugin to create Redshift ROP."""
 import hou  # noqa
 
+from ayon_core.pipeline import CreatorError
 from ayon_core.hosts.houdini.api import plugin
 from ayon_core.lib import EnumDef, BoolDef
 
@@ -42,7 +43,7 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
                 "Redshift_IPR", node_name=f"{basename}_IPR"
             )
         except hou.OperationFailed as e:
-            raise plugin.OpenPypeCreatorError(
+            raise CreatorError(
                 (
                     "Cannot create Redshift node. Is Redshift "
                     "installed and enabled?"

--- a/client/ayon_core/hosts/houdini/plugins/create/create_vray_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_vray_rop.py
@@ -3,7 +3,7 @@
 import hou
 
 from ayon_core.hosts.houdini.api import plugin
-from ayon_core.pipeline import CreatedInstance
+from ayon_core.pipeline import CreatedInstance, CreatorError
 from ayon_core.lib import EnumDef, BoolDef
 
 
@@ -42,7 +42,7 @@ class CreateVrayROP(plugin.HoudiniCreator):
                 "vray", node_name=basename + "_IPR"
             )
         except hou.OperationFailed:
-            raise plugin.OpenPypeCreatorError(
+            raise CreatorError(
                 "Cannot create Vray render node. "
                 "Make sure Vray installed and enabled!"
             )

--- a/client/ayon_core/hosts/houdini/startup/MainMenuCommon.xml
+++ b/client/ayon_core/hosts/houdini/startup/MainMenuCommon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mainMenu>
     <menuBar>
-        <subMenu id="openpype_menu">
+        <subMenu id="ayon_menu">
             <labelExpression><![CDATA[
 import os
 return os.environ.get("AYON_MENU_LABEL") or "AYON"

--- a/client/ayon_core/hosts/max/api/menu.py
+++ b/client/ayon_core/hosts/max/api/menu.py
@@ -8,8 +8,8 @@ from ayon_core.tools.utils import host_tools
 from ayon_core.hosts.max.api import lib
 
 
-class OpenPypeMenu(object):
-    """Object representing OpenPype/AYON menu.
+class AYONMenu(object):
+    """Object representing AYON menu.
 
     This is using "hack" to inject itself before "Help" menu of 3dsmax.
     For some reason `postLoadingMenus` event doesn't fire, and main menu
@@ -39,7 +39,7 @@ class OpenPypeMenu(object):
 
         self._counter = 0
         self._timer.stop()
-        self.build_openpype_menu()
+        self._build_ayon_menu()
 
     @staticmethod
     def get_main_widget():
@@ -50,8 +50,8 @@ class OpenPypeMenu(object):
         """Get main Menubar by 3dsmax main window."""
         return list(self.main_widget.findChildren(QtWidgets.QMenuBar))[0]
 
-    def get_or_create_openpype_menu(
-            self, name: str = "&Openpype",
+    def _get_or_create_ayon_menu(
+            self, name: str = "&AYON",
             before: str = "&Help") -> QtWidgets.QAction:
         """Create AYON menu.
 
@@ -73,7 +73,7 @@ class OpenPypeMenu(object):
         help_action = None
         for item in menu_items:
             if name in item.title():
-                # we already have OpenPype menu
+                # we already have AYON menu
                 return item
 
             if before in item.title():
@@ -85,50 +85,50 @@ class OpenPypeMenu(object):
         self.menu = op_menu
         return op_menu
 
-    def build_openpype_menu(self) -> QtWidgets.QAction:
+    def _build_ayon_menu(self) -> QtWidgets.QAction:
         """Build items in AYON menu."""
-        openpype_menu = self.get_or_create_openpype_menu()
-        load_action = QtWidgets.QAction("Load...", openpype_menu)
+        ayon_menu = self._get_or_create_ayon_menu()
+        load_action = QtWidgets.QAction("Load...", ayon_menu)
         load_action.triggered.connect(self.load_callback)
-        openpype_menu.addAction(load_action)
+        ayon_menu.addAction(load_action)
 
-        publish_action = QtWidgets.QAction("Publish...", openpype_menu)
+        publish_action = QtWidgets.QAction("Publish...", ayon_menu)
         publish_action.triggered.connect(self.publish_callback)
-        openpype_menu.addAction(publish_action)
+        ayon_menu.addAction(publish_action)
 
-        manage_action = QtWidgets.QAction("Manage...", openpype_menu)
+        manage_action = QtWidgets.QAction("Manage...", ayon_menu)
         manage_action.triggered.connect(self.manage_callback)
-        openpype_menu.addAction(manage_action)
+        ayon_menu.addAction(manage_action)
 
-        library_action = QtWidgets.QAction("Library...", openpype_menu)
+        library_action = QtWidgets.QAction("Library...", ayon_menu)
         library_action.triggered.connect(self.library_callback)
-        openpype_menu.addAction(library_action)
+        ayon_menu.addAction(library_action)
 
-        openpype_menu.addSeparator()
+        ayon_menu.addSeparator()
 
-        workfiles_action = QtWidgets.QAction("Work Files...", openpype_menu)
+        workfiles_action = QtWidgets.QAction("Work Files...", ayon_menu)
         workfiles_action.triggered.connect(self.workfiles_callback)
-        openpype_menu.addAction(workfiles_action)
+        ayon_menu.addAction(workfiles_action)
 
-        openpype_menu.addSeparator()
+        ayon_menu.addSeparator()
 
-        res_action = QtWidgets.QAction("Set Resolution", openpype_menu)
+        res_action = QtWidgets.QAction("Set Resolution", ayon_menu)
         res_action.triggered.connect(self.resolution_callback)
-        openpype_menu.addAction(res_action)
+        ayon_menu.addAction(res_action)
 
-        frame_action = QtWidgets.QAction("Set Frame Range", openpype_menu)
+        frame_action = QtWidgets.QAction("Set Frame Range", ayon_menu)
         frame_action.triggered.connect(self.frame_range_callback)
-        openpype_menu.addAction(frame_action)
+        ayon_menu.addAction(frame_action)
 
-        colorspace_action = QtWidgets.QAction("Set Colorspace", openpype_menu)
+        colorspace_action = QtWidgets.QAction("Set Colorspace", ayon_menu)
         colorspace_action.triggered.connect(self.colorspace_callback)
-        openpype_menu.addAction(colorspace_action)
+        ayon_menu.addAction(colorspace_action)
 
-        unit_scale_action = QtWidgets.QAction("Set Unit Scale", openpype_menu)
+        unit_scale_action = QtWidgets.QAction("Set Unit Scale", ayon_menu)
         unit_scale_action.triggered.connect(self.unit_scale_callback)
-        openpype_menu.addAction(unit_scale_action)
+        ayon_menu.addAction(unit_scale_action)
 
-        return openpype_menu
+        return ayon_menu
 
     def load_callback(self):
         """Callback to show Loader tool."""

--- a/client/ayon_core/hosts/max/api/pipeline.py
+++ b/client/ayon_core/hosts/max/api/pipeline.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Pipeline tools for AYON Houdini integration."""
+"""Pipeline tools for AYON 3ds max integration."""
 import os
 import logging
 from operator import attrgetter

--- a/client/ayon_core/hosts/max/api/pipeline.py
+++ b/client/ayon_core/hosts/max/api/pipeline.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Pipeline tools for OpenPype Houdini integration."""
+"""Pipeline tools for AYON Houdini integration."""
 import os
 import logging
 from operator import attrgetter
@@ -148,7 +148,7 @@ attributes "OpenPypeContext"
 
 
 def ls() -> list:
-    """Get all OpenPype instances."""
+    """Get all AYON containers."""
     objs = rt.objects
     containers = [
         obj for obj in objs

--- a/client/ayon_core/hosts/max/api/pipeline.py
+++ b/client/ayon_core/hosts/max/api/pipeline.py
@@ -14,7 +14,7 @@ from ayon_core.pipeline import (
     AVALON_CONTAINER_ID,
     AYON_CONTAINER_ID,
 )
-from ayon_core.hosts.max.api.menu import OpenPypeMenu
+from ayon_core.hosts.max.api.menu import AYONMenu
 from ayon_core.hosts.max.api import lib
 from ayon_core.hosts.max.api.plugin import MS_CUSTOM_ATTRIB
 from ayon_core.hosts.max import MAX_HOST_DIR
@@ -48,7 +48,7 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_creator_plugin_path(CREATE_PATH)
 
         # self._register_callbacks()
-        self.menu = OpenPypeMenu()
+        self.menu = AYONMenu()
 
         self._has_been_setup = True
 
@@ -94,7 +94,7 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
     def _deferred_menu_creation(self):
         self.log.info("Building menu ...")
-        self.menu = OpenPypeMenu()
+        self.menu = AYONMenu()
 
     @staticmethod
     def create_context_node():

--- a/client/ayon_core/hosts/max/api/plugin.py
+++ b/client/ayon_core/hosts/max/api/plugin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""3dsmax specific Avalon/Pyblish plugin definitions."""
+"""3dsmax specific AYON/Pyblish plugin definitions."""
 from abc import ABCMeta
 
 import six

--- a/client/ayon_core/hosts/max/api/plugin.py
+++ b/client/ayon_core/hosts/max/api/plugin.py
@@ -156,10 +156,6 @@ MS_CUSTOM_ATTRIB = """attributes "openPypeData"
 )"""
 
 
-class OpenPypeCreatorError(CreatorError):
-    pass
-
-
 class MaxCreatorBase(object):
 
     @staticmethod

--- a/client/ayon_core/hosts/max/hooks/force_startup_script.py
+++ b/client/ayon_core/hosts/max/hooks/force_startup_script.py
@@ -6,7 +6,7 @@ from ayon_core.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class ForceStartupScript(PreLaunchHook):
-    """Inject OpenPype environment to 3ds max.
+    """Inject AYON environment to 3ds max.
 
     Note that this works in combination whit 3dsmax startup script that
     is translating it back to PYTHONPATH for cases when 3dsmax drops PYTHONPATH

--- a/client/ayon_core/hosts/max/hooks/inject_python.py
+++ b/client/ayon_core/hosts/max/hooks/inject_python.py
@@ -5,7 +5,7 @@ from ayon_core.lib.applications import PreLaunchHook, LaunchTypes
 
 
 class InjectPythonPath(PreLaunchHook):
-    """Inject OpenPype environment to 3dsmax.
+    """Inject AYON environment to 3dsmax.
 
     Note that this works in combination whit 3dsmax startup script that
     is translating it back to PYTHONPATH for cases when 3dsmax drops PYTHONPATH

--- a/client/ayon_core/hosts/max/startup/startup.ms
+++ b/client/ayon_core/hosts/max/startup/startup.ms
@@ -1,4 +1,4 @@
--- OpenPype Init Script
+-- AYON Init Script
 (
     local sysPath = dotNetClass "System.IO.Path"
 	local sysDir = dotNetClass "System.IO.Directory"

--- a/client/ayon_core/hosts/maya/api/commands.py
+++ b/client/ayon_core/hosts/maya/api/commands.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""OpenPype script commands to be used directly in Maya."""
+"""AYON script commands to be used directly in Maya."""
 from maya import cmds
 
 from ayon_api import get_project, get_folder_by_path

--- a/client/ayon_core/hosts/maya/api/customize.py
+++ b/client/ayon_core/hosts/maya/api/customize.py
@@ -109,7 +109,7 @@ def override_toolbox_ui():
 
     controls.append(
         cmds.iconTextButton(
-            "pype_toolbox_lookmanager",
+            "ayon_toolbox_lookmanager",
             annotation="Look Manager",
             label="Look Manager",
             image=os.path.join(icons, "lookmanager.png"),
@@ -122,7 +122,7 @@ def override_toolbox_ui():
 
     controls.append(
         cmds.iconTextButton(
-            "pype_toolbox_workfiles",
+            "ayon_toolbox_workfiles",
             annotation="Work Files",
             label="Work Files",
             image=os.path.join(icons, "workfiles.png"),
@@ -137,7 +137,7 @@ def override_toolbox_ui():
 
     controls.append(
         cmds.iconTextButton(
-            "pype_toolbox_loader",
+            "ayon_toolbox_loader",
             annotation="Loader",
             label="Loader",
             image=os.path.join(icons, "loader.png"),
@@ -152,7 +152,7 @@ def override_toolbox_ui():
 
     controls.append(
         cmds.iconTextButton(
-            "pype_toolbox_manager",
+            "ayon_toolbox_manager",
             annotation="Inventory",
             label="Inventory",
             image=os.path.join(icons, "inventory.png"),

--- a/client/ayon_core/hosts/maya/api/lib.py
+++ b/client/ayon_core/hosts/maya/api/lib.py
@@ -2931,13 +2931,13 @@ def bake_to_world_space(nodes,
 
 
 def load_capture_preset(data):
-    """Convert OpenPype Extract Playblast settings to `capture` arguments
+    """Convert AYON Extract Playblast settings to `capture` arguments
 
     Input data is the settings from:
         `project_settings/maya/publish/ExtractPlayblast/capture_preset`
 
     Args:
-        data (dict): Capture preset settings from OpenPype settings
+        data (dict): Capture preset settings from AYON settings
 
     Returns:
         dict: `capture.capture` compatible keyword arguments
@@ -3288,7 +3288,7 @@ def set_colorspace():
     else:
         # TODO: deprecated code from 3.15.5 - remove
         # Maya 2022+ introduces new OCIO v2 color management settings that
-        # can override the old color management preferences. OpenPype has
+        # can override the old color management preferences. AYON has
         # separate settings for both so we fall back when necessary.
         use_ocio_v2 = imageio["colorManagementPreference_v2"]["enabled"]
         if use_ocio_v2 and not ocio_v2_support:

--- a/client/ayon_core/hosts/maya/api/lib_rendersetup.py
+++ b/client/ayon_core/hosts/maya/api/lib_rendersetup.py
@@ -3,7 +3,7 @@
 
 https://github.com/Colorbleed/colorbleed-config/blob/acre/colorbleed/maya/lib_rendersetup.py
 Credits: Roy Nieterau (BigRoy) / Colorbleed
-Modified for use in OpenPype
+Modified for use in AYON
 
 """
 

--- a/client/ayon_core/hosts/maya/api/menu.py
+++ b/client/ayon_core/hosts/maya/api/menu.py
@@ -50,7 +50,7 @@ def get_context_label():
 
 def install(project_settings):
     if cmds.about(batch=True):
-        log.info("Skipping openpype.menu initialization in batch mode..")
+        log.info("Skipping AYON menu initialization in batch mode..")
         return
 
     def add_menu():

--- a/client/ayon_core/hosts/maya/api/menu.py
+++ b/client/ayon_core/hosts/maya/api/menu.py
@@ -261,7 +261,7 @@ def popup():
 
 
 def update_menu_task_label():
-    """Update the task label in Avalon menu to current session"""
+    """Update the task label in AYON menu to current session"""
 
     if IS_HEADLESS:
         return

--- a/client/ayon_core/hosts/maya/api/pipeline.py
+++ b/client/ayon_core/hosts/maya/api/pipeline.py
@@ -361,13 +361,13 @@ def parse_container(container):
 
 
 def _ls():
-    """Yields Avalon container node names.
+    """Yields AYON container node names.
 
     Used by `ls()` to retrieve the nodes and then query the full container's
     data.
 
     Yields:
-        str: Avalon container node name (objectSet)
+        str: AYON container node name (objectSet)
 
     """
 
@@ -384,7 +384,7 @@ def _ls():
     }
 
     # Iterate over all 'set' nodes in the scene to detect whether
-    # they have the avalon container ".id" attribute.
+    # they have the ayon container ".id" attribute.
     fn_dep = om.MFnDependencyNode()
     iterator = om.MItDependencyNodes(om.MFn.kSet)
     for mobject in _maya_iterate(iterator):

--- a/client/ayon_core/hosts/maya/api/pipeline.py
+++ b/client/ayon_core/hosts/maya/api/pipeline.py
@@ -673,7 +673,7 @@ def workfile_save_before_xgen(event):
     switching context.
 
     Args:
-        event (Event) - openpype/lib/events.py
+        event (Event) - ayon_core/lib/events.py
     """
     if not cmds.pluginInfo("xgenToolkit", query=True, loaded=True):
         return

--- a/client/ayon_core/hosts/maya/api/plugin.py
+++ b/client/ayon_core/hosts/maya/api/plugin.py
@@ -899,7 +899,7 @@ class ReferenceLoader(Loader):
                             cmds.disconnectAttr(input, node_attr)
                         cmds.setAttr(node_attr, data["value"])
 
-        # Fix PLN-40 for older containers created with Avalon that had the
+        # Fix PLN-40 for older containers created with AYON that had the
         # `.verticesOnlySet` set to True.
         if cmds.getAttr("{}.verticesOnlySet".format(node)):
             self.log.info("Setting %s.verticesOnlySet to False", node)

--- a/client/ayon_core/hosts/maya/api/render_setup_tools.py
+++ b/client/ayon_core/hosts/maya/api/render_setup_tools.py
@@ -5,7 +5,7 @@ Export Maya nodes from Render Setup layer as if flattened in that layer instead
 of exporting the defaultRenderLayer as Maya forces by default
 
 Credits: Roy Nieterau (BigRoy) / Colorbleed
-Modified for use in OpenPype
+Modified for use in AYON
 
 """
 

--- a/client/ayon_core/hosts/maya/api/setdress.py
+++ b/client/ayon_core/hosts/maya/api/setdress.py
@@ -150,7 +150,7 @@ def load_package(filepath, name, namespace=None):
             containers.append(container)
 
     # TODO: Do we want to cripple? Or do we want to add a 'parent' parameter?
-    # Cripple the original avalon containers so they don't show up in the
+    # Cripple the original AYON containers so they don't show up in the
     # manager
     # for container in containers:
     #     cmds.setAttr("%s.id" % container,
@@ -175,7 +175,7 @@ def _add(instance, representation_id, loaders, namespace, root="|"):
         namespace (str):
 
     Returns:
-        str: The created Avalon container.
+        str: The created AYON container.
 
     """
 
@@ -244,7 +244,7 @@ def _instances_by_namespace(data):
 
 
 def get_contained_containers(container):
-    """Get the Avalon containers in this container
+    """Get the AYON containers in this container
 
     Args:
         container (dict): The container dict.
@@ -256,7 +256,7 @@ def get_contained_containers(container):
 
     from .pipeline import parse_container
 
-    # Get avalon containers in this package setdress container
+    # Get AYON containers in this package setdress container
     containers = []
     members = cmds.sets(container['objectName'], query=True)
     for node in cmds.ls(members, type="objectSet"):

--- a/client/ayon_core/hosts/maya/plugins/create/convert_legacy.py
+++ b/client/ayon_core/hosts/maya/plugins/create/convert_legacy.py
@@ -19,7 +19,7 @@ class MayaLegacyConvertor(ProductConvertorPlugin,
 
     Its limitation is that you can have multiple creators creating product
     of the same type and there is no way to handle it. This code should
-    nevertheless cover all creators that came with OpenPype.
+    nevertheless cover all creators that came with AYON.
 
     """
     identifier = "io.openpype.creators.maya.legacy"

--- a/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_arnold.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_arnold.py
@@ -108,7 +108,7 @@ class LoadVDBtoArnold(load.LoaderPlugin):
 
         from maya import cmds
 
-        # Get all members of the avalon container, ensure they are unlocked
+        # Get all members of the AYON container, ensure they are unlocked
         # and delete everything
         members = cmds.sets(container['objectName'], query=True)
         cmds.lockNode(members, lock=False)

--- a/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_redshift.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_redshift.py
@@ -115,7 +115,7 @@ class LoadVDBtoRedShift(load.LoaderPlugin):
     def remove(self, container):
         from maya import cmds
 
-        # Get all members of the avalon container, ensure they are unlocked
+        # Get all members of the AYON container, ensure they are unlocked
         # and delete everything
         members = cmds.sets(container['objectName'], query=True)
         cmds.lockNode(members, lock=False)

--- a/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_vray.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_vray.py
@@ -277,7 +277,7 @@ class LoadVDBtoVRay(load.LoaderPlugin):
 
     def remove(self, container):
 
-        # Get all members of the avalon container, ensure they are unlocked
+        # Get all members of the AYON container, ensure they are unlocked
         # and delete everything
         members = cmds.sets(container['objectName'], query=True)
         cmds.lockNode(members, lock=False)

--- a/client/ayon_core/hosts/maya/plugins/publish/collect_inputs.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/collect_inputs.py
@@ -79,12 +79,12 @@ def iter_history(nodes,
 def collect_input_containers(containers, nodes):
     """Collect containers that contain any of the node in `nodes`.
 
-    This will return any loaded Avalon container that contains at least one of
-    the nodes. As such, the Avalon container is an input for it. Or in short,
+    This will return any loaded AYON container that contains at least one of
+    the nodes. As such, the AYON container is an input for it. Or in short,
     there are member nodes of that container.
 
     Returns:
-        list: Input avalon containers
+        list: Input loaded containers
 
     """
     # Assume the containers have collected their cached '_members' data

--- a/client/ayon_core/hosts/maya/plugins/publish/extract_look.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/extract_look.py
@@ -106,10 +106,10 @@ class TextureProcessor:
         self.log = log
 
     def apply_settings(self, project_settings):
-        """Apply OpenPype system/project settings to the TextureProcessor
+        """Apply AYON system/project settings to the TextureProcessor
 
         Args:
-            project_settings (dict): OpenPype project settings
+            project_settings (dict): AYON project settings
 
         Returns:
             None
@@ -278,7 +278,7 @@ class MakeTX(TextureProcessor):
         """Process the texture.
 
         This function requires the `maketx` executable to be available in an
-        OpenImageIO toolset detectable by OpenPype.
+        OpenImageIO toolset detectable by AYON.
 
         Args:
             source (str): Path to source file.

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_loaded_plugin.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_loaded_plugin.py
@@ -24,7 +24,7 @@ class ValidateLoadedPlugin(pyblish.api.ContextPlugin,
 
         invalid = []
         loaded_plugin = cmds.pluginInfo(query=True, listPlugins=True)
-        # get variable from OpenPype settings
+        # get variable from AYON settings
         whitelist_native_plugins = cls.whitelist_native_plugins
         authorized_plugins = cls.authorized_plugins or []
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_vray_referenced_aovs.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_vray_referenced_aovs.py
@@ -45,7 +45,7 @@ class ValidateVrayReferencedAOVs(pyblish.api.InstancePlugin,
                 self.log.warning((
                     "Referenced AOVs are enabled in Vray "
                     "Render Settings and are detected in scene, but "
-                    "Pype render instance option for referenced AOVs is "
+                    "AYON render instance option for referenced AOVs is "
                     "disabled. Those AOVs will be rendered but not published "
                     "by Pype."
                 ))

--- a/client/ayon_core/hosts/maya/startup/userSetup.py
+++ b/client/ayon_core/hosts/maya/startup/userSetup.py
@@ -10,7 +10,7 @@ from maya import cmds
 host = MayaHost()
 install_host(host)
 
-print("Starting OpenPype usersetup...")
+print("Starting AYON usersetup...")
 
 project_name = get_current_project_name()
 settings = get_project_settings(project_name)
@@ -47,4 +47,4 @@ if bool(int(os.environ.get(key, "0"))):
     )
 
 
-print("Finished OpenPype usersetup.")
+print("Finished AYON usersetup.")

--- a/client/ayon_core/hosts/nuke/api/pipeline.py
+++ b/client/ayon_core/hosts/nuke/api/pipeline.py
@@ -128,7 +128,7 @@ class NukeHost(
         register_creator_plugin_path(CREATE_PATH)
         register_inventory_action_path(INVENTORY_PATH)
 
-        # Register Avalon event for workfiles loading.
+        # Register AYON event for workfiles loading.
         register_event_callback("workio.open_file", check_inventory_versions)
         register_event_callback("taskChanged", change_context_label)
 
@@ -230,9 +230,9 @@ def get_context_label():
 
 
 def _install_menu():
-    """Install Avalon menu into Nuke's main menu bar."""
+    """Install AYON menu into Nuke's main menu bar."""
 
-    # uninstall original avalon menu
+    # uninstall original AYON menu
     main_window = get_main_window()
     menubar = nuke.menu("Nuke")
     menu = menubar.addMenu(MENU_LABEL)

--- a/client/ayon_core/hosts/nuke/startup/custom_write_node.py
+++ b/client/ayon_core/hosts/nuke/startup/custom_write_node.py
@@ -1,4 +1,4 @@
-""" OpenPype custom script for setting up write nodes for non-publish """
+""" AYON custom script for setting up write nodes for non-publish """
 import os
 import nuke
 import nukescripts

--- a/client/ayon_core/hosts/nuke/startup/frame_setting_for_read_nodes.py
+++ b/client/ayon_core/hosts/nuke/startup/frame_setting_for_read_nodes.py
@@ -1,4 +1,4 @@
-""" OpenPype custom script for resetting read nodes start frame values """
+""" AYON custom script for resetting read nodes start frame values """
 
 import nuke
 import nukescripts

--- a/client/ayon_core/hosts/resolve/README.markdown
+++ b/client/ayon_core/hosts/resolve/README.markdown
@@ -18,7 +18,7 @@ This is how it looks on my testing project timeline
 ![image](https://user-images.githubusercontent.com/40640033/102637638-96ec6600-4156-11eb-9656-6e8e3ce4baf8.png)
 Notice I had renamed tracks to `main` (holding metadata markers) and `review` used for generating review data with ffmpeg confersion to jpg sequence.
 
-1.  you need to start OpenPype menu from Resolve/EditTab/Menu/Workspace/Scripts/Comp/**__OpenPype_Menu__**
+1.  you need to start AYON menu from Resolve/EditTab/Menu/Workspace/Scripts/Comp/**__OpenPype_Menu__**
 2.  then select any clips in `main` track and change their color to `Chocolate`
 3.  in OpenPype Menu select `Create`
 4.  in Creator select `Create Publishable Clip [New]` (temporary name)

--- a/client/ayon_core/hosts/resolve/api/__init__.py
+++ b/client/ayon_core/hosts/resolve/api/__init__.py
@@ -44,7 +44,7 @@ from .lib import (
     get_reformated_path
 )
 
-from .menu import launch_pype_menu
+from .menu import launch_ayon_menu
 
 from .plugin import (
     ClipLoader,
@@ -113,7 +113,7 @@ __all__ = [
     "get_reformated_path",
 
     # menu
-    "launch_pype_menu",
+    "launch_ayon_menu",
 
     # plugin
     "ClipLoader",

--- a/client/ayon_core/hosts/resolve/api/menu.py
+++ b/client/ayon_core/hosts/resolve/api/menu.py
@@ -38,9 +38,9 @@ class Spacer(QtWidgets.QWidget):
         self.setLayout(layout)
 
 
-class OpenPypeMenu(QtWidgets.QWidget):
+class AYONMenu(QtWidgets.QWidget):
     def __init__(self, *args, **kwargs):
-        super(OpenPypeMenu, self).__init__(*args, **kwargs)
+        super(AYONMenu, self).__init__(*args, **kwargs)
 
         self.setObjectName(f"{MENU_LABEL}Menu")
 
@@ -170,14 +170,14 @@ class OpenPypeMenu(QtWidgets.QWidget):
         host_tools.show_experimental_tools_dialog()
 
 
-def launch_pype_menu():
+def launch_ayon_menu():
     app = QtWidgets.QApplication(sys.argv)
 
-    pype_menu = OpenPypeMenu()
+    ayon_menu = AYONMenu()
 
     stylesheet = load_stylesheet()
-    pype_menu.setStyleSheet(stylesheet)
+    ayon_menu.setStyleSheet(stylesheet)
 
-    pype_menu.show()
+    ayon_menu.show()
 
     sys.exit(app.exec_())

--- a/client/ayon_core/hosts/resolve/api/menu_style.qss
+++ b/client/ayon_core/hosts/resolve/api/menu_style.qss
@@ -51,7 +51,7 @@ QLineEdit {
   qproperty-alignment: AlignCenter;
 }
 
-#OpenPypeMenu {
+#AYONMenu {
     qproperty-alignment: AlignLeft;
     min-width: 10em;
     border: 1px solid #fef9ef;

--- a/client/ayon_core/hosts/resolve/startup.py
+++ b/client/ayon_core/hosts/resolve/startup.py
@@ -35,7 +35,7 @@ def ensure_installed_host():
 def launch_menu():
     print("Launching Resolve AYON menu..")
     ensure_installed_host()
-    ayon_core.hosts.resolve.api.launch_pype_menu()
+    ayon_core.hosts.resolve.api.launch_ayon_menu()
 
 
 def open_workfile(path):

--- a/client/ayon_core/hosts/resolve/utility_scripts/AYON__Menu.py
+++ b/client/ayon_core/hosts/resolve/utility_scripts/AYON__Menu.py
@@ -8,13 +8,13 @@ log = Logger.get_logger(__name__)
 
 
 def main(env):
-    from ayon_core.hosts.resolve.api import ResolveHost, launch_pype_menu
+    from ayon_core.hosts.resolve.api import ResolveHost, launch_ayon_menu
 
     # activate resolve from openpype
     host = ResolveHost()
     install_host(host)
 
-    launch_pype_menu()
+    launch_ayon_menu()
 
 
 if __name__ == "__main__":

--- a/client/ayon_core/hosts/tvpaint/plugins/load/load_sound.py
+++ b/client/ayon_core/hosts/tvpaint/plugins/load/load_sound.py
@@ -54,7 +54,7 @@ class ImportSound(plugin.Loader):
     def load(self, context, name, namespace, options):
         # Create temp file for output
         output_file = tempfile.NamedTemporaryFile(
-            mode="w", prefix="pype_tvp_", suffix=".txt", delete=False
+            mode="w", prefix="ayon_tvp_", suffix=".txt", delete=False
         )
         output_file.close()
         output_filepath = output_file.name.replace("\\", "/")

--- a/client/ayon_core/hosts/unreal/api/pipeline.py
+++ b/client/ayon_core/hosts/unreal/api/pipeline.py
@@ -98,7 +98,7 @@ class UnrealHost(HostBase, ILoadHost, IPublishHost):
 
 
 def install():
-    """Install Unreal configuration for OpenPype."""
+    """Install Unreal configuration for AYON."""
     print("-=" * 40)
     logo = '''.
 .

--- a/client/ayon_core/lib/applications.py
+++ b/client/ayon_core/lib/applications.py
@@ -1897,12 +1897,12 @@ def should_start_last_workfile(
     `"0", "1", "true", "false", "yes", "no"`.
 
     Args:
-        project_name (str): Name of project.
-        host_name (str): Name of host which is launched. In avalon's
-            application context it's value stored in app definition under
-            key `"application_dir"`. Is not case sensitive.
-        task_name (str): Name of task which is used for launching the host.
-            Task name is not case sensitive.
+        project_name (str): Project name.
+        host_name (str): Host name.
+        task_name (str): Task name.
+        task_type (str): Task type.
+        default_output (Optional[bool]): Default output if no profile is
+            found.
 
     Returns:
         bool: True if host should start workfile.
@@ -1947,12 +1947,12 @@ def should_workfile_tool_start(
     `"0", "1", "true", "false", "yes", "no"`.
 
     Args:
-        project_name (str): Name of project.
-        host_name (str): Name of host which is launched. In avalon's
-            application context it's value stored in app definition under
-            key `"application_dir"`. Is not case sensitive.
-        task_name (str): Name of task which is used for launching the host.
-            Task name is not case sensitive.
+        project_name (str): Project name.
+        host_name (str): Host name.
+        task_name (str): Task name.
+        task_type (str): Task type.
+        default_output (Optional[bool]): Default output if no profile is
+            found.
 
     Returns:
         bool: True if host should start workfile.

--- a/client/ayon_core/lib/applications.py
+++ b/client/ayon_core/lib/applications.py
@@ -204,7 +204,7 @@ class ApplicationGroup:
     Application group wraps different versions(variants) of application.
     e.g. "maya" is group and "maya_2020" is variant.
 
-    Group hold `host_name` which is implementation name used in pype. Also
+    Group hold `host_name` which is implementation name used in AYON. Also
     holds `enabled` if whole app group is enabled or `icon` for application
     icon path in resources.
 

--- a/client/ayon_core/lib/ayon_info.py
+++ b/client/ayon_core/lib/ayon_info.py
@@ -102,8 +102,8 @@ def get_all_current_info():
 def extract_ayon_info_to_file(dirpath, filename=None):
     """Extract all current info to a file.
 
-    It is possible to define only directory path. Filename is concatenated with
-    pype version, workstation site id and timestamp.
+    It is possible to define only directory path. Filename is concatenated
+    with AYON version, workstation site id and timestamp.
 
     Args:
         dirpath (str): Path to directory where file will be stored.

--- a/client/ayon_core/lib/python_module_tools.py
+++ b/client/ayon_core/lib/python_module_tools.py
@@ -118,8 +118,8 @@ def classes_from_module(superclass, module):
 
     Arguments:
         superclass (superclass): Superclass of subclasses to look for
-        module (types.ModuleType): Imported module from which to
-            parse valid Avalon plug-ins.
+        module (types.ModuleType): Imported module where to look for
+            'superclass' subclasses.
 
     Returns:
         List of plug-ins, or empty list if none is found.

--- a/client/ayon_core/lib/terminal.py
+++ b/client/ayon_core/lib/terminal.py
@@ -69,7 +69,7 @@ class Terminal:
             Terminal.use_colors = False
             print(
                 "Module `blessed` failed on import or terminal creation."
-                " Pype terminal won't use colors."
+                " AYON terminal won't use colors."
             )
             Terminal._initialized = True
             return

--- a/client/ayon_core/modules/clockify/ftrack/server/action_clockify_sync_server.py
+++ b/client/ayon_core/modules/clockify/ftrack/server/action_clockify_sync_server.py
@@ -11,7 +11,7 @@ class SyncClockifyServer(ServerAction):
     label = "Sync To Clockify (server)"
     description = "Synchronise data to Clockify workspace"
 
-    role_list = ["Pypeclub", "Administrator", "project Manager"]
+    role_list = ["Administrator", "project Manager"]
 
     def __init__(self, *args, **kwargs):
         super(SyncClockifyServer, self).__init__(*args, **kwargs)

--- a/client/ayon_core/modules/clockify/ftrack/user/action_clockify_sync_local.py
+++ b/client/ayon_core/modules/clockify/ftrack/user/action_clockify_sync_local.py
@@ -13,7 +13,7 @@ class SyncClockifyLocal(BaseAction):
     #: Action description.
     description = 'Synchronise data to Clockify workspace'
     #: roles that are allowed to register this action
-    role_list = ["Pypeclub", "Administrator", "project Manager"]
+    role_list = ["Administrator", "project Manager"]
     #: icon
     icon = statics_icon("app_icons", "clockify-white.png")
 

--- a/client/ayon_core/pipeline/create/legacy_create.py
+++ b/client/ayon_core/pipeline/create/legacy_create.py
@@ -44,7 +44,7 @@ class LegacyCreator(object):
 
     @classmethod
     def apply_settings(cls, project_settings):
-        """Apply OpenPype settings to a plugin class."""
+        """Apply AYON settings to a plugin class."""
 
         host_name = os.environ.get("AYON_HOST_NAME")
         plugin_type = "create"

--- a/client/ayon_core/pipeline/publish/README.md
+++ b/client/ayon_core/pipeline/publish/README.md
@@ -1,8 +1,8 @@
 # Publish
-OpenPype is using `pyblish` for publishing process which is a little bit extented and modified mainly for UI purposes. OpenPype's (new) publish UI does not allow to enable/disable instances or plugins that can be done during creation part. Also does support actions only for validators after validation exception.
+AYON is using `pyblish` for publishing process which is a little bit extented and modified mainly for UI purposes. OpenPype's (new) publish UI does not allow to enable/disable instances or plugins that can be done during creation part. Also does support actions only for validators after validation exception.
 
 ## Exceptions
-OpenPype define few specific exceptions that should be used in publish plugins.
+AYON define few specific exceptions that should be used in publish plugins.
 
 ### Validation exception
 Validation plugins should raise `PublishValidationError` to show to an artist what's wrong and give him actions to fix it. The exception says that error happened in plugin can be fixed by artist himself (with or without action on plugin). Any other errors will stop publishing immediately. Exception `PublishValidationError` raised after validation order has same effect as any other exception.
@@ -35,4 +35,4 @@ class MyExtendedPlugin(
 ### Extensions
 Currently only extension is ability to define attributes for instances during creation. Method `get_attribute_defs` returns attribute definitions for families defined in plugin's `families` attribute if it's instance plugin or for whole context if it's context plugin. To convert existing values (or to remove legacy values) can be implemented `convert_attribute_values`. Values of publish attributes from created instance are never removed automatically so implementing of this method is best way to remove legacy data or convert them to new data structure.
 
-Possible attribute definitions can be found in `openpype/pipeline/lib/attribute_definitions.py`.
+Possible attribute definitions can be found in `ayon_core/lib/attribute_definitions.py`.

--- a/client/ayon_core/pipeline/schema/__init__.py
+++ b/client/ayon_core/pipeline/schema/__init__.py
@@ -44,11 +44,6 @@ def validate(data, schema=None):
         _precache()
 
     root, schema = data["schema"].rsplit(":", 1)
-    # assert root in (
-    #     "mindbender-core",  # Backwards compatiblity
-    #     "avalon-core",
-    #     "pype"
-    # )
 
     if isinstance(schema, six.string_types):
         schema = _cache[schema + ".json"]

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1726,7 +1726,7 @@ class PlaceholderCreateMixin(object):
                 items=creator_items,
                 tooltip=(
                     "Creator"
-                    "\nDefines what OpenPype creator will be used to"
+                    "\nDefines what AYON creator will be used to"
                     " create publishable instance."
                     "\nUseable creator depends on current host's creator list."
                     "\nField is case sensitive."


### PR DESCRIPTION
## Changelog Description
Another PR changing Openpype/Pype to AYON in codebase. All changes are affecting only prints, comments or UI elements and should not affect real logic.

## Additional info
Use AYON naming in UIs, prints, class & function names, readme or button identifiers.
Removed unused `OpenPypeCreatorError` in 3dsMax integration.
Removed `OpenPypeCreatorError` from houdini which just inherited from `CreatorError`, I didn't find any reason to keep it.

## Testing notes:
- [x] Changed comments/logs make sense.
- [x] 3dsMax menu works.
- [x] Fusion menu works.
- [x] Resolve menu works.
- [x] Houdini does raise correct Create error (don't know how to).

EDITED:
Also renamed avalon to AYON.