### PR TITLE
Maya: Optimize `get_all_children` logic with ignoring intermediate objects

### DIFF
--- a/client/ayon_core/hosts/maya/api/lib.py
+++ b/client/ayon_core/hosts/maya/api/lib.py
@@ -4009,17 +4009,26 @@ def len_flattened(components):
     return n
 
 
-def get_all_children(nodes):
+def get_all_children(nodes, ignore_intermediate_objects=False):
     """Return all children of `nodes` including each instanced child.
     Using maya.cmds.listRelatives(allDescendents=True) includes only the first
     instance. As such, this function acts as an optimal replacement with a
     focus on a fast query.
+
+    Args:
+        nodes (iterable): List of nodes to get children for.
+        ignore_intermediate_objects (bool): Ignore any children that
+            are intermediate objects.
+
+    Returns:
+        set: Children of input nodes.
 
     """
 
     sel = OpenMaya.MSelectionList()
     traversed = set()
     iterator = OpenMaya.MItDag(OpenMaya.MItDag.kDepthFirst)
+    fn_dag = OpenMaya.MFnDagNode()
     for node in nodes:
 
         if node in traversed:
@@ -4036,6 +4045,13 @@ def get_all_children(nodes):
         iterator.next()  # noqa: B305
         while not iterator.isDone():
 
+            if ignore_intermediate_objects:
+                fn_dag.setObject(iterator.currentItem())
+                if fn_dag.isIntermediateObject:
+                    iterator.prune()
+                    iterator.next()  # noqa: B305
+                    continue
+
             path = iterator.fullPathName()
 
             if path in traversed:
@@ -4046,7 +4062,7 @@ def get_all_children(nodes):
             traversed.add(path)
             iterator.next()  # noqa: B305
 
-    return list(traversed)
+    return traversed
 
 
 def get_capture_preset(

--- a/client/ayon_core/hosts/maya/plugins/publish/collect_arnold_scene_source.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/collect_arnold_scene_source.py
@@ -46,11 +46,18 @@ class CollectArnoldSceneSource(pyblish.api.InstancePlugin):
         self.log.debug("data: {}".format(instance.data))
 
     def get_hierarchy(self, nodes):
-        """Return nodes with all their children"""
+        """Return nodes with all their children:
+
+        Arguments:
+            nodes (List[str]): List of nodes to collect children hierarchy for
+
+        Returns:
+            list: Input nodes with their children hierarchy
+
+        """
         nodes = cmds.ls(nodes, long=True)
         if not nodes:
             return []
-        children = get_all_children(nodes)
-        # Make sure nodes merged with children only
-        # contains unique entries
-        return list(set(nodes + children))
+
+        children = get_all_children(nodes, ignore_intermediate_objects=True)
+        return list(children.union(nodes))

--- a/client/ayon_core/hosts/maya/plugins/publish/collect_arnold_scene_source.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/collect_arnold_scene_source.py
@@ -46,7 +46,7 @@ class CollectArnoldSceneSource(pyblish.api.InstancePlugin):
         self.log.debug("data: {}".format(instance.data))
 
     def get_hierarchy(self, nodes):
-        """Return nodes with all their children:
+        """Return nodes with all their children.
 
         Arguments:
             nodes (List[str]): List of nodes to collect children hierarchy for

--- a/client/ayon_core/hosts/maya/plugins/publish/collect_instances.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/collect_instances.py
@@ -48,15 +48,15 @@ class CollectNewInstances(pyblish.api.InstancePlugin):
             # Collect members
             members = cmds.ls(members, long=True) or []
 
+            # Collect full hierarchy
             dag_members = cmds.ls(members, type="dagNode", long=True)
-            children = get_all_children(dag_members)
-            children = cmds.ls(children, noIntermediate=True, long=True)
-            parents = (
-                self.get_all_parents(members)
-                if creator_attributes.get("includeParentHierarchy", True)
-                else []
-            )
-            members_hierarchy = list(set(members + children + parents))
+            children = get_all_children(dag_members,
+                                        ignore_intermediate_objects=True)
+
+            members_hierarchy = set(members)
+            members_hierarchy.update(children)
+            if creator_attributes.get("includeParentHierarchy", True):
+                members_hierarchy.update(self.get_all_parents(dag_members))
 
             instance[:] = members_hierarchy
 
@@ -97,16 +97,16 @@ class CollectNewInstances(pyblish.api.InstancePlugin):
         """Get all parents by using string operations (optimization)
 
         Args:
-            nodes (list): the nodes which are found in the objectSet
+            nodes (iterable): the nodes which are found in the objectSet
 
         Returns:
-            list
+            set
         """
 
-        parents = []
+        parents = set()
         for node in nodes:
             splitted = node.split("|")
             items = ["|".join(splitted[0:i]) for i in range(2, len(splitted))]
-            parents.extend(items)
+            parents.update(items)
 
-        return list(set(parents))
+        return parents

--- a/client/ayon_core/hosts/maya/tools/mayalookassigner/commands.py
+++ b/client/ayon_core/hosts/maya/tools/mayalookassigner/commands.py
@@ -49,8 +49,9 @@ def get_selected_nodes():
     """Get information from current selection"""
 
     selection = cmds.ls(selection=True, long=True)
-    hierarchy = lib.get_all_children(selection)
-    return list(set(selection + hierarchy))
+    hierarchy = lib.get_all_children(selection,
+                                     ignore_intermediate_objects=True)
+    return list(hierarchy.union(selection))
 
 
 def get_all_asset_nodes():


### PR DESCRIPTION
## Changelog Description

Optimize `get_all_children` logic with ignoring intermediate objects

## Additional info

n/a

## Testing notes:

1. Publishing should still work (with regards to `Collect Instances` plugin) so really any one of them, but test e.g. model, pointcache and rigs
2. Maya Look assigner should still work
3. Publishing arnold standins (`ass` product type) should still work
