### PR TITLE
Chore: Better context entity getter function

### DIFF
--- a/client/ayon_core/hosts/fusion/api/lib.py
+++ b/client/ayon_core/hosts/fusion/api/lib.py
@@ -7,7 +7,7 @@ from ayon_core.lib import Logger
 
 from ayon_core.pipeline import registered_host
 from ayon_core.pipeline.create import CreateContext
-from ayon_core.pipeline.context_tools import get_current_project_folder
+from ayon_core.pipeline.context_tools import get_current_folder_entity
 
 self = sys.modules[__name__]
 self._project = None
@@ -57,7 +57,7 @@ def update_frame_range(start, end, comp=None, set_render_range=True,
 def set_current_context_framerange(folder_entity=None):
     """Set Comp's frame range based on current folder."""
     if folder_entity is None:
-        folder_entity = get_current_project_folder(
+        folder_entity = get_current_folder_entity(
             fields={"attrib.frameStart",
                     "attrib.frameEnd",
                     "attrib.handleStart",
@@ -76,7 +76,7 @@ def set_current_context_framerange(folder_entity=None):
 def set_current_context_fps(folder_entity=None):
     """Set Comp's frame rate (FPS) to based on current asset"""
     if folder_entity is None:
-        folder_entity = get_current_project_folder(fields={"attrib.fps"})
+        folder_entity = get_current_folder_entity(fields={"attrib.fps"})
 
     fps = float(folder_entity["attrib"].get("fps", 24.0))
     comp = get_current_comp()
@@ -88,7 +88,7 @@ def set_current_context_fps(folder_entity=None):
 def set_current_context_resolution(folder_entity=None):
     """Set Comp's resolution width x height default based on current folder"""
     if folder_entity is None:
-        folder_entity = get_current_project_folder(
+        folder_entity = get_current_folder_entity(
             fields={"attrib.resolutionWidth", "attrib.resolutionHeight"})
 
     folder_attributes = folder_entity["attrib"]
@@ -124,7 +124,7 @@ def validate_comp_prefs(comp=None, force_repair=False):
         "attrib.resolutionHeight",
         "attrib.pixelAspect",
     }
-    folder_entity = get_current_project_folder(fields=fields)
+    folder_entity = get_current_folder_entity(fields=fields)
     folder_path = folder_entity["path"]
     folder_attributes = folder_entity["attrib"]
 
@@ -389,7 +389,7 @@ def prompt_reset_context():
         return None
 
     options = dialog.get_values()
-    folder_entity = get_current_project_folder()
+    folder_entity = get_current_folder_entity()
     if options["frame_range"]:
         set_current_context_framerange(folder_entity)
 

--- a/client/ayon_core/hosts/harmony/api/pipeline.py
+++ b/client/ayon_core/hosts/harmony/api/pipeline.py
@@ -13,7 +13,7 @@ from ayon_core.pipeline import (
     AVALON_CONTAINER_ID,
 )
 from ayon_core.pipeline.load import get_outdated_containers
-from ayon_core.pipeline.context_tools import get_current_project_folder
+from ayon_core.pipeline.context_tools import get_current_folder_entity
 
 from ayon_core.hosts.harmony import HARMONY_ADDON_ROOT
 import ayon_core.hosts.harmony.api as harmony
@@ -50,7 +50,7 @@ def get_current_context_settings():
 
     """
 
-    folder_entity = get_current_project_folder()
+    folder_entity = get_current_folder_entity()
     folder_attributes = folder_entity["attrib"]
 
     fps = folder_attributes.get("fps")

--- a/client/ayon_core/hosts/houdini/api/lib.py
+++ b/client/ayon_core/hosts/houdini/api/lib.py
@@ -22,7 +22,7 @@ from ayon_core.pipeline import (
 )
 from ayon_core.pipeline.create import CreateContext
 from ayon_core.pipeline.template_data import get_template_data
-from ayon_core.pipeline.context_tools import get_current_project_folder
+from ayon_core.pipeline.context_tools import get_current_folder_entity
 from ayon_core.tools.utils import PopupUpdateKeys, SimplePopup
 from ayon_core.tools.utils.host_tools import get_tool_by_name
 
@@ -39,7 +39,7 @@ def get_folder_fps(folder_entity=None):
     """Return current folder fps."""
 
     if folder_entity is None:
-        folder_entity = get_current_project_folder(fields=["attrib.fps"])
+        folder_entity = get_current_folder_entity(fields=["attrib.fps"])
     return folder_entity["attrib"]["fps"]
 
 
@@ -741,7 +741,7 @@ def set_camera_resolution(camera, folder_entity=None):
     """Apply resolution to camera from folder entity of the publish"""
 
     if not folder_entity:
-        folder_entity = get_current_project_folder()
+        folder_entity = get_current_folder_entity()
 
     resolution = get_resolution_from_folder(folder_entity)
 

--- a/client/ayon_core/hosts/houdini/plugins/inventory/set_camera_resolution.py
+++ b/client/ayon_core/hosts/houdini/plugins/inventory/set_camera_resolution.py
@@ -3,7 +3,7 @@ from ayon_core.hosts.houdini.api.lib import (
     get_camera_from_container,
     set_camera_resolution
 )
-from ayon_core.pipeline.context_tools import get_current_project_folder
+from ayon_core.pipeline.context_tools import get_current_folder_entity
 
 
 class SetCameraResolution(InventoryAction):
@@ -19,7 +19,7 @@ class SetCameraResolution(InventoryAction):
         )
 
     def process(self, containers):
-        folder_entity = get_current_project_folder()
+        folder_entity = get_current_folder_entity()
         for container in containers:
             node = container["node"]
             camera = get_camera_from_container(node)

--- a/client/ayon_core/hosts/max/api/lib.py
+++ b/client/ayon_core/hosts/max/api/lib.py
@@ -11,7 +11,7 @@ import ayon_api
 from ayon_core.pipeline import get_current_project_name, colorspace
 from ayon_core.settings import get_project_settings
 from ayon_core.pipeline.context_tools import (
-    get_current_project_folder,
+    get_current_folder_entity,
 )
 from ayon_core.style import load_stylesheet
 from pymxs import runtime as rt
@@ -222,7 +222,7 @@ def reset_scene_resolution():
     contains any information regarding scene resolution.
     """
 
-    folder_entity = get_current_project_folder(
+    folder_entity = get_current_folder_entity(
         fields={"attrib.resolutionWidth", "attrib.resolutionHeight"}
     )
     folder_attributes = folder_entity["attrib"]
@@ -243,7 +243,7 @@ def get_frame_range(folder_entiy=None) -> Union[Dict[str, Any], None]:
     """
     # Set frame start/end
     if folder_entiy is None:
-        folder_entiy = get_current_project_folder()
+        folder_entiy = get_current_folder_entity()
 
     folder_attributes = folder_entiy["attrib"]
     frame_start = folder_attributes.get("frameStart")

--- a/client/ayon_core/hosts/max/api/lib_rendersettings.py
+++ b/client/ayon_core/hosts/max/api/lib_rendersettings.py
@@ -3,7 +3,7 @@ from pymxs import runtime as rt
 from ayon_core.lib import Logger
 from ayon_core.settings import get_project_settings
 from ayon_core.pipeline import get_current_project_name
-from ayon_core.pipeline.context_tools import get_current_project_folder
+from ayon_core.pipeline.context_tools import get_current_folder_entity
 
 from ayon_core.hosts.max.api.lib import (
     set_render_frame_range,
@@ -57,7 +57,7 @@ class RenderSettings(object):
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
         # hard-coded, should be customized in the setting
-        folder_attributes = get_current_project_folder()["attrib"]
+        folder_attributes = get_current_folder_entity()["attrib"]
 
         # get project resolution
         width = folder_attributes.get("resolutionWidth")

--- a/client/ayon_core/hosts/maya/api/lib.py
+++ b/client/ayon_core/hosts/maya/api/lib.py
@@ -37,7 +37,7 @@ from ayon_core.pipeline import (
     AYON_CONTAINER_ID,
 )
 from ayon_core.lib import NumberDef
-from ayon_core.pipeline.context_tools import get_current_project_folder
+from ayon_core.pipeline.context_tools import get_current_folder_entity
 from ayon_core.pipeline.create import CreateContext
 from ayon_core.lib.profiles_filtering import filter_profiles
 
@@ -2631,7 +2631,7 @@ def reset_scene_resolution():
         None
     """
 
-    folder_attributes = get_current_project_folder()["attrib"]
+    folder_attributes = get_current_folder_entity()["attrib"]
 
     # Set resolution
     width = folder_attributes.get("resolutionWidth", 1920)
@@ -3240,7 +3240,7 @@ def update_content_on_context_change():
     This will update scene content to match new folder on context change
     """
     scene_sets = cmds.listSets(allSets=True)
-    folder_entity = get_current_project_folder()
+    folder_entity = get_current_folder_entity()
     folder_attributes = folder_entity["attrib"]
     new_folder_path = folder_entity["path"]
     for s in scene_sets:

--- a/client/ayon_core/hosts/maya/api/lib_rendersettings.py
+++ b/client/ayon_core/hosts/maya/api/lib_rendersettings.py
@@ -7,7 +7,7 @@ from ayon_core.lib import Logger
 from ayon_core.settings import get_project_settings
 
 from ayon_core.pipeline import CreatorError, get_current_project_name
-from ayon_core.pipeline.context_tools import get_current_project_folder
+from ayon_core.pipeline.context_tools import get_current_folder_entity
 from ayon_core.hosts.maya.api.lib import reset_frame_range
 
 
@@ -77,7 +77,7 @@ class RenderSettings(object):
             renderer = cmds.getAttr(
                 'defaultRenderGlobals.currentRenderer').lower()
 
-        folder_entity = get_current_project_folder()
+        folder_entity = get_current_folder_entity()
         folder_attributes = folder_entity["attrib"]
         # project_settings/maya/create/CreateRender/aov_separator
         try:

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_maya_units.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_maya_units.py
@@ -3,7 +3,7 @@ import maya.cmds as cmds
 import pyblish.api
 
 import ayon_core.hosts.maya.api.lib as mayalib
-from ayon_core.pipeline.context_tools import get_current_project_folder
+from ayon_core.pipeline.context_tools import get_current_folder_entity
 from ayon_core.pipeline.publish import (
     RepairContextAction,
     ValidateSceneOrder,
@@ -132,5 +132,5 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin,
 
         cls.log.info("Setting time unit to match project")
         # TODO replace query with using 'context.data["folderEntity"]'
-        folder_entity = get_current_project_folder()
+        folder_entity = get_current_folder_entity()
         mayalib.set_scene_fps(folder_entity["attrib"]["fps"])

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_maya_units.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_maya_units.py
@@ -3,7 +3,6 @@ import maya.cmds as cmds
 import pyblish.api
 
 import ayon_core.hosts.maya.api.lib as mayalib
-from ayon_core.pipeline.context_tools import get_current_folder_entity
 from ayon_core.pipeline.publish import (
     RepairContextAction,
     ValidateSceneOrder,
@@ -131,6 +130,5 @@ class ValidateMayaUnits(pyblish.api.ContextPlugin,
         cls.log.debug(current_linear)
 
         cls.log.info("Setting time unit to match project")
-        # TODO replace query with using 'context.data["folderEntity"]'
-        folder_entity = get_current_folder_entity()
+        folder_entity = context.data["folderEntity"]
         mayalib.set_scene_fps(folder_entity["attrib"]["fps"])

--- a/client/ayon_core/hosts/unreal/plugins/load/load_animation.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_animation.py
@@ -8,7 +8,7 @@ from unreal import EditorAssetLibrary
 from unreal import MovieSceneSkeletalAnimationTrack
 from unreal import MovieSceneSkeletalAnimationSection
 
-from ayon_core.pipeline.context_tools import get_current_project_folder
+from ayon_core.pipeline.context_tools import get_current_folder_entity
 from ayon_core.pipeline import (
     get_representation_path,
     AYON_CONTAINER_ID
@@ -53,7 +53,7 @@ class AnimationFBXLoader(plugin.Loader):
         if not actor:
             return None
 
-        folder_entity = get_current_project_folder(fields=["attrib.fps"])
+        folder_entity = get_current_folder_entity(fields=["attrib.fps"])
 
         task.set_editor_property('filename', path)
         task.set_editor_property('destination_path', asset_dir)
@@ -256,7 +256,7 @@ class AnimationFBXLoader(plugin.Loader):
         repre_entity = context["representation"]
         folder_name = container["asset_name"]
         source_path = get_representation_path(repre_entity)
-        folder_entity = get_current_project_folder(fields=["attrib.fps"])
+        folder_entity = get_current_folder_entity(fields=["attrib.fps"])
         destination_path = container["namespace"]
 
         task = unreal.AssetImportTask()

--- a/client/ayon_core/hosts/unreal/plugins/load/load_layout.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_layout.py
@@ -25,7 +25,7 @@ from ayon_core.pipeline import (
     AYON_CONTAINER_ID,
     get_current_project_name,
 )
-from ayon_core.pipeline.context_tools import get_current_project_folder
+from ayon_core.pipeline.context_tools import get_current_folder_entity
 from ayon_core.settings import get_current_project_settings
 from ayon_core.hosts.unreal.api import plugin
 from ayon_core.hosts.unreal.api.pipeline import (
@@ -169,7 +169,7 @@ class LayoutLoader(plugin.Loader):
 
         anim_path = f"{asset_dir}/animations/{anim_file_name}"
 
-        folder_entity = get_current_project_folder()
+        folder_entity = get_current_folder_entity()
         # Import animation
         task = unreal.AssetImportTask()
         task.options = unreal.FbxImportUI()

--- a/client/ayon_core/pipeline/context_tools.py
+++ b/client/ayon_core/pipeline/context_tools.py
@@ -411,6 +411,40 @@ def get_current_folder_entity(fields=None):
     )
 
 
+def get_current_task_entity(fields=None):
+    """Helper function to get task entity based on current context.
+
+    This function should be called only in process where host is installed.
+
+    Task is found out based on current project name, folder path
+        and task name.
+
+    Args:
+        fields (Optional[Iterable[str]]): Limit returned data of task entity
+            to specific keys.
+
+    Returns:
+        Union[dict[str, Any], None]: Task entity or None.
+
+    """
+    context = get_current_context()
+    project_name = context["project_name"]
+    folder_path = context["folder_path"]
+    task_name = context["task_name"]
+
+    # Skip if is not set even on context
+    if not project_name or not folder_path or not task_name:
+        return None
+    folder_entity = ayon_api.get_folder_by_path(
+        project_name, folder_path, fields={"id"}
+    )
+    if not folder_entity:
+        return None
+    return ayon_api.get_task_by_name(
+        project_name, folder_entity["id"], task_name, fields=fields
+    )
+
+
 def is_representation_from_latest(representation):
     """Return whether the representation is from latest version
 

--- a/client/ayon_core/pipeline/context_tools.py
+++ b/client/ayon_core/pipeline/context_tools.py
@@ -384,37 +384,28 @@ def get_current_project_entity(fields=None):
     return ayon_api.get_project(project_name, fields=fields)
 
 
-def get_current_project_folder(folder_path=None, folder_id=None, fields=None):
+def get_current_folder_entity(fields=None):
     """Helper function to get folder entity based on current context.
 
     This function should be called only in process where host is installed.
 
-    Folder is found out based on passed folder path or id (not both). Folder
-    path is not used for filtering if folder id is passed. When both
-    folder path and id are missing then current folder path is used.
+    Folder is found out based on current project name and folder path.
 
     Args:
-        folder_path (Union[str, None]): Folder path used for filter.
-        folder_id (Union[str, None]): Folder id. If entered then
-            is used as only filter.
         fields (Optional[Iterable[str]]): Limit returned data of folder entity
             to specific keys.
 
     Returns:
-        Union[dict[str, Any], None]: Fodler entity or None.
+        Union[dict[str, Any], None]: Folder entity or None.
+
     """
+    context = get_current_context()
+    project_name = context["project_name"]
+    folder_path = context["folder_path"]
 
-    project_name = get_current_project_name()
-    if folder_id:
-        return ayon_api.get_folder_by_id(
-            project_name, folder_id, fields=fields
-        )
-
-    if not folder_path:
-        folder_path = get_current_folder_path()
-        # Skip if is not set even on context
-        if not folder_path:
-            return None
+    # Skip if is not set even on context
+    if not project_name or not folder_path:
+        return None
     return ayon_api.get_folder_by_path(
         project_name, folder_path, fields=fields
     )

--- a/client/ayon_core/pipeline/context_tools.py
+++ b/client/ayon_core/pipeline/context_tools.py
@@ -389,7 +389,7 @@ def get_current_folder_entity(fields=None):
 
     This function should be called only in process where host is installed.
 
-    Folder is found out based on current project name and folder path.
+    Folder is based on current context project name and folder path.
 
     Args:
         fields (Optional[Iterable[str]]): Limit returned data of folder entity
@@ -416,7 +416,7 @@ def get_current_task_entity(fields=None):
 
     This function should be called only in process where host is installed.
 
-    Task is found out based on current project name, folder path
+    Task is based on current context project name, folder path
         and task name.
 
     Args:


### PR DESCRIPTION
## Changelog Description
Use more suitable function name to get current folder entity and added function to get current task entity.

## Additional info
The function `get_current_folder_entity` was intended to be also used to get different folder from current project, but it not used that way so that part was removed, which gave option to use more suitable name of the function.

Current task entity funcion is not trivial and must call twice to get the task entity, that might change with new ayon api.

## Testing notes:
1. Validate my reasoning is correct.
2. All usage of the function should be replaced.
