### PR TITLE
Applications: Disable applications addon if does not have settings available

### DIFF
--- a/client/ayon_core/addons/applications/ayon_applications/addon.py
+++ b/client/ayon_core/addons/applications/ayon_applications/addon.py
@@ -11,6 +11,10 @@ from .manager import ApplicationManager
 class ApplicationsAddon(AYONAddon, IPluginPaths):
     name = "applications"
 
+    def initialize(self, settings):
+        # TODO remove when addon is removed from ayon-core
+        self.enabled = self.name in settings
+
     def get_app_environments_for_context(
         self,
         project_name,


### PR DESCRIPTION
## Changelog Description
Disable applications addon if does not have available settings (addon is disabled on server).

## Additional info
The client addon would crash if server would be disabled.
