### PR TITLE
Maya: ExtractGpuCache and ExtractModel (maya scene) optional state in settings

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/extract_gpu_cache.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/extract_gpu_cache.py
@@ -5,7 +5,8 @@ from maya import cmds
 from ayon_core.pipeline import publish
 
 
-class ExtractGPUCache(publish.Extractor):
+class ExtractGPUCache(publish.Extractor,
+                      publish.OptionalPyblishPluginMixin):
     """Extract the content of the instance to a GPU cache file."""
 
     label = "GPU Cache"
@@ -20,6 +21,9 @@ class ExtractGPUCache(publish.Extractor):
     useBaseTessellation = True
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
         cmds.loadPlugin("gpuCache", quiet=True)
 
         staging_dir = self.staging_dir(instance)

--- a/server_addon/maya/server/settings/publishers.py
+++ b/server_addon/maya/server/settings/publishers.py
@@ -372,9 +372,9 @@ class ExtractLookModel(BaseSettingsModel):
 
 
 class ExtractGPUCacheModel(BaseSettingsModel):
-    enabled: bool = True
-    optional: bool = True
-    active: bool = True
+    enabled: bool = SettingsField(title="Enabled")
+    optional: bool = SettingsField(title="Optional")
+    active: bool = SettingsField(title="Active")
     families: list[str] = SettingsField(default_factory=list, title="Families")
     step: float = SettingsField(1.0, ge=1.0, title="Step")
     stepSave: int = SettingsField(1, ge=1, title="Step Save")

--- a/server_addon/maya/server/settings/publishers.py
+++ b/server_addon/maya/server/settings/publishers.py
@@ -316,6 +316,12 @@ class ExtractObjModel(BaseSettingsModel):
     optional: bool = SettingsField(title="Optional")
 
 
+class ExtractModelModel(BaseSettingsModel):
+    enabled: bool = SettingsField(title="Enabled")
+    optional: bool = SettingsField(title="Optional")
+    active: bool = SettingsField(title="Active")
+
+
 class ExtractMayaSceneRawModel(BaseSettingsModel):
     """Add loaded instances to those published families:"""
     enabled: bool = SettingsField(title="ExtractMayaSceneRaw")
@@ -800,6 +806,10 @@ class PublishersModel(BaseSettingsModel):
     ExtractGPUCache: ExtractGPUCacheModel = SettingsField(
         default_factory=ExtractGPUCacheModel,
         title="Extract GPU Cache",
+    )
+    ExtractModel: ExtractModelModel = SettingsField(
+        default_factory=ExtractModelModel,
+        title="Extract Model (Maya Scene)"
     )
 
 
@@ -1357,5 +1367,10 @@ DEFAULT_PUBLISH_SETTINGS = {
         "optimizeAnimationsForMotionBlur": True,
         "writeMaterials": True,
         "useBaseTessellation": True
+    },
+    "ExtractModel": {
+        "enabled": True,
+        "optional": True,
+        "active": True,
     }
 }

--- a/server_addon/maya/server/settings/publishers.py
+++ b/server_addon/maya/server/settings/publishers.py
@@ -373,6 +373,8 @@ class ExtractLookModel(BaseSettingsModel):
 
 class ExtractGPUCacheModel(BaseSettingsModel):
     enabled: bool = True
+    optional: bool = True
+    active: bool = True
     families: list[str] = SettingsField(default_factory=list, title="Families")
     step: float = SettingsField(1.0, ge=1.0, title="Step")
     stepSave: int = SettingsField(1, ge=1, title="Step Save")
@@ -1341,6 +1343,8 @@ DEFAULT_PUBLISH_SETTINGS = {
     },
     "ExtractGPUCache": {
         "enabled": False,
+        "optional": False,
+        "active": True,
         "families": [
             "model",
             "animation",

--- a/server_addon/maya/server/version.py
+++ b/server_addon/maya/server/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring addon version."""
-__version__ = "0.1.12"
+__version__ = "0.1.13"


### PR DESCRIPTION
## Changelog Description

Add support for changing the `enabled`, `active` and `optional` state in settings of:
- Extract GPU Cache
- Extract Model (Maya Scene)

## Additional info

n/a

## Testing notes:

1. Default values for the settings should be 'backwards compatible' (behave like before)
2. Changing settings for Extract GPU Cache should work
3. Changing settings for Extract Model (Maya Scene) should work
