### PR TITLE
Maya: Look assigner fix folder entity key

### DIFF
--- a/client/ayon_core/hosts/maya/tools/mayalookassigner/widgets.py
+++ b/client/ayon_core/hosts/maya/tools/mayalookassigner/widgets.py
@@ -125,8 +125,9 @@ class AssetOutliner(QtWidgets.QWidget):
         folder_items = {}
         namespaces_by_folder_path = defaultdict(set)
         for item in items:
-            folder_id = item["folder"]["id"]
-            folder_path = item["folder"]["path"]
+            folder_entity = item["folder_entity"]
+            folder_id = folder_entity["id"]
+            folder_path = folder_entity["path"]
             namespaces_by_folder_path[folder_path].add(item.get("namespace"))
 
             if folder_path in folder_items:


### PR DESCRIPTION
## Changelog Description
Use correct key to access folder entity in tool code.

## Testing notes:
1. Tool can be operational.
