### PR TITLE
Fusion: Support nested usage of the `comp_lock_and_undo_chunk` context manager

### DIFF
--- a/client/ayon_core/hosts/fusion/api/lib.py
+++ b/client/ayon_core/hosts/fusion/api/lib.py
@@ -278,6 +278,13 @@ def comp_lock_and_undo_chunk(
     keep_undo=True,
 ):
     """Lock comp and open an undo chunk during the context"""
+
+    # If comp is already locked do nothing and consider us to
+    # be inside another undo chunk currently. This allows nesting the chunks.
+    if comp.IsLocked():
+        yield
+        return
+
     try:
         comp.Lock()
         comp.StartUndo(undo_queue_name)


### PR DESCRIPTION
## Changelog Description

Support nested usage of the `comp_lock_and_undo_chunk` context manager

## Additional info

As far as I know there's no current pressing issue that should be 'tested' against whether it's resolved. Consider this more of a 'safe improvement' to allow nesting the comp locking.

## Testing notes:

1. Publishing should work as usual.
2. Nothing special to test really.
