### PR TITLE
Fix initial state for `CachedData.remapping`

### DIFF
--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -23,7 +23,7 @@ log = Logger.get_logger(__name__)
 
 
 class CachedData:
-    remapping = None
+    remapping = {}
     has_compatible_ocio_package = None
     config_version_data = {}
     ocio_config_colorspaces = {}


### PR DESCRIPTION
## Changelog Description

Fix colorspace `get_remapped_colorspace_to_native` and `get_remapped_colorspace_from_native`

## Additional info

n/a

## Testing notes:

1. Use API methods of `get_remapped_colorspace_to_native` and `get_remapped_colorspace_from_native` in any way.