### PR TITLE
Chore: Tag 'reformatted' typo fix

### DIFF
--- a/client/ayon_core/hosts/nuke/api/plugin.py
+++ b/client/ayon_core/hosts/nuke/api/plugin.py
@@ -911,7 +911,7 @@ class ExporterReviewMov(ExporterReview):
                     node, product_name, "Reposition node...   `{}`"
                 )
             # append reformatted tag
-            add_tags.append("reformated")
+            add_tags.append("reformatted")
 
         # only create colorspace baking if toggled on
         if bake_viewer_process:

--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -1225,7 +1225,11 @@ class ExtractReview(pyblish.api.InstancePlugin):
         filters = []
 
         # if reformat input video file is already reforamted from upstream
-        reformat_in_baking = bool("reformated" in new_repre["tags"])
+        reformat_in_baking = (
+            "reformatted" in new_repre["tags"]
+            # Backwards compatibility
+            or "reformated" in new_repre["tags"]
+        )
         self.log.debug("reformat_in_baking: `{}`".format(reformat_in_baking))
 
         # Get instance data


### PR DESCRIPTION
## Changelog Description
Use `reformatted` tag name instead of `reformated`.

## Additional info
The only place which is using the tag was modified to be backwards compatible. @jakubjezek001 do you think it is necessary? Do we know about other places using the tag?

NOTE: Based on PR https://github.com/ynput/ayon-core/pull/196 .
