### PR TITLE
Maya: Tweak validate transform zero formatting

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/validate_transform_zero.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_transform_zero.py
@@ -1,5 +1,6 @@
-from maya import cmds
+import inspect
 
+from maya import cmds
 import pyblish.api
 
 import ayon_core.hosts.maya.api.action
@@ -57,7 +58,7 @@ class ValidateTransformZero(pyblish.api.Validator,
             if ('_LOC' in transform) or ('_loc' in transform):
                 continue
             mat = cmds.xform(transform, q=1, matrix=True, objectSpace=True)
-            if not all(abs(x-y) < cls._tolerance
+            if not all(abs(x - y) < cls._tolerance
                        for x, y in zip(cls._identity, mat)):
                 invalid.append(transform)
 
@@ -69,13 +70,24 @@ class ValidateTransformZero(pyblish.api.Validator,
             return
         invalid = self.get_invalid(instance)
         if invalid:
-            names = "\n".join(
-                "- {}".format(node) for node in invalid
+            names = "<br>".join(
+                " - {}".format(node) for node in invalid
             )
 
             raise PublishValidationError(
                 title="Transform Zero",
-                message="The model publish allows no transformations. "
-                        "You must **freeze transformations** to continue.\n\n"
-                        "Nodes found with transform values:\n"
+                description=self.get_description(),
+                message="The model publish allows no transformations. You must"
+                        " <b>freeze transformations</b> to continue.<br><br>"
+                        "Nodes found with transform values:<br>"
                         "{0}".format(names))
+
+    @staticmethod
+    def get_description():
+        return inspect.cleandoc("""### Transform can't have any values
+
+        The model publish allows no transformations. 
+
+        You must **freeze transformations** to continue.
+
+        """)

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_transform_zero.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_transform_zero.py
@@ -69,14 +69,13 @@ class ValidateTransformZero(pyblish.api.Validator,
             return
         invalid = self.get_invalid(instance)
         if invalid:
-
-            names = "<br>".join(
-                " - {}".format(node) for node in invalid
+            names = "\n".join(
+                "- {}".format(node) for node in invalid
             )
 
             raise PublishValidationError(
                 title="Transform Zero",
-                message="The model publish allows no transformations. You must"
-                        " <b>freeze transformations</b> to continue.<br><br>"
-                        "Nodes found with transform values: "
+                message="The model publish allows no transformations. "
+                        "You must **freeze transformations** to continue.\n\n"
+                        "Nodes found with transform values:\n"
                         "{0}".format(names))


### PR DESCRIPTION
## Changelog Description

Tweak validate transform zero artist report formatting.

- Add line break before first object name
- Add static description instead of listing objects right-hand side.

## Additional info

![image](https://github.com/ynput/ayon-core/assets/2439881/7e3e318a-881f-4c85-bc93-a9f6995256e4)

## Testing notes:

1. Enable `ValidateTransformZero` plugin in settings
2. Publish model with transforms
2. Validation should be clear.
