### PR TITLE
Maya: Fix variable name in convertor plugin

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/create/convert_legacy.py
+++ b/client/ayon_core/hosts/maya/plugins/create/convert_legacy.py
@@ -83,7 +83,7 @@ class MayaLegacyConvertor(ProductConvertorPlugin,
                 ).format(product_type))
                 continue
 
-            creator_id = product_type_to_id[family]
+            creator_id = product_type_to_id[product_type]
             creator = self.create_context.creators[creator_id]
             data["creator_identifier"] = creator_id
 


### PR DESCRIPTION
## Changelog Description
Use correct variable `product_type` instead of `family` in maya legacy convertor plugin.
