### PR TITLE
Workfiles tool: Fix update of context change

### DIFF
--- a/client/ayon_core/tools/workfiles/control.py
+++ b/client/ayon_core/tools/workfiles/control.py
@@ -659,16 +659,7 @@ class BaseWorkfileController(
             folder_id != self.get_current_folder_id()
             or task_name != self.get_current_task_name()
         ):
-            folder_entity = ayon_api.get_folder_by_id(
-                event_data["project_name"],
-                event_data["folder_id"],
-            )
-            task_entity = ayon_api.get_task_by_name(
-                event_data["project_name"],
-                event_data["folder_id"],
-                event_data["task_name"]
-            )
-            change_current_context(folder_entity, task_entity)
+            self._change_current_context(project_name, folder_id, task_id)
 
         self._host_open_workfile(filepath)
 
@@ -710,16 +701,8 @@ class BaseWorkfileController(
             folder_id != self.get_current_folder_id()
             or task_name != self.get_current_task_name()
         ):
-            folder_entity = ayon_api.get_folder_by_id(
-                project_name, folder["id"]
-            )
-            task_entity = ayon_api.get_task_by_name(
-                project_name, folder["id"], task_name
-            )
-            change_current_context(
-                folder_entity,
-                task_entity,
-                template_key=template_key
+            self._change_current_context(
+                project_name, folder_id, task_id, template_key
             )
 
         # Save workfile
@@ -745,3 +728,18 @@ class BaseWorkfileController(
         # Trigger after save events
         emit_event("workfile.save.after", event_data, source="workfiles.tool")
         self.reset()
+
+    def _change_current_context(
+        self, project_name, folder_id, task_id, template_key=None
+    ):
+        # Change current context
+        folder_entity = self.get_folder_entity(project_name, folder_id)
+        task_entity = self.get_task_entity(project_name, task_id)
+        change_current_context(
+            folder_entity,
+            task_entity,
+            template_key=template_key
+        )
+        self._current_folder_id = folder_entity["id"]
+        self._current_folder_path = folder_entity["path"]
+        self._current_task_name = task_entity["name"]

--- a/client/ayon_core/tools/workfiles/control.py
+++ b/client/ayon_core/tools/workfiles/control.py
@@ -727,7 +727,6 @@ class BaseWorkfileController(
 
         # Trigger after save events
         emit_event("workfile.save.after", event_data, source="workfiles.tool")
-        self.reset()
 
     def _change_current_context(
         self, project_name, folder_id, task_id, template_key=None


### PR DESCRIPTION
## Changelog Description
Context change is propagated correctly, because controller of workfiles tool does capture it correctly.

## Additional info
Change the context also in controller, and unify the context change into single method. Removed `reset` of controller on save as ( I'm not sure why the reset was there, probably only to update current context?).

### How to replicate (maybe)
1. Launch DCC -> Task 1.
2. Open workfiles tool.
3. Keep folder, and change task and open workfile. Must be `Open` not `Save as`. -> Task 2
4. Check current context in AYON menu
5. Open workfiles tool again.
6. Again keep folder, change task back to the first one. -> Task 1
7. Context in AYON menu should show context of Task 2

## Testing notes:
1. Workfile opened in same folder, but different task will change the context.

Resolves https://github.com/ynput/ayon-core/issues/180
