### PR TITLE
Chore: Move workfile utils functions to workfile pipeline code

### DIFF
--- a/client/ayon_core/pipeline/workfile/__init__.py
+++ b/client/ayon_core/pipeline/workfile/__init__.py
@@ -13,6 +13,11 @@ from .path_resolving import (
     create_workdir_extra_folders,
 )
 
+from .utils import (
+    should_use_last_workfile_on_launch,
+    should_open_workfiles_tool_on_launch,
+)
+
 from .build_workfile import BuildWorkfile
 
 
@@ -29,6 +34,9 @@ __all__ = (
     "get_custom_workfile_template_by_string_context",
 
     "create_workdir_extra_folders",
+
+    "should_use_last_workfile_on_launch",
+    "should_open_workfiles_tool_on_launch",
 
     "BuildWorkfile",
 )

--- a/client/ayon_core/pipeline/workfile/utils.py
+++ b/client/ayon_core/pipeline/workfile/utils.py
@@ -1,0 +1,121 @@
+from ayon_core.lib import filter_profiles
+from ayon_core.settings import get_project_settings
+
+
+def should_use_last_workfile_on_launch(
+    project_name,
+    host_name,
+    task_name,
+    task_type,
+    default_output=False,
+    project_settings=None,
+):
+    """Define if host should start last version workfile if possible.
+
+    Default output is `False`. Can be overridden with environment variable
+    `AYON_OPEN_LAST_WORKFILE`, valid values without case sensitivity are
+    `"0", "1", "true", "false", "yes", "no"`.
+
+    Args:
+        project_name (str): Name of project.
+        host_name (str): Name of host which is launched. In avalon's
+            application context it's value stored in app definition under
+            key `"application_dir"`. Is not case sensitive.
+        task_name (str): Name of task which is used for launching the host.
+            Task name is not case sensitive.
+        task_type (str): Task type.
+        default_output (Optional[bool]): Default output value if no profile
+            is found.
+        project_settings (Optional[dict[str, Any]]): Project settings.
+
+    Returns:
+        bool: True if host should start workfile.
+
+    """
+    if project_settings is None:
+        project_settings = get_project_settings(project_name)
+    profiles = (
+        project_settings
+        ["core"]
+        ["tools"]
+        ["Workfiles"]
+        ["last_workfile_on_startup"]
+    )
+
+    if not profiles:
+        return default_output
+
+    filter_data = {
+        "tasks": task_name,
+        "task_types": task_type,
+        "hosts": host_name
+    }
+    matching_item = filter_profiles(profiles, filter_data)
+
+    output = None
+    if matching_item:
+        output = matching_item.get("enabled")
+
+    if output is None:
+        return default_output
+    return output
+
+
+def should_open_workfiles_tool_on_launch(
+    project_name,
+    host_name,
+    task_name,
+    task_type,
+    default_output=False,
+    project_settings=None,
+):
+    """Define if host should start workfile tool at host launch.
+
+    Default output is `False`. Can be overridden with environment variable
+    `AYON_WORKFILE_TOOL_ON_START`, valid values without case sensitivity are
+    `"0", "1", "true", "false", "yes", "no"`.
+
+    Args:
+        project_name (str): Name of project.
+        host_name (str): Name of host which is launched. In avalon's
+            application context it's value stored in app definition under
+            key `"application_dir"`. Is not case sensitive.
+        task_name (str): Name of task which is used for launching the host.
+            Task name is not case sensitive.
+        task_type (str): Task type.
+        default_output (Optional[bool]): Default output value if no profile
+            is found.
+        project_settings (Optional[dict[str, Any]]): Project settings.
+
+    Returns:
+        bool: True if host should start workfile.
+
+    """
+
+    if project_settings is None:
+        project_settings = get_project_settings(project_name)
+    profiles = (
+        project_settings
+        ["core"]
+        ["tools"]
+        ["Workfiles"]
+        ["open_workfile_tool_on_startup"]
+    )
+
+    if not profiles:
+        return default_output
+
+    filter_data = {
+        "tasks": task_name,
+        "task_types": task_type,
+        "hosts": host_name
+    }
+    matching_item = filter_profiles(profiles, filter_data)
+
+    output = None
+    if matching_item:
+        output = matching_item.get("enabled")
+
+    if output is None:
+        return default_output
+    return output

--- a/client/ayon_core/tools/launcher/models/actions.py
+++ b/client/ayon_core/tools/launcher/models/actions.py
@@ -6,6 +6,7 @@ from ayon_core.pipeline.actions import (
     discover_launcher_actions,
     LauncherAction,
 )
+from ayon_core.pipeline.workfile import should_use_last_workfile_on_launch
 
 
 # class Action:
@@ -301,8 +302,6 @@ class ActionsModel:
         host_name,
         not_open_workfile_actions
     ):
-        from ayon_core.lib.applications import should_start_last_workfile
-
         if identifier in not_open_workfile_actions:
             return not not_open_workfile_actions[identifier]
 
@@ -315,7 +314,7 @@ class ActionsModel:
             task_name = task_entity["name"]
             task_type = task_entity["taskType"]
 
-        output = should_start_last_workfile(
+        output = should_use_last_workfile_on_launch(
             project_name,
             host_name,
             task_name,


### PR DESCRIPTION
## Changelog Description
Moved `should_start_last_workfile` and `should_workfile_tool_start` from applications logic to workfile pipeline code.

## Additional info
Both functions are pipeline related, are using core settings and should be available from anywhere. Because applications logic will be separate into addon this is the ideal change.

## Testing notes:
1. Last workfiles should be opened correctly.
2. Showing of workfiles tool on startup should work too (not sure for which host integrations it really works?).
