### PR TITLE
Maya: Remove apply settings logic for Create unreal product types

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/create/create_unreal_skeletalmesh.py
+++ b/client/ayon_core/hosts/maya/plugins/create/create_unreal_skeletalmesh.py
@@ -20,13 +20,6 @@ class CreateUnrealSkeletalMesh(plugin.MayaCreator):
     # Defined in settings
     joint_hints = set()
 
-    def apply_settings(self, project_settings):
-        """Apply project settings to creator"""
-        settings = (
-            project_settings["maya"]["create"]["CreateUnrealSkeletalMesh"]
-        )
-        self.joint_hints = set(settings.get("joint_hints", []))
-
     def get_dynamic_data(
         self,
         project_name,

--- a/client/ayon_core/hosts/maya/plugins/create/create_unreal_staticmesh.py
+++ b/client/ayon_core/hosts/maya/plugins/create/create_unreal_staticmesh.py
@@ -15,11 +15,6 @@ class CreateUnrealStaticMesh(plugin.MayaCreator):
     # Defined in settings
     collision_prefixes = []
 
-    def apply_settings(self, project_settings):
-        """Apply project settings to creator"""
-        settings = project_settings["maya"]["create"]["CreateUnrealStaticMesh"]
-        self.collision_prefixes = settings["collision_prefixes"]
-
     def get_dynamic_data(
         self,
         project_name,


### PR DESCRIPTION
## Changelog Description

Remove apply settings logic for Create unreal product types.
No need to define `apply_settings` since it gets auto-applied. 

## Additional info

n/a

## Testing notes:

1. Settings for Create Unreal Skeletal Mesh and Create Unreal Static Mesh should still work
