### PR TITLE
Maya: Use frame range from task attributes

### DIFF
--- a/client/ayon_core/hosts/maya/api/lib.py
+++ b/client/ayon_core/hosts/maya/api/lib.py
@@ -2525,7 +2525,7 @@ def get_fps_for_current_context():
 
 
 def get_frame_range(include_animation_range=False):
-    """Get the current folder frame range and handles.
+    """Get the current task frame range and handles.
 
     Args:
         include_animation_range (bool, optional): Whether to include
@@ -2533,25 +2533,31 @@ def get_frame_range(include_animation_range=False):
             range of the timeline. It is excluded by default.
 
     Returns:
-        dict: Folder's expected frame range values.
+        dict: Task's expected frame range values.
 
     """
 
     # Set frame start/end
     project_name = get_current_project_name()
     folder_path = get_current_folder_path()
-    folder_entity = ayon_api.get_folder_by_path(project_name, folder_path)
-    folder_attributes = folder_entity["attrib"]
+    task_name = get_current_task_name()
 
-    frame_start = folder_attributes.get("frameStart")
-    frame_end = folder_attributes.get("frameEnd")
+    folder_entity = ayon_api.get_folder_by_path(project_name, folder_path)
+    task_entity = ayon_api.get_task_by_name(
+            project_name, folder_entity["id"], task_name
+        )
+
+    task_attributes = task_entity["attrib"]
+
+    frame_start = task_attributes.get("frameStart")
+    frame_end = task_attributes.get("frameEnd")
 
     if frame_start is None or frame_end is None:
         cmds.warning("No edit information found for '{}'".format(folder_path))
         return
 
-    handle_start = folder_attributes.get("handleStart") or 0
-    handle_end = folder_attributes.get("handleEnd") or 0
+    handle_start = task_attributes.get("handleStart") or 0
+    handle_end = task_attributes.get("handleEnd") or 0
 
     frame_range = {
         "frameStart": frame_start,
@@ -2565,11 +2571,8 @@ def get_frame_range(include_animation_range=False):
         # Some usages of this function use the full dictionary to define
         # instance attributes for which we want to exclude the animation
         # keys. That is why these are excluded by default.
-        task_name = get_current_task_name()
+
         settings = get_project_settings(project_name)
-        task_entity = ayon_api.get_task_by_name(
-            project_name, folder_entity["id"], task_name
-        )
         task_type = None
         if task_entity:
             task_type = task_entity["taskType"]

--- a/client/ayon_core/hosts/maya/api/lib.py
+++ b/client/ayon_core/hosts/maya/api/lib.py
@@ -2542,7 +2542,10 @@ def get_frame_range(include_animation_range=False):
     folder_path = get_current_folder_path()
     task_name = get_current_task_name()
 
-    folder_entity = ayon_api.get_folder_by_path(project_name, folder_path)
+    folder_entity = ayon_api.get_folder_by_path(
+        project_name,
+        folder_path,
+        fields={"id"})
     task_entity = ayon_api.get_task_by_name(
             project_name, folder_entity["id"], task_name
         )
@@ -2573,9 +2576,8 @@ def get_frame_range(include_animation_range=False):
         # keys. That is why these are excluded by default.
 
         settings = get_project_settings(project_name)
-        task_type = None
-        if task_entity:
-            task_type = task_entity["taskType"]
+
+        task_type = task_entity["taskType"]
 
         include_handles_settings = settings["maya"]["include_handles"]
 


### PR DESCRIPTION
## Changelog Description
A bug fix for the issue reported here https://github.com/ynput/ayon-core/pull/323#pullrequestreview-1970044683
Frame Range values should be taken from task level attributes. 
![image](https://github.com/ynput/ayon-core/assets/352795/f45a8032-8aea-4c8e-afb9-bfda84c93a5f)

## Testing notes:
1. Launch Maya 
2. Reset Frame Range
