### PR TITLE
Maya: Make Create Unreal Yeti Cache creator class name unique `

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/create/create_unreal_yeticache.py
+++ b/client/ayon_core/hosts/maya/plugins/create/create_unreal_yeticache.py
@@ -5,7 +5,7 @@ from ayon_core.hosts.maya.api import (
 from ayon_core.lib import NumberDef
 
 
-class CreateYetiCache(plugin.MayaCreator):
+class CreateUnrealYetiCache(plugin.MayaCreator):
     """Output for procedural plugin nodes of Yeti """
 
     identifier = "io.openpype.creators.maya.unrealyeticache"


### PR DESCRIPTION
## Changelog Description

Make Creator class name compared to existing `CreateYetiCache` in `create_yeti_cache.py`

## Additional info

n/a

## Testing notes:

1. Publishing for Create Yeti Cache and Create Unreal Yeti Cache should both work.
2. Legacy instances for Unreal Yeti Cache should continue to work.