### PR TITLE
Settings: Fix class name typos `Pugin` to `Plugin`

### DIFF
--- a/server_addon/blender/server/settings/main.py
+++ b/server_addon/blender/server/settings/main.py
@@ -6,7 +6,7 @@ from ayon_server.settings import (
 
 from .imageio import BlenderImageIOModel
 from .publish_plugins import (
-    PublishPuginsModel,
+    PublishPluginsModel,
     DEFAULT_BLENDER_PUBLISH_SETTINGS
 )
 from .render_settings import (
@@ -47,8 +47,8 @@ class BlenderSettings(BaseSettingsModel):
         default_factory=TemplateWorkfileBaseOptions,
         title="Workfile Builder"
     )
-    publish: PublishPuginsModel = SettingsField(
-        default_factory=PublishPuginsModel,
+    publish: PublishPluginsModel = SettingsField(
+        default_factory=PublishPluginsModel,
         title="Publish Plugins"
     )
 

--- a/server_addon/blender/server/settings/publish_plugins.py
+++ b/server_addon/blender/server/settings/publish_plugins.py
@@ -66,7 +66,7 @@ class ExtractPlayblastModel(BaseSettingsModel):
         return validate_json_dict(value)
 
 
-class PublishPuginsModel(BaseSettingsModel):
+class PublishPluginsModel(BaseSettingsModel):
     ValidateCameraZeroKeyframe: ValidatePluginModel = SettingsField(
         default_factory=ValidatePluginModel,
         title="Validate Camera Zero Keyframe",

--- a/server_addon/celaction/server/settings.py
+++ b/server_addon/celaction/server/settings.py
@@ -42,7 +42,7 @@ class WorkfileModel(BaseSettingsModel):
     )
 
 
-class PublishPuginsModel(BaseSettingsModel):
+class PublishPluginsModel(BaseSettingsModel):
     CollectRenderPath: CollectRenderPathModel = SettingsField(
         default_factory=CollectRenderPathModel,
         title="Collect Render Path"
@@ -57,8 +57,8 @@ class CelActionSettings(BaseSettingsModel):
     workfile: WorkfileModel = SettingsField(
         title="Workfile"
     )
-    publish: PublishPuginsModel = SettingsField(
-        default_factory=PublishPuginsModel,
+    publish: PublishPluginsModel = SettingsField(
+        default_factory=PublishPluginsModel,
         title="Publish plugins",
     )
 

--- a/server_addon/flame/server/settings/create_plugins.py
+++ b/server_addon/flame/server/settings/create_plugins.py
@@ -87,7 +87,7 @@ class CreateShotClipModel(BaseSettingsModel):
     )
 
 
-class CreatePuginsModel(BaseSettingsModel):
+class CreatePluginsModel(BaseSettingsModel):
     CreateShotClip: CreateShotClipModel = SettingsField(
         default_factory=CreateShotClipModel,
         title="Create Shot Clip"

--- a/server_addon/flame/server/settings/main.py
+++ b/server_addon/flame/server/settings/main.py
@@ -1,8 +1,8 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
 from .imageio import FlameImageIOModel, DEFAULT_IMAGEIO_SETTINGS
-from .create_plugins import CreatePuginsModel, DEFAULT_CREATE_SETTINGS
-from .publish_plugins import PublishPuginsModel, DEFAULT_PUBLISH_SETTINGS
+from .create_plugins import CreatePluginsModel, DEFAULT_CREATE_SETTINGS
+from .publish_plugins import PublishPluginsModel, DEFAULT_PUBLISH_SETTINGS
 from .loader_plugins import LoaderPluginsModel, DEFAULT_LOADER_SETTINGS
 
 
@@ -11,12 +11,12 @@ class FlameSettings(BaseSettingsModel):
         default_factory=FlameImageIOModel,
         title="Color Management (ImageIO)"
     )
-    create: CreatePuginsModel = SettingsField(
-        default_factory=CreatePuginsModel,
+    create: CreatePluginsModel = SettingsField(
+        default_factory=CreatePluginsModel,
         title="Create plugins"
     )
-    publish: PublishPuginsModel = SettingsField(
-        default_factory=PublishPuginsModel,
+    publish: PublishPluginsModel = SettingsField(
+        default_factory=PublishPluginsModel,
         title="Publish plugins"
     )
     load: LoaderPluginsModel = SettingsField(

--- a/server_addon/flame/server/settings/publish_plugins.py
+++ b/server_addon/flame/server/settings/publish_plugins.py
@@ -121,7 +121,7 @@ class IntegrateBatchGroupModel(BaseSettingsModel):
     )
 
 
-class PublishPuginsModel(BaseSettingsModel):
+class PublishPluginsModel(BaseSettingsModel):
     CollectTimelineInstances: CollectTimelineInstancesModel = SettingsField(
         default_factory=CollectTimelineInstancesModel,
         title="Collect Timeline Instances"

--- a/server_addon/hiero/server/settings/loader_plugins.py
+++ b/server_addon/hiero/server/settings/loader_plugins.py
@@ -15,7 +15,7 @@ class LoadClipModel(BaseSettingsModel):
     )
 
 
-class LoaderPuginsModel(BaseSettingsModel):
+class LoaderPluginsModel(BaseSettingsModel):
     LoadClip: LoadClipModel = SettingsField(
         default_factory=LoadClipModel,
         title="Load Clip"

--- a/server_addon/hiero/server/settings/main.py
+++ b/server_addon/hiero/server/settings/main.py
@@ -9,11 +9,11 @@ from .create_plugins import (
     DEFAULT_CREATE_SETTINGS
 )
 from .loader_plugins import (
-    LoaderPuginsModel,
+    LoaderPluginsModel,
     DEFAULT_LOADER_PLUGINS_SETTINGS
 )
 from .publish_plugins import (
-    PublishPuginsModel,
+    PublishPluginsModel,
     DEFAULT_PUBLISH_PLUGIN_SETTINGS
 )
 from .scriptsmenu import (
@@ -35,12 +35,12 @@ class HieroSettings(BaseSettingsModel):
         default_factory=CreatorPluginsSettings,
         title="Creator Plugins",
     )
-    load: LoaderPuginsModel = SettingsField(
-        default_factory=LoaderPuginsModel,
+    load: LoaderPluginsModel = SettingsField(
+        default_factory=LoaderPluginsModel,
         title="Loader plugins"
     )
-    publish: PublishPuginsModel = SettingsField(
-        default_factory=PublishPuginsModel,
+    publish: PublishPluginsModel = SettingsField(
+        default_factory=PublishPluginsModel,
         title="Publish plugins"
     )
     scriptsmenu: ScriptsmenuSettings = SettingsField(

--- a/server_addon/hiero/server/settings/publish_plugins.py
+++ b/server_addon/hiero/server/settings/publish_plugins.py
@@ -49,7 +49,7 @@ class ExtractReviewCutUpVideoModel(BaseSettingsModel):
     )
 
 
-class PublishPuginsModel(BaseSettingsModel):
+class PublishPluginsModel(BaseSettingsModel):
     CollectInstanceVersion: CollectInstanceVersionModel = SettingsField(
         default_factory=CollectInstanceVersionModel,
         title="Collect Instance Version"

--- a/server_addon/nuke/server/settings/loader_plugins.py
+++ b/server_addon/nuke/server/settings/loader_plugins.py
@@ -42,7 +42,7 @@ class LoadClipModel(BaseSettingsModel):
     )
 
 
-class LoaderPuginsModel(BaseSettingsModel):
+class LoaderPluginsModel(BaseSettingsModel):
     LoadImage: LoadImageModel = SettingsField(
         default_factory=LoadImageModel,
         title="Load Image"

--- a/server_addon/nuke/server/settings/main.py
+++ b/server_addon/nuke/server/settings/main.py
@@ -28,11 +28,11 @@ from .create_plugins import (
     DEFAULT_CREATE_SETTINGS
 )
 from .publish_plugins import (
-    PublishPuginsModel,
+    PublishPluginsModel,
     DEFAULT_PUBLISH_PLUGIN_SETTINGS
 )
 from .loader_plugins import (
-    LoaderPuginsModel,
+    LoaderPluginsModel,
     DEFAULT_LOADER_PLUGINS_SETTINGS
 )
 from .workfile_builder import (
@@ -75,13 +75,13 @@ class NukeSettings(BaseSettingsModel):
         title="Creator Plugins",
     )
 
-    publish: PublishPuginsModel = SettingsField(
-        default_factory=PublishPuginsModel,
+    publish: PublishPluginsModel = SettingsField(
+        default_factory=PublishPluginsModel,
         title="Publish Plugins",
     )
 
-    load: LoaderPuginsModel = SettingsField(
-        default_factory=LoaderPuginsModel,
+    load: LoaderPluginsModel = SettingsField(
+        default_factory=LoaderPluginsModel,
         title="Loader Plugins",
     )
 

--- a/server_addon/nuke/server/settings/publish_plugins.py
+++ b/server_addon/nuke/server/settings/publish_plugins.py
@@ -219,7 +219,7 @@ class IncrementScriptVersionModel(BaseSettingsModel):
     active: bool = SettingsField(title="Active")
 
 
-class PublishPuginsModel(BaseSettingsModel):
+class PublishPluginsModel(BaseSettingsModel):
     CollectInstanceData: CollectInstanceDataModel = SettingsField(
         title="Collect Instance Version",
         default_factory=CollectInstanceDataModel,

--- a/server_addon/resolve/server/settings.py
+++ b/server_addon/resolve/server/settings.py
@@ -69,7 +69,7 @@ class CreateShotClipModels(BaseSettingsModel):
     )
 
 
-class CreatorPuginsModel(BaseSettingsModel):
+class CreatorPluginsModel(BaseSettingsModel):
     CreateShotClip: CreateShotClipModels = SettingsField(
         default_factory=CreateShotClipModels,
         title="Create Shot Clip"
@@ -84,8 +84,8 @@ class ResolveSettings(BaseSettingsModel):
         default_factory=ResolveImageIOModel,
         title="Color Management (ImageIO)"
     )
-    create: CreatorPuginsModel = SettingsField(
-        default_factory=CreatorPuginsModel,
+    create: CreatorPluginsModel = SettingsField(
+        default_factory=CreatorPluginsModel,
         title="Creator plugins",
     )
 


### PR DESCRIPTION
## Changelog Description

Fix class name typos `Pugin` to `Plugin` in settings.

## Additional info

Since this does not change the field names this shouldn't actually influence the stored settings - right? @iLLiCiTiT @martastain
If so, I wouldn't bother bumping server addon versions either.

## Testing notes:

1. Settings should still work