### PR TITLE
Maya: Parent look assigner UI to Maya window when opening via toolbox

### DIFF
--- a/client/ayon_core/hosts/maya/api/customize.py
+++ b/client/ayon_core/hosts/maya/api/customize.py
@@ -113,7 +113,9 @@ def override_toolbox_ui():
             annotation="Look Manager",
             label="Look Manager",
             image=os.path.join(icons, "lookmanager.png"),
-            command=show_look_assigner,
+            command=lambda: show_look_assigner(
+                parent=parent_widget
+            ),
             width=icon_size,
             height=icon_size,
             parent=parent


### PR DESCRIPTION
## Changelog Description

When opening Maya - and opening the Look Assign tool via the toolbox the window was not parented to Maya main window. And as such, clicking somewhere inside of maya would make the dialog appear behind maya - which is very annoying.

This PR makes the behavior the same as when Look Assigner is opened via AYON top menu - parented to the Maya main window.

![maya_look_assigner_toolbox](https://github.com/ynput/ayon-core/assets/2439881/cfe5a220-bad6-4961-8048-b3e94120a0f1)

## Additional info

Note that both buttons (toolbox and in menu) use the same 'singleton' dialog. So as soon as you had run it from AYON menu once in current session then opening via toolbox again would still have it parented to Maya. Vice-versa the same, if first opened via Toolbox and then via AYON menu it would still _not_ be parented to maya windows.

## Testing notes:

1. Launch Maya
2. Open Look Assigner via Maya Toolbox
3. Look assigner tool should be parented to maya main window.
