### PR TITLE
Use is_active for proper optional functionality in hero integration.

### DIFF
--- a/client/ayon_core/plugins/publish/integrate_hero_version.py
+++ b/client/ayon_core/plugins/publish/integrate_hero_version.py
@@ -90,6 +90,9 @@ class IntegrateHeroVersion(
     # *but all other plugins must be sucessfully completed
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
         self.log.debug(
             "--- Integration of Hero version for product `{}` begins.".format(
                 instance.data["productName"]


### PR DESCRIPTION
## Changelog Description
The `IntegrateHeroVersion` plugin was not properly checking whether it should run.

## Testing notes:
1. Enable hero integration in settings.
2. Setup `model` in Maya and uncheck `Integrate Hero Version`.
3. Verify that `Integrate Hero Version` does not run.
