### PR TITLE
Houdini: Fix creating instances from tab menu

### DIFF
--- a/client/ayon_core/hosts/houdini/api/creator_node_shelves.py
+++ b/client/ayon_core/hosts/houdini/api/creator_node_shelves.py
@@ -91,7 +91,7 @@ def create_interactive(creator_identifier, **kwargs):
     pane = stateutils.activePane(kwargs)
     if isinstance(pane, hou.NetworkEditor):
         pwd = pane.pwd()
-        project_name = context.get_current_project_name(),
+        project_name = context.get_current_project_name()
         folder_path = context.get_current_folder_path()
         task_name = context.get_current_task_name()
         folder_entity = ayon_api.get_folder_by_path(


### PR DESCRIPTION
## Changelog Description

Fix creating instances via TAB menu in Houdini

## Additional info

![image](https://github.com/ynput/ayon-core/assets/2439881/aa7a122e-3816-43f6-b00c-086517a9f448)


Error:
```python
Traceback (most recent call last):
  File "ayon_create.io.openpype.creators.houdini.vdbcache", line 3, in <module>
  File "E:\dev\ayon-core\client\ayon_core\hosts\houdini\api\creator_node_shelves.py", line 97, in create_interactive
    folder_entity = ayon_api.get_folder_by_path(
  File "C:\Program Files\Ynput\AYON 1.0.2\dependencies\ayon_api\_api.py", line 810, in get_folder_by_path
    return con.get_folder_by_path(*args, **kwargs)
  File "C:\Program Files\Ynput\AYON 1.0.2\dependencies\ayon_api\server_api.py", line 3799, in get_folder_by_path
    for folder in folders:
  File "C:\Program Files\Ynput\AYON 1.0.2\dependencies\ayon_api\server_api.py", line 3721, in get_folders
    for parsed_data in query.continuous_query(self):
  File "C:\Program Files\Ynput\AYON 1.0.2\dependencies\ayon_api\graphql.py", line 380, in continuous_query
    raise GraphQlQueryFailed(
ayon_api.exceptions.GraphQlQueryFailed: GraphQl query Failed: Variable '$projectName' got invalid value ['ayontest']; String cannot represent a non string value: ['ayontest'] (Line 1 Column 20)
```

## Testing notes:

1. Create instances via TAB menu should work
