### PR TITLE
Validate Containers: Rename `Options` to `Context` in report

### DIFF
--- a/client/ayon_core/plugins/publish/help/validate_containers.xml
+++ b/client/ayon_core/plugins/publish/help/validate_containers.xml
@@ -10,7 +10,7 @@ Scene contains one or more outdated loaded containers, eg. versions loaded into 
 ### How to repair?
 
 Use 'Scene Inventory' and update all highlighted old container to latest OR
-    refresh Publish and switch 'Validate Containers' toggle on 'Options' tab.
+refresh Publish and switch 'Validate Containers' toggle on 'Context' tab.
 
     WARNING: Skipping this validator will result in publishing (and probably rendering) old version of loaded assets.
 </description>


### PR DESCRIPTION
## Changelog Description

Rename `Options` to `Context` in report

## Additional info

It has been `Context` for a while now.

## Testing notes:

1. Outdated containers message should now state "Context" instead of "Options"
