### PR TITLE
Maya: Validate Animation Out Set Related Node Ids improve report

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/help/validate_animation_out_set_related_node_ids.xml
+++ b/client/ayon_core/hosts/maya/plugins/publish/help/validate_animation_out_set_related_node_ids.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Shape IDs mismatch original shape</title>
+<description>## Shapes mismatch IDs with original shape
+
+Meshes are detected where the (deformed) mesh has a different `cbId` than
+the same mesh in its deformation history.
+Theses should normally be the same.
+
+### How to repair?
+
+By using the repair action the IDs from the shape in history will be
+copied to the deformed shape. For **animation** instances using the
+repair action usually is usually the correct fix.
+
+</description>
+<detail>
+### How does this happen?
+
+When a deformer is applied in the scene on a referenced mesh that had no
+deformers then Maya will create a new shape node for the mesh that
+does not have the original id. Then on scene save new ids get created for the
+meshes lacking a `cbId` and thus the mesh then has a different `cbId` than
+the mesh in the deformation history.
+
+</detail>
+</error>
+</root>


### PR DESCRIPTION
## Changelog Description

Validate Animation Out Set Related Node Ids improve validation report message.

Note that it does have some additional changes:

- Ignore nodes without ids - that is validated elsewhere
- Only check specific types instead of excluding only locators (so that e.g. also constraints or deformers are excluded in the check)
- Improve report message

## Additional info

n/a

## Testing notes:

1. Loaded rigs (referenced) with additional deformers applied should work to publish animation for.
2. Validator should work and be clear in messaging.
