### PR TITLE
Chore: Use project name from context to get settings

### DIFF
--- a/client/ayon_core/plugins/publish/collect_settings.py
+++ b/client/ayon_core/plugins/publish/collect_settings.py
@@ -10,6 +10,9 @@ class CollectSettings(api.ContextPlugin):
 
     def process(self, context):
         project_name = context.data["projectName"]
+        self.log.debug(
+            "Collecting settings for project: {}".format(project_name)
+        )
         project_settings = get_project_settings(project_name)
         context.data["project_settings"] = project_settings
         context.data["projectSettings"] = project_settings

--- a/client/ayon_core/plugins/publish/collect_settings.py
+++ b/client/ayon_core/plugins/publish/collect_settings.py
@@ -1,5 +1,5 @@
 from pyblish import api
-from ayon_core.settings import get_current_project_settings
+from ayon_core.settings import get_project_settings
 
 
 class CollectSettings(api.ContextPlugin):
@@ -9,4 +9,7 @@ class CollectSettings(api.ContextPlugin):
     label = "Collect Settings"
 
     def process(self, context):
-        context.data["project_settings"] = get_current_project_settings()
+        project_name = context.data["projectName"]
+        project_settings = get_project_settings(project_name)
+        context.data["project_settings"] = project_settings
+        context.data["projectSettings"] = project_settings


### PR DESCRIPTION
## Changelog Description
Use `"projectName"` value to get settings instead of `get_current_project_settings`.

## Additional info
This is technical change, we should make sure the project which is set in context is used as source of truth for publishing.

## Testing notes:
1. Settings are collected as before.
