### PR TITLE
Traypublisher: collector of frame data skipping if video file

### DIFF
--- a/client/ayon_core/hosts/traypublisher/plugins/publish/collect_sequence_frame_data.py
+++ b/client/ayon_core/hosts/traypublisher/plugins/publish/collect_sequence_frame_data.py
@@ -43,7 +43,6 @@ class CollectSequenceFrameData(
             instance.data[key] = value
             self.log.debug(f"Collected Frame range data '{key}':{value} ")
 
-
     def get_frame_data_from_repre_sequence(self, instance):
         repres = instance.data.get("representations")
         folder_attributes = instance.data["folderEntity"]["attrib"]
@@ -56,6 +55,9 @@ class CollectSequenceFrameData(
                 return
 
             files = first_repre["files"]
+            if not isinstance(files, list):
+                files = [files]
+
             collections, _ = clique.assemble(files)
             if not collections:
                 # No sequences detected and we can't retrieve


### PR DESCRIPTION
## Changelog Description
Skipping video files for frame range collection. This should only work on sequence data. 

## Testing notes:
1. Open traypublisher in context of any testing folder and task
2. set Render product type
3. drop any mp4 file into representation and review representation
4. publish and in log notice that 'Collect Original Sequence Frame Data` plugin is  logging `No sequences detected in the representation data...`