### PR TITLE
Maya: Fix Validate Node No Ghosting

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/validate_node_no_ghosting.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_node_no_ghosting.py
@@ -6,9 +6,10 @@ import ayon_core.hosts.maya.api.action
 from ayon_core.pipeline.publish import (
     ValidateContentsOrder,
     OptionalPyblishPluginMixin
-
 )
-class ValidateNodeNoGhosting(pyblish.api.InstancePlugin.
+
+
+class ValidateNodeNoGhosting(pyblish.api.InstancePlugin,
                              OptionalPyblishPluginMixin):
     """Ensure nodes do not have ghosting enabled.
 


### PR DESCRIPTION
## Changelog Description

Fix validator for no enabled 'ghosting' on models.

## Additional info

Fixes:
```python
Traceback:
Traceback (most recent call last):
File "E:\dev\ayon-core\client\ayon_core\pipeline\publish\lib.py", line 257, in publish_plugins_discover
module = import_filepath(abspath, mod_name)
File "E:\dev\ayon-core\client\ayon_core\lib\python_module_tools.py", line 38, in import_filepath
module_loader.exec_module(module)
File "", line 883, in exec_module
File "", line 241, in _call_with_frames_removed
File "E:\dev\ayon-core\client\ayon_core\hosts\maya\plugins\publish\validate_node_no_ghosting.py", line 12, in 
OptionalPyblishPluginMixin):
AttributeError: type object 'InstancePlugin' has no attribute 'OptionalPyblishPluginMixin'
```

## Testing notes:

1. Validator should not be listed under crashed plug-ins.
2. Validate should correctly invalidate ghosting on models.