### PR TITLE
Fix: Report the duplicated creator class

### DIFF
--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -1790,10 +1790,10 @@ class CreateContext:
 
             creator_identifier = creator_class.identifier
             if creator_identifier in creators:
-                self.log.warning((
-                    "Duplicated Creator identifier. "
-                    "Using first and skipping following"
-                ))
+                self.log.warning(
+                    "Duplicated Creator identifier. Using first and "
+                    "skipping following: {}".format(str(creator_class))
+                )
                 continue
 
             # Filter by host name


### PR DESCRIPTION
## Changelog Description

Fix warning message: Actually report the duplicated creator class.

## Additional info

Before it wouldn't actually list the duplicated class.

## Testing notes:

1. Register two creators with same identifier.
2. The log should show the conflicting classes.