### PR TITLE
Maya: Validate node ids in database, query folder ids once

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_in_database.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_in_database.py
@@ -37,8 +37,8 @@ class ValidateNodeIdsInDatabase(pyblish.api.InstancePlugin):
         invalid = self.get_invalid(instance)
         if invalid:
             raise PublishValidationError(
-                ("Found folder ids which are not related to "
-                 "current project in instance: `{}`").format(instance.name))
+                "Found folder ids which are not related to "
+                "current project in instance: `{}`".format(instance.name))
 
     @classmethod
     def get_invalid(cls, instance):

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_in_database.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_in_database.py
@@ -50,12 +50,7 @@ class ValidateNodeIdsInDatabase(pyblish.api.InstancePlugin):
                                                       nodes=instance[:])
 
         # check ids against database ids
-        project_name = instance.context.data["projectName"]
-        folder_entities = ayon_api.get_folders(project_name, fields={"id"})
-        folder_ids = {
-            folder_entity["id"]
-            for folder_entity in folder_entities
-        }
+        folder_ids = cls.get_project_folder_ids(context=instance.context)
 
         # Get all asset IDs
         for node in id_required_nodes:
@@ -71,3 +66,22 @@ class ValidateNodeIdsInDatabase(pyblish.api.InstancePlugin):
                 invalid.append(node)
 
         return invalid
+
+    @classmethod
+    def get_project_folder_ids(cls, context):
+        # We query the database only for the first instance instead of
+        # per instance by storing a cache in the context
+        key = "__cache_project_folders_ids"
+        if key in context.data:
+            return context.data[key]
+
+        # check ids against database
+        project_name = context.data["projectName"]
+        folder_entities = ayon_api.get_folders(project_name, fields={"id"})
+        folder_ids = {
+            folder_entity["id"]
+            for folder_entity in folder_entities
+        }
+
+        context.data[key] = folder_ids
+        return folder_ids

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_in_database.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_in_database.py
@@ -70,6 +70,15 @@ class ValidateNodeIdsInDatabase(pyblish.api.InstancePlugin):
 
     @classmethod
     def get_project_folder_ids(cls, context):
+        """Return all folder ids in the current project.
+
+        Arguments:
+            context (pyblish.api.Context): The publish context.
+
+        Returns:
+            set[str]: All folder ids in the current project.
+
+        """
         # We query the database only for the first instance instead of
         # per instance by storing a cache in the context
         key = "__cache_project_folders_ids"

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_in_database.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_in_database.py
@@ -43,16 +43,17 @@ class ValidateNodeIdsInDatabase(pyblish.api.InstancePlugin):
     @classmethod
     def get_invalid(cls, instance):
 
-        invalid = []
-
         # Get all id required nodes
         id_required_nodes = lib.get_id_required_nodes(referenced_nodes=True,
                                                       nodes=instance[:])
+        if not id_required_nodes:
+            return []
 
         # check ids against database ids
         folder_ids = cls.get_project_folder_ids(context=instance.context)
 
         # Get all asset IDs
+        invalid = []
         for node in id_required_nodes:
             cb_id = lib.get_id(node)
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_in_database.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_in_database.py
@@ -43,9 +43,13 @@ class ValidateNodeIdsInDatabase(pyblish.api.InstancePlugin):
     @classmethod
     def get_invalid(cls, instance):
 
+        nodes = instance[:]
+        if not nodes:
+            return
+
         # Get all id required nodes
         id_required_nodes = lib.get_id_required_nodes(referenced_nodes=True,
-                                                      nodes=instance[:])
+                                                      nodes=nodes)
         if not id_required_nodes:
             return []
 

--- a/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_in_database.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_node_ids_in_database.py
@@ -81,7 +81,7 @@ class ValidateNodeIdsInDatabase(pyblish.api.InstancePlugin):
         """
         # We query the database only for the first instance instead of
         # per instance by storing a cache in the context
-        key = "__cache_project_folders_ids"
+        key = "__cache_project_folder_ids"
         if key in context.data:
             return context.data[key]
 


### PR DESCRIPTION
## Changelog Description

For the Validate Node Ids In Database validator cache the folder ids of the project on the first query so we don't need to query all folder ids in the current project per instance.

## Additional info

Also only query the database if the instance actually contains nodes that should have an id to begin with.

## Testing notes:

1. Validation of whether folder id in `cbId` (part before the `:`) is a valid folder id in current project should still work.
2. It should be faster for many instances.