### PR TITLE
Maya: Validate Look Shading Group ignore if no material

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/validate_look_shading_group.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_look_shading_group.py
@@ -47,10 +47,18 @@ class ValidateShadingEngine(pyblish.api.InstancePlugin,
                 shape, destination=True, type="shadingEngine"
             ) or []
             for shading_engine in shading_engines:
-                name = (
-                    cmds.listConnections(shading_engine + ".surfaceShader")[0]
-                    + "SG"
+                materials = cmds.listConnections(
+                    shading_engine + ".surfaceShader",
+                    source=True, destination=False
                 )
+                if not materials:
+                    cls.log.warning(
+                        "Shading engine '{}' has no material connected to its "
+                        ".surfaceShader attribute.".format(shading_engine))
+                    continue
+
+                material = materials[0]  # there should only ever be one input
+                name = material + "SG"
                 if shading_engine != name:
                     invalid.append(shading_engine)
 


### PR DESCRIPTION
## Changelog Description

Do not error with confusing message if shadingEngine has no material for whatever reason.

## Additional info

We hit this in production once and took a few minutes to debug and find the issue. By having this warning it's much easier to find what might be causing the issue.

## Testing notes:

1. Prepare a look
2. For one material, break the connection between material and `shadingEngine.surfaceShader`
3. Publish look
4. Validator should detect it without crashing.
