### PR TITLE
Substance Painter: Allow loading `usd` mesh to substance painter

### DIFF
--- a/client/ayon_core/hosts/substancepainter/plugins/load/load_mesh.py
+++ b/client/ayon_core/hosts/substancepainter/plugins/load/load_mesh.py
@@ -18,7 +18,7 @@ class SubstanceLoadProjectMesh(load.LoaderPlugin):
     """Load mesh for project"""
 
     product_types = {"*"}
-    representations = ["abc", "fbx", "obj", "gltf"]
+    representations = ["abc", "fbx", "obj", "gltf", "usd", "usda", "usdc"]
 
     label = "Load mesh"
     order = -10


### PR DESCRIPTION
## Changelog Description

Substance Painter: Allow loading `usd` mesh to substance painter

## Additional info

n/a

## Testing notes:

1. Load mesh in loader should now also show (and work) for USD representations.
