### PR TITLE
Houdini: Fix removal of `get_id_required_nodes` and `generate_ids`

### DIFF
--- a/client/ayon_core/hosts/houdini/api/pipeline.py
+++ b/client/ayon_core/hosts/houdini/api/pipeline.py
@@ -307,10 +307,6 @@ def on_save():
     # update houdini vars
     lib.update_houdini_vars_context_dialog()
 
-    nodes = lib.get_id_required_nodes()
-    for node, new_id in lib.generate_ids(nodes):
-        lib.set_id(node, new_id, overwrite=False)
-
     # We are now starting the actual save directly
     global ABOUT_TO_SAVE
     ABOUT_TO_SAVE = False


### PR DESCRIPTION
## Changelog Description

Fix removal of `get_id_required_nodes` and `generate_ids`

## Additional info

Likely one of the many PRs today introduced a merge conflict that got resolved the wrong way.

Should originally have been removed by https://github.com/ynput/ayon-core/pull/263

## Testing notes:

1. Workfile save in Houdini should work without errors.