### PR TITLE
Maya: Validate Shape Render Stats improve error message

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/validate_shape_render_stats.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_shape_render_stats.py
@@ -6,6 +6,7 @@ import ayon_core.hosts.maya.api.action
 from ayon_core.pipeline.publish import (
     RepairAction,
     ValidateMeshOrder,
+    PublishValidationError,
     OptionalPyblishPluginMixin
 )
 
@@ -20,7 +21,6 @@ class ValidateShapeRenderStats(pyblish.api.Validator,
     label = 'Shape Default Render Stats'
     actions = [ayon_core.hosts.maya.api.action.SelectInvalidAction,
                RepairAction]
-    optional = True
 
     defaults = {'castsShadows': 1,
                 'receiveShadows': 1,
@@ -37,14 +37,13 @@ class ValidateShapeRenderStats(pyblish.api.Validator,
         # It seems the "surfaceShape" and those derived from it have
         # `renderStat` attributes.
         shapes = cmds.ls(instance, long=True, type='surfaceShape')
-        invalid = []
+        invalid = set()
         for shape in shapes:
-            _iteritems = getattr(cls.defaults, "iteritems", cls.defaults.items)
-            for attr, default_value in _iteritems():
+            for attr, default_value in cls.defaults.items():
                 if cmds.attributeQuery(attr, node=shape, exists=True):
                     value = cmds.getAttr('{}.{}'.format(shape, attr))
                     if value != default_value:
-                        invalid.append(shape)
+                        invalid.add(shape)
 
         return invalid
 
@@ -52,17 +51,36 @@ class ValidateShapeRenderStats(pyblish.api.Validator,
         if not self.is_active(instance.data):
             return
         invalid = self.get_invalid(instance)
+        if not invalid:
+            return
 
-        if invalid:
-            raise ValueError("Shapes with non-default renderStats "
-                             "found: {0}".format(invalid))
+        defaults_str = "\n".join(
+            "- {}: {}\n".format(key, value)
+            for key, value in self.defaults.items()
+        )
+        description = (
+            "## Shape Default Render Stats\n"
+            "Shapes are detected with non-default render stats.\n\n"
+            "To ensure a model's shapes behave like a shape would by default "
+            "we require the render stats to have not been altered in "
+            "the published models.\n\n"
+            "### How to repair?\n"
+            "You can reset the default values on the shapes by using the "
+            "repair action."
+        )
+
+        raise PublishValidationError(
+            "Shapes with non-default renderStats "
+            "found: {0}".format(", ".join(sorted(invalid))),
+            description=description,
+            detail="The expected default values "
+                   "are:\n\n{}".format(defaults_str)
+        )
 
     @classmethod
     def repair(cls, instance):
         for shape in cls.get_invalid(instance):
-            _iteritems = getattr(cls.defaults, "iteritems", cls.defaults.items)
-            for attr, default_value in _iteritems():
-
+            for attr, default_value in cls.defaults.items():
                 if cmds.attributeQuery(attr, node=shape, exists=True):
                     plug = '{0}.{1}'.format(shape, attr)
                     value = cmds.getAttr(plug)


### PR DESCRIPTION
## Changelog Description

Improve validation message for Maya's Validate Shape Render Stats

## Additional info

Now raises `PublishValidationError`
Also removes Py2 fallback logic with `iteritems`.

![image](https://github.com/ynput/ayon-core/assets/2439881/c330d2bb-672f-416e-9e76-d4dad6bbd35b)

## Testing notes:

Validator is disabled by default, enable `ayon+settings://maya/publish/ValidateShapeRenderStats`

1. Publish model with non-default render stats
2. See validation report - should be much improved.
