### PR TITLE
TVPaint: Fix george script in auto create plugin

### DIFF
--- a/client/ayon_core/hosts/tvpaint/plugins/create/create_render.py
+++ b/client/ayon_core/hosts/tvpaint/plugins/create/create_render.py
@@ -760,7 +760,9 @@ class TVPaintAutoDetectRenderCreator(TVPaintCreator):
         grg_lines: list[str] = []
         for group_id, group_name in new_group_name_by_id.items():
             group: dict[str, Any] = groups_by_id[group_id]
-            grg_line: str = "tv_layercolor \"setcolor\" {} {} {} {} {}".format(
+            grg_line: str = (
+                "tv_layercolor \"setcolor\" {} {} {} {} {} \"{}\""
+            ).format(
                 group["clip_id"],
                 group_id,
                 group["red"],


### PR DESCRIPTION
## Changelog Description
Semi-automated create plugin did not change group name when actually should which may lead to invalid render layer name.

## Testing notes:
1. Make sure you're using code from this PR.
2. Run create plugin that automatically detects render layers and passes in scene.
3. Color groups in TVPaint should be renamed to correct group name.

NOTE: Based on PR https://github.com/ynput/ayon-core/pull/196 .