### PR TITLE
Maya: Validate Look Shading Group syntax error

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/validate_look_shading_group.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_look_shading_group.py
@@ -16,7 +16,7 @@ class ValidateShadingEngine(pyblish.api.InstancePlugin,
 
     Shading engines should be named "{surface_shader}SG"
     """
-``
+
     order = ValidateContentsOrder
     families = ["look"]
     hosts = ["maya"]


### PR DESCRIPTION
## Changelog Description

Fix Validate Look Shading Group syntax error.

## Additional info

n/a

## Testing notes:

1. Plugin should not be listed as crashed plug-in
2. Plugin should work.
