### PR TITLE
Maya: Add setting to disable `cbId` workflow

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/validate_animation_out_set_related_node_ids.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_animation_out_set_related_node_ids.py
@@ -32,6 +32,13 @@ class ValidateOutRelatedNodeIds(pyblish.api.InstancePlugin,
     ]
     optional = False
 
+    @classmethod
+    def apply_settings(cls, project_settings):
+        # Disable plug-in if cbId workflow is disabled
+        if not project_settings["maya"].get("use_cbid_workflow", True):
+            cls.enabled = False
+            return
+
     def process(self, instance):
         """Process all meshes"""
         if not self.is_active(instance.data):

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_animation_out_set_related_node_ids.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_animation_out_set_related_node_ids.py
@@ -7,7 +7,9 @@ from ayon_core.pipeline.publish import (
     RepairAction,
     ValidateContentsOrder,
     PublishValidationError,
-    OptionalPyblishPluginMixin
+    OptionalPyblishPluginMixin,
+    get_plugin_settings,
+    apply_plugin_settings_automatically
 )
 
 
@@ -38,6 +40,13 @@ class ValidateOutRelatedNodeIds(pyblish.api.InstancePlugin,
         if not project_settings["maya"].get("use_cbid_workflow", True):
             cls.enabled = False
             return
+
+        # Preserve automatic settings applying logic
+        settings = get_plugin_settings(plugin=cls,
+                                       project_settings=project_settings,
+                                       log=cls.log,
+                                       category="maya")
+        apply_plugin_settings_automatically(cls, settings, logger=cls.log)
 
     def process(self, instance):
         """Process all meshes"""

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_animation_out_set_related_node_ids.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_animation_out_set_related_node_ids.py
@@ -36,17 +36,17 @@ class ValidateOutRelatedNodeIds(pyblish.api.InstancePlugin,
 
     @classmethod
     def apply_settings(cls, project_settings):
-        # Disable plug-in if cbId workflow is disabled
-        if not project_settings["maya"].get("use_cbid_workflow", True):
-            cls.enabled = False
-            return
-
         # Preserve automatic settings applying logic
         settings = get_plugin_settings(plugin=cls,
                                        project_settings=project_settings,
                                        log=cls.log,
                                        category="maya")
         apply_plugin_settings_automatically(cls, settings, logger=cls.log)
+
+        # Disable plug-in if cbId workflow is disabled
+        if not project_settings["maya"].get("use_cbid_workflow", True):
+            cls.enabled = False
+            return
 
     def process(self, instance):
         """Process all meshes"""

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_arnold_scene_source_cbid.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_arnold_scene_source_cbid.py
@@ -22,6 +22,13 @@ class ValidateArnoldSceneSourceCbid(pyblish.api.InstancePlugin,
     actions = [RepairAction]
     optional = False
 
+    @classmethod
+    def apply_settings(cls, project_settings):
+        # Disable plug-in if cbId workflow is disabled
+        if not project_settings["maya"].get("use_cbid_workflow", True):
+            cls.enabled = False
+            return
+
     @staticmethod
     def _get_nodes_by_name(nodes):
         nodes_by_name = {}

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_look_id_reference_edits.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_look_id_reference_edits.py
@@ -27,6 +27,13 @@ class ValidateLookIdReferenceEdits(pyblish.api.InstancePlugin):
     actions = [ayon_core.hosts.maya.api.action.SelectInvalidAction,
                RepairAction]
 
+    @classmethod
+    def apply_settings(cls, project_settings):
+        # Disable plug-in if cbId workflow is disabled
+        if not project_settings["maya"].get("use_cbid_workflow", True):
+            cls.enabled = False
+            return
+
     def process(self, instance):
         invalid = self.get_invalid(instance)
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids.py
@@ -31,6 +31,13 @@ class ValidateNodeIDs(pyblish.api.InstancePlugin):
     actions = [ayon_core.hosts.maya.api.action.SelectInvalidAction,
                ayon_core.hosts.maya.api.action.GenerateUUIDsOnInvalidAction]
 
+    @classmethod
+    def apply_settings(cls, project_settings):
+        # Disable plug-in if cbId workflow is disabled
+        if not project_settings["maya"].get("use_cbid_workflow", True):
+            cls.enabled = False
+            return
+
     def process(self, instance):
         """Process all meshes"""
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_deformed_shapes.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_deformed_shapes.py
@@ -26,6 +26,13 @@ class ValidateNodeIdsDeformedShape(pyblish.api.InstancePlugin):
         RepairAction
     ]
 
+    @classmethod
+    def apply_settings(cls, project_settings):
+        # Disable plug-in if cbId workflow is disabled
+        if not project_settings["maya"].get("use_cbid_workflow", True):
+            cls.enabled = False
+            return
+
     def process(self, instance):
         """Process all the nodes in the instance"""
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_in_database.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_in_database.py
@@ -26,6 +26,13 @@ class ValidateNodeIdsInDatabase(pyblish.api.InstancePlugin):
     actions = [ayon_core.hosts.maya.api.action.SelectInvalidAction,
                ayon_core.hosts.maya.api.action.GenerateUUIDsOnInvalidAction]
 
+    @classmethod
+    def apply_settings(cls, project_settings):
+        # Disable plug-in if cbId workflow is disabled
+        if not project_settings["maya"].get("use_cbid_workflow", True):
+            cls.enabled = False
+            return
+
     def process(self, instance):
         invalid = self.get_invalid(instance)
         if invalid:

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_related.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_related.py
@@ -24,6 +24,13 @@ class ValidateNodeIDsRelated(pyblish.api.InstancePlugin,
     actions = [ayon_core.hosts.maya.api.action.SelectInvalidAction,
                ayon_core.hosts.maya.api.action.GenerateUUIDsOnInvalidAction]
 
+    @classmethod
+    def apply_settings(cls, project_settings):
+        # Disable plug-in if cbId workflow is disabled
+        if not project_settings["maya"].get("use_cbid_workflow", True):
+            cls.enabled = False
+            return
+
     def process(self, instance):
         """Process all nodes in instance (including hierarchy)"""
         if not self.is_active(instance.data):

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_unique.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_unique.py
@@ -26,6 +26,13 @@ class ValidateNodeIdsUnique(pyblish.api.InstancePlugin):
     actions = [ayon_core.hosts.maya.api.action.SelectInvalidAction,
                ayon_core.hosts.maya.api.action.GenerateUUIDsOnInvalidAction]
 
+    @classmethod
+    def apply_settings(cls, project_settings):
+        # Disable plug-in if cbId workflow is disabled
+        if not project_settings["maya"].get("use_cbid_workflow", True):
+            cls.enabled = False
+            return
+
     def process(self, instance):
         """Process all meshes"""
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_rig_out_set_node_ids.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_rig_out_set_node_ids.py
@@ -38,17 +38,17 @@ class ValidateRigOutSetNodeIds(pyblish.api.InstancePlugin,
 
     @classmethod
     def apply_settings(cls, project_settings):
-        # Disable plug-in if cbId workflow is disabled
-        if not project_settings["maya"].get("use_cbid_workflow", True):
-            cls.enabled = False
-            return
-
         # Preserve automatic settings applying logic
         settings = get_plugin_settings(plugin=cls,
                                        project_settings=project_settings,
                                        log=cls.log,
                                        category="maya")
         apply_plugin_settings_automatically(cls, settings, logger=cls.log)
+
+        # Disable plug-in if cbId workflow is disabled
+        if not project_settings["maya"].get("use_cbid_workflow", True):
+            cls.enabled = False
+            return
 
     def process(self, instance):
         """Process all meshes"""

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_rig_out_set_node_ids.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_rig_out_set_node_ids.py
@@ -8,7 +8,9 @@ from ayon_core.pipeline.publish import (
     RepairAction,
     ValidateContentsOrder,
     PublishValidationError,
-    OptionalPyblishPluginMixin
+    OptionalPyblishPluginMixin,
+    get_plugin_settings,
+    apply_plugin_settings_automatically
 )
 
 
@@ -40,6 +42,13 @@ class ValidateRigOutSetNodeIds(pyblish.api.InstancePlugin,
         if not project_settings["maya"].get("use_cbid_workflow", True):
             cls.enabled = False
             return
+
+        # Preserve automatic settings applying logic
+        settings = get_plugin_settings(plugin=cls,
+                                       project_settings=project_settings,
+                                       log=cls.log,
+                                       category="maya")
+        apply_plugin_settings_automatically(cls, settings, logger=cls.log)
 
     def process(self, instance):
         """Process all meshes"""

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_rig_out_set_node_ids.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_rig_out_set_node_ids.py
@@ -34,6 +34,13 @@ class ValidateRigOutSetNodeIds(pyblish.api.InstancePlugin,
     allow_history_only = False
     optional = False
 
+    @classmethod
+    def apply_settings(cls, project_settings):
+        # Disable plug-in if cbId workflow is disabled
+        if not project_settings["maya"].get("use_cbid_workflow", True):
+            cls.enabled = False
+            return
+
     def process(self, instance):
         """Process all meshes"""
         if not self.is_active(instance.data):

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_rig_output_ids.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_rig_output_ids.py
@@ -32,6 +32,13 @@ class ValidateRigOutputIds(pyblish.api.InstancePlugin):
     actions = [RepairAction,
                ayon_core.hosts.maya.api.action.SelectInvalidAction]
 
+    @classmethod
+    def apply_settings(cls, project_settings):
+        # Disable plug-in if cbId workflow is disabled
+        if not project_settings["maya"].get("use_cbid_workflow", True):
+            cls.enabled = False
+            return
+
     def process(self, instance):
         invalid = self.get_invalid(instance, compute=True)
         if invalid:

--- a/server_addon/maya/server/settings/main.py
+++ b/server_addon/maya/server/settings/main.py
@@ -30,6 +30,15 @@ class ExtMappingItemModel(BaseSettingsModel):
 class MayaSettings(BaseSettingsModel):
     """Maya Project Settings."""
 
+    use_cbid_workflow: bool = SettingsField(
+        True, title="Use cbId workflow",
+        description=(
+            "When enabled, a per node `cbId` identifier will be created and "
+            "validated for many product types. This is then used for look "
+            "publishing and many others. By disabling this, the `cbId` "
+            "attribute will still be created on scene save but it will not "
+            "be validated."))
+
     open_workfile_post_initialization: bool = SettingsField(
         True, title="Open Workfile Post Initialization")
     explicit_plugins_loading: ExplicitPluginsLoadingModel = SettingsField(
@@ -88,6 +97,7 @@ DEFAULT_MEL_WORKSPACE_SETTINGS = "\n".join((
 ))
 
 DEFAULT_MAYA_SETTING = {
+    "use_cbid_workflow": True,
     "open_workfile_post_initialization": True,
     "explicit_plugins_loading": DEFAULT_EXPLITCIT_PLUGINS_LOADING_SETTINGS,
     "imageio": DEFAULT_IMAGEIO_SETTINGS,

--- a/server_addon/maya/server/version.py
+++ b/server_addon/maya/server/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring addon version."""
-__version__ = "0.1.10"
+__version__ = "0.1.11"


### PR DESCRIPTION
## Changelog Description

Add a single setting to disable the `cbId` workflow **validations** in Maya.

## Additional info

This is an equivalent to [this commit](https://github.com/BigRoy/OpenPype/commit/9a543e9fffc1bb3ea58a22b95efaccfb2f6b8632) that we did to disable `cbId` validations in Maya in our USD project.

Implemented because you might want to disable `cbId` completely when moving to USD since it's layering can replace the full `cbId` workflow for looks, etc. Also relevant to this [Ynput discord discussion](https://discord.com/channels/517362899170230292/1219996539146076160/1220057378808922173) with Lucas Bruchhage at BCN Visuals.

This can benefit from a follow up PR that will, using the same toggle, disable the `cbId` creation on file save completely. However - removing that completely might be hard with certain other areas of the code relying on them existing, e.g. certain Arnold exports or Yeti cache workflows. It is entirely true that even with the validations disabled you can hardly rely on them in production - but it's a start to remove them. If you still need them, then you're better of keeping this setting enabled.

Let me know if you want me to remove the creation of the ids on scene save as well.

Note that this may be considered a **major change** since the `cbId` functionality was a key component of lots of logic in the Maya implementation. With e.g. `cbId` workflow disabled the `look` product type would have no real value anymore.

## Testing notes:

1. When the setting is disabled, publishing should never error on `cbId` related logic.
2. When the setting is enabled, all `cbId` validators should function as usually.