### PR TITLE
Chore: remove deprecated loader action which does not work in AYON

### DIFF
--- a/client/ayon_core/pipeline/load/plugins.py
+++ b/client/ayon_core/pipeline/load/plugins.py
@@ -220,19 +220,6 @@ class LoaderPlugin(list):
         """
         return cls.options or []
 
-    @property
-    def fname(self):
-        """Backwards compatibility with deprecation warning"""
-
-        self.log.warning((
-            "DEPRECATION WARNING: Source - Loader plugin {}."
-            " The 'fname' property on the Loader plugin will be removed in"
-            " future versions of OpenPype. Planned version to drop the support"
-            " is 3.16.6 or 3.17.0."
-        ).format(self.__class__.__name__))
-        if hasattr(self, "_fname"):
-            return self._fname
-
 
 class ProductLoaderPlugin(LoaderPlugin):
     """Load product into host application


### PR DESCRIPTION
## Changelog Description
The functionality of `fname` removed as it isn't implemented in AYON anymore

## Additional info
n/a

## Testing notes:
1. Launch AYON
2. Test the loaders with any app
3. All assets should be loaded as expected