### PR TITLE
Remove deprecated `AVALON_ACTIONS`

### DIFF
--- a/client/ayon_core/modules/launcher_action.py
+++ b/client/ayon_core/modules/launcher_action.py
@@ -37,20 +37,6 @@ class LauncherAction(AYONAddon, ITrayAction):
             if path and os.path.exists(path):
                 register_launcher_action_path(path)
 
-        paths_str = os.environ.get("AVALON_ACTIONS") or ""
-        if paths_str:
-            self.log.warning(
-                "WARNING: 'AVALON_ACTIONS' is deprecated. Support of this"
-                " environment variable will be removed in future versions."
-                " Please consider using 'OpenPypeModule' to define custom"
-                " action paths. Planned version to drop the support"
-                " is 3.17.2 or 3.18.0 ."
-            )
-
-        for path in paths_str.split(os.pathsep):
-            if path and os.path.exists(path):
-                register_launcher_action_path(path)
-
     def on_action_trigger(self):
         """Implementation for ITrayAction interface.
 


### PR DESCRIPTION
## Changelog Description

Remove backwards compatibility for `AVALON_ACTIONS` 

## Additional info

n/a

## Testing notes:

1. Launcher + launcher actions should work as usual
