### PR TITLE
Chore: Added more keys for folder template data

### DIFF
--- a/client/ayon_core/pipeline/template_data.py
+++ b/client/ayon_core/pipeline/template_data.py
@@ -74,7 +74,7 @@ def get_folder_template_data(folder_entity, project_name):
                       project
 
     Required document fields:
-        Folder: 'path' -> Plan to require: 'folderType'
+        Folder: 'path', 'folderType'
 
     Args:
         folder_entity (Dict[str, Any]): Folder entity.
@@ -101,6 +101,10 @@ def get_folder_template_data(folder_entity, project_name):
     return {
         "folder": {
             "name": folder_name,
+            "path": path,
+            "type": folder_entity["folderType"],
+            "parents": hierarchy,
+            "parent": parent_name,
         },
         "asset": folder_name,
         "hierarchy": hierarchy,

--- a/client/ayon_core/plugins/publish/collect_anatomy_instance_data.py
+++ b/client/ayon_core/plugins/publish/collect_anatomy_instance_data.py
@@ -399,6 +399,10 @@ class CollectAnatomyInstanceData(pyblish.api.ContextPlugin):
                 "parent": parent_name,
                 "folder": {
                     "name": folder_name,
+                    "path": folder_path,
+                    "type": folder_entity["folderType"],
+                    "parent": parent_name,
+                    "parents": hierarchy,
                 },
             })
             return
@@ -411,13 +415,18 @@ class CollectAnatomyInstanceData(pyblish.api.ContextPlugin):
             if hierarchy:
                 parent_name = hierarchy.split("/")[-1]
 
-            folder_name = instance.data["folderPath"].split("/")[-1]
+            folder_path = instance.data["folderPath"]
+            folder_name = folder_path.split("/")[-1]
             anatomy_data.update({
                 "asset": folder_name,
                 "hierarchy": hierarchy,
                 "parent": parent_name,
                 "folder": {
                     "name": folder_name,
+                    "path": folder_path,
+                    "type": "Shot",
+                    "parent": parent_name,
+                    "parents": hierarchy,
                 },
             })
 


### PR DESCRIPTION
## Changelog Description
Proposal of new keys available in folder dictionary.

## Additional info
Added new keys under folder template data. First obvious is `"type"` where is folder type. Key `"path"` is just a folder path, `"parent"` is name of parent which is project if direct parent is folder, `"parents"` is what `"hirarchy"` was.

Any comments, ideas, confrontations welcommed.