### PR TITLE
Maya: Load plugins use correct source for product type

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/load/load_redshift_proxy.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_redshift_proxy.py
@@ -32,10 +32,7 @@ class RedshiftProxyLoader(load.LoaderPlugin):
 
     def load(self, context, name=None, namespace=None, options=None):
         """Plugin entry point."""
-        try:
-            product_type = context["representation"]["context"]["family"]
-        except ValueError:
-            product_type = "redshiftproxy"
+        product_type = context["product"]["productType"]
 
         folder_name = context["folder"]["name"]
         namespace = namespace or unique_namespace(

--- a/client/ayon_core/hosts/maya/plugins/load/load_reference.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_reference.py
@@ -117,11 +117,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
     def process_reference(self, context, name, namespace, options):
         import maya.cmds as cmds
 
-        try:
-            product_type = context["representation"]["context"]["family"]
-        except ValueError:
-            product_type = "model"
-
+        product_type = context["product"]["productType"]
         project_name = context["project"]["name"]
         # True by default to keep legacy behaviours
         attach_to_root = options.get("attach_to_root", True)

--- a/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_arnold.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_arnold.py
@@ -25,10 +25,7 @@ class LoadVDBtoArnold(load.LoaderPlugin):
         from ayon_core.hosts.maya.api.pipeline import containerise
         from ayon_core.hosts.maya.api.lib import unique_namespace
 
-        try:
-            product_type = context["representation"]["context"]["family"]
-        except ValueError:
-            product_type = "vdbcache"
+        product_type = context["product"]["productType"]
 
         # Check if the plugin for arnold is available on the pc
         try:

--- a/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_redshift.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_redshift.py
@@ -31,10 +31,7 @@ class LoadVDBtoRedShift(load.LoaderPlugin):
         from ayon_core.hosts.maya.api.pipeline import containerise
         from ayon_core.hosts.maya.api.lib import unique_namespace
 
-        try:
-            product_type = context["representation"]["context"]["family"]
-        except ValueError:
-            product_type = "vdbcache"
+        product_type = context["product"]["productType"]
 
         # Check if the plugin for redshift is available on the pc
         try:

--- a/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_vray.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_vray.py
@@ -94,10 +94,7 @@ class LoadVDBtoVRay(load.LoaderPlugin):
             "Path does not exist: %s" % path
         )
 
-        try:
-            product_type = context["representation"]["context"]["family"]
-        except ValueError:
-            product_type = "vdbcache"
+        product_type = context["product"]["productType"]
 
         # Ensure V-ray is loaded with the vrayvolumegrid
         if not cmds.pluginInfo("vrayformaya", query=True, loaded=True):

--- a/client/ayon_core/hosts/maya/plugins/load/load_vrayproxy.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_vrayproxy.py
@@ -47,10 +47,7 @@ class VRayProxyLoader(load.LoaderPlugin):
 
         """
 
-        try:
-            product_type = context["representation"]["context"]["family"]
-        except ValueError:
-            product_type = "vrayproxy"
+        product_type = context["product"]["productType"]
 
         #  get all representations for this version
         filename = self._get_abc(

--- a/client/ayon_core/hosts/maya/plugins/load/load_vrayscene.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_vrayscene.py
@@ -26,10 +26,7 @@ class VRaySceneLoader(load.LoaderPlugin):
     color = "orange"
 
     def load(self, context, name, namespace, data):
-        try:
-            product_type = context["representation"]["context"]["family"]
-        except ValueError:
-            product_type = "vrayscene_layer"
+        product_type = context["product"]["productType"]
 
         folder_name = context["folder"]["name"]
         namespace = namespace or unique_namespace(

--- a/client/ayon_core/hosts/maya/plugins/load/load_yeti_cache.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_yeti_cache.py
@@ -56,10 +56,7 @@ class YetiCacheLoader(load.LoaderPlugin):
 
         """
 
-        try:
-            product_type = context["representation"]["context"]["family"]
-        except ValueError:
-            product_type = "yeticache"
+        product_type = context["product"]["productType"]
 
         # Build namespace
         folder_name = context["folder"]["name"]

--- a/client/ayon_core/hosts/unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_alembic_animation.py
@@ -72,7 +72,7 @@ class AnimationAlembicLoader(plugin.Loader):
         root = unreal_pipeline.AYON_ASSET_DIR
         folder_name = context["folder"]["name"]
         folder_path = context["folder"]["path"]
-        product_type = context["representation"]["context"]["family"]
+        product_type = context["product"]["productType"]
         suffix = "_CON"
         if folder_name:
             asset_name = "{}_{}".format(folder_name, name)

--- a/client/ayon_core/hosts/unreal/plugins/load/load_layout.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_layout.py
@@ -659,7 +659,7 @@ class LayoutLoader(plugin.Loader):
             "loader": str(self.__class__.__name__),
             "representation": context["representation"]["id"],
             "parent": context["representation"]["versionId"],
-            "family": context["representation"]["context"]["family"],
+            "family": context["product"]["productType"],
             "loaded_assets": loaded_assets
         }
         imprint(

--- a/client/ayon_core/hosts/unreal/plugins/load/load_layout_existing.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_layout_existing.py
@@ -393,7 +393,7 @@ class ExistingLayoutLoader(plugin.Loader):
 
         folder_name = context["folder"]["name"]
         folder_path = context["folder"]["path"]
-        product_type = context["representation"]["context"]["family"]
+        product_type = context["product"]["productType"]
         asset_name = f"{folder_name}_{name}" if folder_name else name
         container_name = f"{folder_name}_{name}_CON"
 


### PR DESCRIPTION
## Changelog Description
Load plugins are looking for product type on product entity instead of context data.

## Additional info
Key `"family"` may not available on representation context as we've changed it to product type.

## Testing notes:
1. Load plugins can be used on newest published instances from current develop.

EDITED:
The same fix was also done for Unreal plugins.