### PR TITLE
Maya: Account for no nodes in container

### DIFF
--- a/client/ayon_core/hosts/maya/api/workfile_template_builder.py
+++ b/client/ayon_core/hosts/maya/api/workfile_template_builder.py
@@ -286,7 +286,7 @@ class MayaPlaceholderLoadPlugin(PlaceholderPlugin, PlaceholderLoadMixin):
         if not container:
             return
 
-        roots = cmds.sets(container, q=True)
+        roots = cmds.sets(container, q=True) or []
         ref_node = None
         try:
             ref_node = get_reference_node(roots)


### PR DESCRIPTION
## Changelog Description
When builder a template with `renderSetup` product, this error would occur since `renderSetup` product now does not return any roots after https://github.com/ynput/ayon-core/pull/310;

```
# Error: AssertionError: file C:\Users\tokejepsen\ayon-core\client\ayon_core\hosts\maya\api\testing\tests.py line 251: Failed to process placeholder "|Context_rendersetup_folder_template_json" with plugin "MayaPlaceholderLoadPlugin"
# Traceback (most recent call last):
#   File "C:\Users\tokejepsen\ayon-core\client\ayon_core\pipeline\workfile\workfile_template_builder.py", line 717, in populate_scene_placeholders
#     placeholder_plugin.populate_placeholder(placeholder)
#   File "C:\Users\tokejepsen\ayon-core\client\ayon_core\hosts\maya\api\workfile_template_builder.py", line 246, in populate_placeholder
#     self.populate_load_placeholder(placeholder)
#   File "C:\Users\tokejepsen\ayon-core\client\ayon_core\pipeline\workfile\workfile_template_builder.py", line 1639, in populate_load_placeholder
#     self.load_succeed(placeholder, container)
#   File "C:\Users\tokejepsen\ayon-core\client\ayon_core\hosts\maya\api\workfile_template_builder.py", line 280, in load_succeed
#     self._parent_in_hierarchy(placeholder, container)
#   File "C:\Users\tokejepsen\ayon-core\client\ayon_core\hosts\maya\api\workfile_template_builder.py", line 302, in _parent_in_hierarchy
#     for root in roots:
# TypeError: 'NoneType' object is not iterable
```

## Testing notes:
1. Setup placeholder with `renderSetup` product in Maya.
2. Build the templated workfile.
