### PR TITLE
Houdini: Load usd to SOPs directly

### DIFF
--- a/client/ayon_core/hosts/houdini/plugins/load/load_usd_sop.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_usd_sop.py
@@ -1,0 +1,91 @@
+import os
+
+from ayon_core.pipeline import load
+from ayon_core.hosts.houdini.api import pipeline
+
+
+class SopUsdImportLoader(load.LoaderPlugin):
+    """Load USD to SOPs via `usdimport`"""
+
+    label = "Load USD to SOPs"
+    product_types = {"*"}
+    representations = ["usd"]
+    order = -6
+    icon = "code-fork"
+    color = "orange"
+
+    def load(self, context, name=None, namespace=None, data=None):
+        import hou
+
+        # Format file name, Houdini only wants forward slashes
+        file_path = self.filepath_from_context(context)
+        file_path = os.path.normpath(file_path)
+        file_path = file_path.replace("\\", "/")
+
+        # Get the root node
+        obj = hou.node("/obj")
+
+        # Define node name
+        namespace = namespace if namespace else context["folder"]["name"]
+        node_name = "{}_{}".format(namespace, name) if namespace else name
+
+        # Create a new geo node
+        container = obj.createNode("geo", node_name=node_name)
+
+        # Remove the file node, it only loads static meshes
+        # Houdini 17 has removed the file node from the geo node
+        file_node = container.node("file1")
+        if file_node:
+            file_node.destroy()
+
+        # Create a usdimport node
+        usdimport = container.createNode("usdimport", node_name=node_name)
+        usdimport.setParms({"filepath1": file_path})
+
+        # Ensure display flag is on the first input node and not on the OUT
+        # node to optimize "debug" displaying in the viewport.
+        usdimport.setDisplayFlag(True)
+
+        # Set new position for unpack node else it gets cluttered
+        nodes = [container, usdimport]
+        for nr, node in enumerate(nodes):
+            node.setPosition([0, (0 - nr)])
+
+        self[:] = nodes
+
+        return pipeline.containerise(
+            node_name,
+            namespace,
+            nodes,
+            context,
+            self.__class__.__name__,
+            suffix="",
+        )
+
+    def update(self, container, context):
+
+        node = container["node"]
+        try:
+            usdimport_node = next(
+                n for n in node.children() if n.type().name() == "usdimport"
+            )
+        except StopIteration:
+            self.log.error("Could not find node of type `usdimport`")
+            return
+
+        # Update the file path
+        file_path = self.filepath_from_context(context)
+        file_path = file_path.replace("\\", "/")
+
+        usdimport_node.setParms({"filepath1": file_path})
+
+        # Update attribute
+        node.setParms({"representation": context["representation"]["id"]})
+
+    def remove(self, container):
+
+        node = container["node"]
+        node.destroy()
+
+    def switch(self, container, representation):
+        self.update(container, representation)

--- a/client/ayon_core/hosts/houdini/plugins/load/load_usd_sop.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_usd_sop.py
@@ -32,24 +32,12 @@ class SopUsdImportLoader(load.LoaderPlugin):
         # Create a new geo node
         container = obj.createNode("geo", node_name=node_name)
 
-        # Remove the file node, it only loads static meshes
-        # Houdini 17 has removed the file node from the geo node
-        file_node = container.node("file1")
-        if file_node:
-            file_node.destroy()
-
         # Create a usdimport node
         usdimport = container.createNode("usdimport", node_name=node_name)
         usdimport.setParms({"filepath1": file_path})
 
-        # Ensure display flag is on the first input node and not on the OUT
-        # node to optimize "debug" displaying in the viewport.
-        usdimport.setDisplayFlag(True)
-
         # Set new position for unpack node else it gets cluttered
         nodes = [container, usdimport]
-        for nr, node in enumerate(nodes):
-            node.setPosition([0, (0 - nr)])
 
         self[:] = nodes
 


### PR DESCRIPTION
## Changelog Description

Implement a SOPs level `usdimport` loader.

## Additional info

This allows artists to directly load managed data into SOPs instead of having load a LOPs state first and then have a `lopimport` inside SOPs. Without that extra bunny-hopping the load logic here may be slightly faster for certain cases.

## Testing notes:

1. Load a USD file to SOPs
2. Manage versions should also work (update)
