### PR TITLE
Chore: Use explicit plug-ins and orders from pyblish api instead of legacy plug-ins

### DIFF
--- a/client/ayon_core/hosts/blender/plugins/publish/validate_mesh_no_negative_scale.py
+++ b/client/ayon_core/hosts/blender/plugins/publish/validate_mesh_no_negative_scale.py
@@ -12,7 +12,7 @@ from ayon_core.pipeline.publish import (
 import ayon_core.hosts.blender.api.action
 
 
-class ValidateMeshNoNegativeScale(pyblish.api.Validator,
+class ValidateMeshNoNegativeScale(pyblish.api.InstancePlugin,
                                   OptionalPyblishPluginMixin):
     """Ensure that meshes don't have a negative scale."""
 

--- a/client/ayon_core/hosts/celaction/plugins/publish/collect_celaction_cli_kwargs.py
+++ b/client/ayon_core/hosts/celaction/plugins/publish/collect_celaction_cli_kwargs.py
@@ -3,11 +3,11 @@ import sys
 from pprint import pformat
 
 
-class CollectCelactionCliKwargs(pyblish.api.Collector):
+class CollectCelactionCliKwargs(pyblish.api.ContextPlugin):
     """ Collects all keyword arguments passed from the terminal """
 
     label = "Collect Celaction Cli Kwargs"
-    order = pyblish.api.Collector.order - 0.1
+    order = pyblish.api.CollectorOrder - 0.1
 
     def process(self, context):
         args = list(sys.argv[1:])

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_color_sets.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_color_sets.py
@@ -10,7 +10,7 @@ from ayon_core.pipeline.publish import (
 )
 
 
-class ValidateColorSets(pyblish.api.Validator,
+class ValidateColorSets(pyblish.api.InstancePlugin,
                         OptionalPyblishPluginMixin):
     """Validate all meshes in the instance have unlocked normals
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_mesh_ngons.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_mesh_ngons.py
@@ -10,7 +10,7 @@ from ayon_core.pipeline.publish import (
 )
 
 
-class ValidateMeshNgons(pyblish.api.Validator,
+class ValidateMeshNgons(pyblish.api.InstancePlugin,
                         OptionalPyblishPluginMixin):
     """Ensure that meshes don't have ngons
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_mesh_no_negative_scale.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_mesh_no_negative_scale.py
@@ -16,7 +16,7 @@ def _as_report_list(values, prefix="- ", suffix="\n"):
     return prefix + (suffix + prefix).join(values)
 
 
-class ValidateMeshNoNegativeScale(pyblish.api.Validator,
+class ValidateMeshNoNegativeScale(pyblish.api.InstancePlugin,
                                   OptionalPyblishPluginMixin):
     """Ensure that meshes don't have a negative scale.
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_mesh_non_manifold.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_mesh_non_manifold.py
@@ -16,7 +16,7 @@ def _as_report_list(values, prefix="- ", suffix="\n"):
     return prefix + (suffix + prefix).join(values)
 
 
-class ValidateMeshNonManifold(pyblish.api.Validator,
+class ValidateMeshNonManifold(pyblish.api.InstancePlugin,
                               OptionalPyblishPluginMixin):
     """Ensure that meshes don't have non-manifold edges or vertices
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_mesh_normals_unlocked.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_mesh_normals_unlocked.py
@@ -18,7 +18,7 @@ def _as_report_list(values, prefix="- ", suffix="\n"):
     return prefix + (suffix + prefix).join(values)
 
 
-class ValidateMeshNormalsUnlocked(pyblish.api.Validator,
+class ValidateMeshNormalsUnlocked(pyblish.api.InstancePlugin,
                                   OptionalPyblishPluginMixin):
     """Validate all meshes in the instance have unlocked normals
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_no_animation.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_no_animation.py
@@ -16,7 +16,7 @@ def _as_report_list(values, prefix="- ", suffix="\n"):
     return prefix + (suffix + prefix).join(values)
 
 
-class ValidateNoAnimation(pyblish.api.Validator,
+class ValidateNoAnimation(pyblish.api.InstancePlugin,
                           OptionalPyblishPluginMixin):
     """Ensure no keyframes on nodes in the Instance.
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_shape_render_stats.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_shape_render_stats.py
@@ -10,7 +10,7 @@ from ayon_core.pipeline.publish import (
 )
 
 
-class ValidateShapeRenderStats(pyblish.api.Validator,
+class ValidateShapeRenderStats(pyblish.api.InstancePlugin,
                                OptionalPyblishPluginMixin):
     """Ensure all render stats are set to the default values."""
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_shape_zero.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_shape_zero.py
@@ -12,7 +12,7 @@ from ayon_core.pipeline.publish import (
 )
 
 
-class ValidateShapeZero(pyblish.api.Validator,
+class ValidateShapeZero(pyblish.api.InstancePlugin,
                         OptionalPyblishPluginMixin):
     """Shape components may not have any "tweak" values
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_transform_zero.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_transform_zero.py
@@ -10,7 +10,7 @@ from ayon_core.pipeline.publish import (
 )
 
 
-class ValidateTransformZero(pyblish.api.Validator,
+class ValidateTransformZero(pyblish.api.InstancePlugin,
                             OptionalPyblishPluginMixin):
     """Transforms can't have any values
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_unique_names.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_unique_names.py
@@ -9,7 +9,7 @@ from ayon_core.pipeline.publish import (
 )
 
 
-class ValidateUniqueNames(pyblish.api.Validator,
+class ValidateUniqueNames(pyblish.api.InstancePlugin,
                           OptionalPyblishPluginMixin):
     """transform names should be unique
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_yeti_rig_input_in_instance.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_yeti_rig_input_in_instance.py
@@ -10,7 +10,7 @@ from ayon_core.pipeline.publish import (
 )
 
 
-class ValidateYetiRigInputShapesInInstance(pyblish.api.Validator,
+class ValidateYetiRigInputShapesInInstance(pyblish.api.InstancePlugin,
                                            OptionalPyblishPluginMixin):
     """Validate if all input nodes are part of the instance's hierarchy"""
 

--- a/client/ayon_core/hosts/nuke/plugins/publish/extract_script_save.py
+++ b/client/ayon_core/hosts/nuke/plugins/publish/extract_script_save.py
@@ -2,10 +2,10 @@ import nuke
 import pyblish.api
 
 
-class ExtractScriptSave(pyblish.api.Extractor):
+class ExtractScriptSave(pyblish.api.InstancePlugin):
     """Save current Nuke workfile script"""
     label = 'Script Save'
-    order = pyblish.api.Extractor.order - 0.1
+    order = pyblish.api.ExtractorOrder - 0.1
     hosts = ['nuke']
 
     def process(self, instance):

--- a/client/ayon_core/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/client/ayon_core/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -25,8 +25,9 @@ from ayon_core.hosts.tvpaint.lib import (
 )
 
 
-class ExtractSequence(pyblish.api.Extractor):
+class ExtractSequence(pyblish.api.InstancePlugin):
     label = "Extract Sequence"
+    order = pyblish.api.ExtractorOrder
     hosts = ["tvpaint"]
     families = ["review", "render"]
 


### PR DESCRIPTION
## Changelog Description

Use explicit plug-ins from pyblish api instead of legacy plug-ins
Use explicit pyblish api orders, instead of order of legacy plug-ins

## Additional info

This shouldn't change usage behavior but these are more explicit and by refactoring these older uses we're now making it more unified usage inside AYON by removing the legacy usage.

Only remaining usage seems to be in [`./tools/pyblish_pype/mock.py` here](https://github.com/ynput/ayon-core/blob/a4f2f76fbf98becd22b75012abf1abfc09bbd69d/client/ayon_core/tools/pyblish_pype/mock.py)

## Testing notes:

1. Changed plug-ins should still work
