### PR TITLE
Maya: Support SelectInvalidAction with pyblish ContextPlugin

### DIFF
--- a/client/ayon_core/hosts/maya/api/action.py
+++ b/client/ayon_core/hosts/maya/api/action.py
@@ -4,7 +4,10 @@ from __future__ import absolute_import
 import pyblish.api
 import ayon_api
 
-from ayon_core.pipeline.publish import get_errored_instances_from_context
+from ayon_core.pipeline.publish import (
+    get_errored_instances_from_context,
+    get_errored_plugins_from_context
+)
 
 
 class GenerateUUIDsOnInvalidAction(pyblish.api.Action):
@@ -112,20 +115,25 @@ class SelectInvalidAction(pyblish.api.Action):
         except ImportError:
             raise ImportError("Current host is not Maya")
 
-        errored_instances = get_errored_instances_from_context(context,
-                                                               plugin=plugin)
-
         # Get the invalid nodes for the plug-ins
         self.log.info("Finding invalid nodes..")
         invalid = list()
-        for instance in errored_instances:
-            invalid_nodes = plugin.get_invalid(instance)
-            if invalid_nodes:
-                if isinstance(invalid_nodes, (list, tuple)):
-                    invalid.extend(invalid_nodes)
-                else:
-                    self.log.warning("Plug-in returned to be invalid, "
-                                     "but has no selectable nodes.")
+        if issubclass(plugin, pyblish.api.ContextPlugin):
+            errored_plugins = get_errored_plugins_from_context(context)
+            if plugin in errored_plugins:
+                invalid = plugin.get_invalid(context)
+        else:
+            errored_instances = get_errored_instances_from_context(
+                context, plugin=plugin
+            )
+            for instance in errored_instances:
+                invalid_nodes = plugin.get_invalid(instance)
+                if invalid_nodes:
+                    if isinstance(invalid_nodes, (list, tuple)):
+                        invalid.extend(invalid_nodes)
+                    else:
+                        self.log.warning("Plug-in returned to be invalid, "
+                                         "but has no selectable nodes.")
 
         # Ensure unique (process each node only once)
         invalid = list(set(invalid))


### PR DESCRIPTION
## Changelog Description

Support `SelectInvalidAction` with pyblish ContextPlugin

## Additional info

I don't believe there's currently any `ContextPlugin` in the maya integration that is actively using the `SelectInvalidAction`. However we had some in our codebase and it would be nice to port at least this functionality upstream to avoid any surprises in the future.

We might want to match the logic in other host integrations if they also have a `SelectInvalidAction` so they are also prepared.

## Testing notes:

1. Select Invalid actions should still work in publisher UI.
