### PR TITLE
Maya: Set scene frame range - apply playback options in one call

### DIFF
--- a/client/ayon_core/hosts/maya/api/lib.py
+++ b/client/ayon_core/hosts/maya/api/lib.py
@@ -2444,12 +2444,10 @@ def set_scene_fps(fps, update=True):
     cmds.currentUnit(time=unit, updateAnimation=update)
 
     # Set time slider data back to previous state
-    cmds.playbackOptions(edit=True, minTime=start_frame)
-    cmds.playbackOptions(edit=True, maxTime=end_frame)
-
-    # Set animation data
-    cmds.playbackOptions(edit=True, animationStartTime=animation_start)
-    cmds.playbackOptions(edit=True, animationEndTime=animation_end)
+    cmds.playbackOptions(minTime=start_frame,
+                         maxTime=end_frame,
+                         animationStartTime=animation_start,
+                         animationEndTime=animation_end)
 
     cmds.currentTime(current_frame, edit=True, update=True)
 


### PR DESCRIPTION
## Changelog Description

Don't set time slider values one by one, but set all at once.

## Additional info

Less maya calls is always good.

This really shouldn't break anything. :)

## Testing notes:

1. Updating scene frame range should work. (e.g. reset frame range) or by the 'fix' in the prompt on scene save if your scene is wrong frame range.