### PR TITLE
Chore: remove unused work root function

### DIFF
--- a/client/ayon_core/hosts/blender/api/__init__.py
+++ b/client/ayon_core/hosts/blender/api/__init__.py
@@ -23,8 +23,7 @@ from .workio import (
     save_file,
     current_file,
     has_unsaved_changes,
-    file_extensions,
-    work_root,
+    file_extensions
 )
 
 from .lib import (
@@ -59,7 +58,6 @@ __all__ = [
     "current_file",
     "has_unsaved_changes",
     "file_extensions",
-    "work_root",
 
     # Utility functions
     "maintained_selection",

--- a/client/ayon_core/hosts/blender/api/pipeline.py
+++ b/client/ayon_core/hosts/blender/api/pipeline.py
@@ -40,8 +40,7 @@ from .workio import (
     save_file,
     current_file,
     has_unsaved_changes,
-    file_extensions,
-    work_root,
+    file_extensions
 )
 
 
@@ -119,18 +118,6 @@ class BlenderHost(HostBase, IWorkfileHost, IPublishHost, ILoadHost):
                 modifications.
         """
         return has_unsaved_changes()
-
-    def work_root(self, session) -> str:
-        """Override work_root method from IWorkfileHost.
-        Modify workdir per host.
-
-        Args:
-            session (dict): Session context data.
-
-        Returns:
-            str: Path to new workdir.
-        """
-        return work_root(session)
 
     def get_context_data(self) -> dict:
         """Override abstract method from IPublishHost.

--- a/client/ayon_core/hosts/blender/api/workio.py
+++ b/client/ayon_core/hosts/blender/api/workio.py
@@ -77,13 +77,3 @@ def file_extensions() -> List[str]:
     """Return the supported file extensions for Blender scene files."""
 
     return [".blend"]
-
-
-def work_root(session: dict) -> str:
-    """Return the default root to browse for work files."""
-
-    work_dir = session["AYON_WORKDIR"]
-    scene_dir = session.get("AVALON_SCENEDIR")
-    if scene_dir:
-        return str(Path(work_dir, scene_dir))
-    return work_dir

--- a/client/ayon_core/hosts/flame/api/__init__.py
+++ b/client/ayon_core/hosts/flame/api/__init__.py
@@ -65,8 +65,7 @@ from .workio import (
     save_file,
     current_file,
     has_unsaved_changes,
-    file_extensions,
-    work_root
+    file_extensions
 )
 from .render_utils import (
     export_clip,
@@ -146,7 +145,6 @@ __all__ = [
     "current_file",
     "has_unsaved_changes",
     "file_extensions",
-    "work_root",
 
     # render utils
     "export_clip",

--- a/client/ayon_core/hosts/flame/api/workio.py
+++ b/client/ayon_core/hosts/flame/api/workio.py
@@ -31,7 +31,3 @@ def open_file(filepath):
 
 def current_file():
     pass
-
-
-def work_root(session):
-    return os.path.normpath(session["AYON_WORKDIR"]).replace("\\", "/")

--- a/client/ayon_core/hosts/fusion/api/pipeline.py
+++ b/client/ayon_core/hosts/fusion/api/pipeline.py
@@ -140,15 +140,6 @@ class FusionHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
         return current_filepath
 
-    def work_root(self, session):
-        work_dir = session["AYON_WORKDIR"]
-        scene_dir = session.get("AVALON_SCENEDIR")
-        if scene_dir:
-            return os.path.join(work_dir, scene_dir)
-        else:
-            return work_dir
-    # endregion
-
     @contextlib.contextmanager
     def maintained_selection(self):
         from .lib import maintained_selection

--- a/client/ayon_core/hosts/harmony/api/__init__.py
+++ b/client/ayon_core/hosts/harmony/api/__init__.py
@@ -42,8 +42,7 @@ from .workio import (
     save_file,
     current_file,
     has_unsaved_changes,
-    file_extensions,
-    work_root
+    file_extensions
 )
 
 __all__ = [
@@ -84,7 +83,6 @@ __all__ = [
     "save_file",
     "current_file",
     "has_unsaved_changes",
-    "file_extensions",
-    "work_root",
+    "file_extensions"
 ]
 

--- a/client/ayon_core/hosts/harmony/api/workio.py
+++ b/client/ayon_core/hosts/harmony/api/workio.py
@@ -71,7 +71,3 @@ def open_file(filepath):
 def current_file():
     """Returning None to make Workfiles app look at first file extension."""
     return None
-
-
-def work_root(session):
-    return os.path.normpath(session["AYON_WORKDIR"]).replace("\\", "/")

--- a/client/ayon_core/hosts/hiero/api/__init__.py
+++ b/client/ayon_core/hosts/hiero/api/__init__.py
@@ -3,8 +3,7 @@ from .workio import (
     save_file,
     current_file,
     has_unsaved_changes,
-    file_extensions,
-    work_root
+    file_extensions
 )
 
 from .pipeline import (
@@ -84,8 +83,7 @@ __all__ = [
     "save_file",
     "current_file",
     "has_unsaved_changes",
-    "file_extensions",
-    "work_root",
+    "file_extensions"
 
     # Constants
     "OPENPYPE_TAG_NAME",

--- a/client/ayon_core/hosts/hiero/api/workio.py
+++ b/client/ayon_core/hosts/hiero/api/workio.py
@@ -67,7 +67,3 @@ def current_file():
     if not current_file:
         return None
     return os.path.normpath(current_file)
-
-
-def work_root(session):
-    return os.path.normpath(session["AYON_WORKDIR"]).replace("\\", "/")

--- a/client/ayon_core/hosts/maya/api/__init__.py
+++ b/client/ayon_core/hosts/maya/api/__init__.py
@@ -21,8 +21,7 @@ from .workio import (
     save_file,
     current_file,
     has_unsaved_changes,
-    file_extensions,
-    work_root
+    file_extensions
 )
 
 from .lib import (
@@ -53,8 +52,7 @@ __all__ = [
     "save_file",
     "current_file",
     "has_unsaved_changes",
-    "file_extensions",
-    "work_root",
+    "file_extensions"
 
     # Utility functions
     "lsattr",

--- a/client/ayon_core/hosts/maya/api/pipeline.py
+++ b/client/ayon_core/hosts/maya/api/pipeline.py
@@ -53,7 +53,6 @@ from .workio import (
     save_file,
     file_extensions,
     has_unsaved_changes,
-    work_root,
     current_file
 )
 
@@ -132,9 +131,6 @@ class MayaHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
     def save_workfile(self, filepath=None):
         return save_file(filepath)
-
-    def work_root(self, session):
-        return work_root(session)
 
     def get_current_workfile(self):
         return current_file()

--- a/client/ayon_core/hosts/maya/api/workio.py
+++ b/client/ayon_core/hosts/maya/api/workio.py
@@ -32,35 +32,3 @@ def current_file():
         return None
 
     return current_filepath
-
-
-def work_root(session):
-    work_dir = session["AYON_WORKDIR"]
-    scene_dir = None
-
-    # Query scene file rule from workspace.mel if it exists in WORKDIR
-    # We are parsing the workspace.mel manually as opposed to temporarily
-    # setting the Workspace in Maya in a context manager since Maya had a
-    # tendency to crash on frequently changing the workspace when this
-    # function was called many times as one scrolled through Work Files assets.
-    workspace_mel = os.path.join(work_dir, "workspace.mel")
-    if os.path.exists(workspace_mel):
-        scene_rule = 'workspace -fr "scene" '
-        # We need to use builtins as `open` is overridden by the workio API
-        open_file = __builtins__["open"]
-        with open_file(workspace_mel, "r") as f:
-            for line in f:
-                if line.strip().startswith(scene_rule):
-                    # remainder == "rule";
-                    remainder = line[len(scene_rule):]
-                    # scene_dir == rule
-                    scene_dir = remainder.split('"')[1]
-    else:
-        # We can't query a workspace that does not exist
-        # so we return similar to what we do in other hosts.
-        scene_dir = session.get("AVALON_SCENEDIR")
-
-    if scene_dir:
-        return os.path.join(work_dir, scene_dir)
-    else:
-        return work_dir

--- a/client/ayon_core/hosts/nuke/api/__init__.py
+++ b/client/ayon_core/hosts/nuke/api/__init__.py
@@ -3,8 +3,7 @@ from .workio import (
     has_unsaved_changes,
     save_file,
     open_file,
-    current_file,
-    work_root,
+    current_file
 )
 from .command import (
     viewer_update_and_undo_stop
@@ -61,7 +60,6 @@ __all__ = (
     "save_file",
     "open_file",
     "current_file",
-    "work_root",
 
     "viewer_update_and_undo_stop",
 

--- a/client/ayon_core/hosts/nuke/api/pipeline.py
+++ b/client/ayon_core/hosts/nuke/api/pipeline.py
@@ -64,7 +64,6 @@ from .workio import (
     save_file,
     file_extensions,
     has_unsaved_changes,
-    work_root,
     current_file
 )
 from .constants import ASSIST
@@ -92,9 +91,6 @@ class NukeHost(
 
     def save_workfile(self, filepath=None):
         return save_file(filepath)
-
-    def work_root(self, session):
-        return work_root(session)
 
     def get_current_workfile(self):
         return current_file()

--- a/client/ayon_core/hosts/nuke/api/workio.py
+++ b/client/ayon_core/hosts/nuke/api/workio.py
@@ -64,15 +64,3 @@ def current_file():
         return None
 
     return os.path.normpath(current_file).replace("\\", "/")
-
-
-def work_root(session):
-
-    work_dir = session["AYON_WORKDIR"]
-    scene_dir = session.get("AVALON_SCENEDIR")
-    if scene_dir:
-        path = os.path.join(work_dir, scene_dir)
-    else:
-        path = work_dir
-
-    return os.path.normpath(path).replace("\\", "/")

--- a/client/ayon_core/hosts/photoshop/api/pipeline.py
+++ b/client/ayon_core/hosts/photoshop/api/pipeline.py
@@ -63,9 +63,6 @@ class PhotoshopHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
         return None
 
-    def work_root(self, session):
-        return os.path.normpath(session["AYON_WORKDIR"]).replace("\\", "/")
-
     def open_workfile(self, filepath):
         lib.stub().open(filepath)
 

--- a/client/ayon_core/hosts/resolve/api/__init__.py
+++ b/client/ayon_core/hosts/resolve/api/__init__.py
@@ -58,8 +58,7 @@ from .workio import (
     save_file,
     current_file,
     has_unsaved_changes,
-    file_extensions,
-    work_root
+    file_extensions
 )
 
 from .testing_utils import TestGUI
@@ -127,7 +126,6 @@ __all__ = [
     "current_file",
     "has_unsaved_changes",
     "file_extensions",
-    "work_root",
 
     "TestGUI"
 ]

--- a/client/ayon_core/hosts/resolve/api/pipeline.py
+++ b/client/ayon_core/hosts/resolve/api/pipeline.py
@@ -27,7 +27,6 @@ from .workio import (
     save_file,
     file_extensions,
     has_unsaved_changes,
-    work_root,
     current_file
 )
 
@@ -77,9 +76,6 @@ class ResolveHost(HostBase, IWorkfileHost, ILoadHost):
 
     def save_workfile(self, filepath=None):
         return save_file(filepath)
-
-    def work_root(self, session):
-        return work_root(session)
 
     def get_current_workfile(self):
         return current_file()

--- a/client/ayon_core/hosts/resolve/api/workio.py
+++ b/client/ayon_core/hosts/resolve/api/workio.py
@@ -90,7 +90,3 @@ def current_file():
     # return current file path if it exists
     if os.path.exists(current_file_path):
         return os.path.normpath(current_file_path)
-
-
-def work_root(session):
-    return os.path.normpath(session["AYON_WORKDIR"]).replace("\\", "/")

--- a/client/ayon_core/hosts/tvpaint/api/pipeline.py
+++ b/client/ayon_core/hosts/tvpaint/api/pipeline.py
@@ -155,9 +155,6 @@ class TVPaintHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         george_script = "tv_SaveProject {}".format(filepath.replace("\\", "/"))
         return execute_george(george_script)
 
-    def work_root(self, session):
-        return session["AYON_WORKDIR"]
-
     def get_current_workfile(self):
         return execute_george("tv_GetProjectName")
 


### PR DESCRIPTION
## Changelog Description
There was a functionality to modify workfile directory by calling `work_root` on host but it is no longer possible now. Although the functions are still implemented, the workfile tool does not use it.
This PR is to remove the unused function.
Hosts needed to be tested:
- [x] blender
- [ ] flame
- [x] fusion
- [ ] harmony
- [ ] hiero
- [x] maya
- [ ] nuke
- [x] photoshop
- [ ] resolve
- [ ] tvpaint
## Additional info
There might be an issue for maya as it uses the mel file to determine workfile directory

## Testing notes:
1. Launch the app
2. Try to browse, save and open workfile via workfile tool
3. It should be browsing/saving/opening the correct workfile directory as usual
