### PR TITLE
Chore: Convert `ABOUT_TO_SAVE` to `_about_to_save`

### DIFF
--- a/client/ayon_core/hosts/fusion/api/pipeline.py
+++ b/client/ayon_core/hosts/fusion/api/pipeline.py
@@ -43,7 +43,7 @@ CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
 # Track whether the workfile tool is about to save
-ABOUT_TO_SAVE = False
+_about_to_save = False
 
 
 class FusionLogHandler(logging.Handler):
@@ -176,15 +176,15 @@ def on_save(event):
     validate_comp_prefs(comp)
 
     # We are now starting the actual save directly
-    global ABOUT_TO_SAVE
-    ABOUT_TO_SAVE = False
+    global _about_to_save
+    _about_to_save = False
 
 
 def on_task_changed():
-    global ABOUT_TO_SAVE
-    print(f"Task changed: {ABOUT_TO_SAVE}")
+    global _about_to_save
+    print(f"Task changed: {_about_to_save}")
     # TODO: Only do this if not headless
-    if ABOUT_TO_SAVE:
+    if _about_to_save:
         # Let's prompt the user to update the context settings or not
         prompt_reset_context()
 
@@ -228,7 +228,7 @@ def before_workfile_save(event):
     # have been shut down, and restarted - which will restart it to the
     # environment Fusion started with; not necessarily where the artist
     # is currently working.
-    # The `ABOUT_TO_SAVE` var is used to detect context changes when
+    # The `_about_to_save` var is used to detect context changes when
     # saving into another asset. If we keep it False it will be ignored
     # as context change. As such, before we change tasks we will only
     # consider it the current filepath is within the currently known
@@ -239,8 +239,8 @@ def before_workfile_save(event):
     filepath = comp.GetAttrs()["COMPS_FileName"]
     workdir = os.environ.get("AYON_WORKDIR")
     if Path(workdir) in Path(filepath).parents:
-        global ABOUT_TO_SAVE
-        ABOUT_TO_SAVE = True
+        global _about_to_save
+        _about_to_save = True
 
 
 def ls():

--- a/client/ayon_core/hosts/houdini/api/pipeline.py
+++ b/client/ayon_core/hosts/houdini/api/pipeline.py
@@ -39,7 +39,7 @@ CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
 # Track whether the workfile tool is about to save
-ABOUT_TO_SAVE = False
+_about_to_save = False
 
 
 class HoudiniHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
@@ -292,8 +292,8 @@ def ls():
 
 
 def before_workfile_save(event):
-    global ABOUT_TO_SAVE
-    ABOUT_TO_SAVE = True
+    global _about_to_save
+    _about_to_save = True
 
 
 def before_save():
@@ -308,13 +308,13 @@ def on_save():
     lib.update_houdini_vars_context_dialog()
 
     # We are now starting the actual save directly
-    global ABOUT_TO_SAVE
-    ABOUT_TO_SAVE = False
+    global _about_to_save
+    _about_to_save = False
 
 
 def on_task_changed():
-    global ABOUT_TO_SAVE
-    if not IS_HEADLESS and ABOUT_TO_SAVE:
+    global _about_to_save
+    if not IS_HEADLESS and _about_to_save:
         # Let's prompt the user to update the context settings or not
         lib.prompt_reset_context()
 

--- a/client/ayon_core/hosts/maya/api/pipeline.py
+++ b/client/ayon_core/hosts/maya/api/pipeline.py
@@ -68,7 +68,7 @@ INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 AVALON_CONTAINERS = ":AVALON_CONTAINERS"
 
 # Track whether the workfile tool is about to save
-ABOUT_TO_SAVE = False
+_about_to_save = False
 
 
 class MayaHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
@@ -585,8 +585,8 @@ def on_save():
         lib.set_id(node, new_id, overwrite=False)
 
     # We are now starting the actual save directly
-    global ABOUT_TO_SAVE
-    ABOUT_TO_SAVE = False
+    global _about_to_save
+    _about_to_save = False
 
 
 def on_open():
@@ -657,8 +657,8 @@ def on_task_changed():
         lib.set_context_settings()
         lib.update_content_on_context_change()
 
-    global ABOUT_TO_SAVE
-    if not lib.IS_HEADLESS and ABOUT_TO_SAVE:
+    global _about_to_save
+    if not lib.IS_HEADLESS and _about_to_save:
         # Let's prompt the user to update the context settings or not
         lib.prompt_reset_context()
 
@@ -676,8 +676,8 @@ def before_workfile_save(event):
     if workdir_path:
         create_workspace_mel(workdir_path, project_name)
 
-    global ABOUT_TO_SAVE
-    ABOUT_TO_SAVE = True
+    global _about_to_save
+    _about_to_save = True
 
 
 def workfile_save_before_xgen(event):


### PR DESCRIPTION
## Changelog Description

Change `ABOUT_TO_SAVE` to `_about_to_save` as @iLLiCiTiT requested [here](https://github.com/ynput/ayon-core/pull/261#discussion_r1547412186)

## Additional info

Value is not a public constant, but a private global

## Testing notes:

1. Prompts on saving to another task should work:
    - [ ] Houdini
    - [ ] Fusion
    - [ ] Maya
