### PR TITLE
Maya: Load RenderSetup add more options

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/load/load_rendersetup.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_rendersetup.py
@@ -111,10 +111,10 @@ class RenderSetupLoader(load.LoaderPlugin):
 
         if data.get("load_managed", True):
             self.log.info(">>> containerising [ {} ]".format(name))
-            asset = context['asset']['name']
+            folder_name = context["folder"]["name"]
             namespace = namespace or lib.unique_namespace(
-                asset + "_",
-                prefix="_" if asset[0].isdigit() else "",
+                folder_name + "_",
+                prefix="_" if folder_name[0].isdigit() else "",
                 suffix="_",
             )
 

--- a/client/ayon_core/hosts/maya/plugins/load/load_rendersetup.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_rendersetup.py
@@ -127,8 +127,6 @@ class RenderSetupLoader(load.LoaderPlugin):
 
     def remove(self, container):
         """Remove RenderSetup settings instance."""
-        from maya import cmds
-
         container_name = container["objectName"]
 
         self.log.info("Removing '%s' from Maya.." % container["name"])


### PR DESCRIPTION
## Changelog Description

Maya Load Rendersetup with more options:
- allow loading unmanaged 
- automatically 'accept' the import 
- pick import mode

## Additional info

n/a

## Testing notes:

1. Loading RenderSetup to maya should work.