### PR TITLE
Maya: Create multiple "render" instances better error message

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/create/create_render.py
+++ b/client/ayon_core/hosts/maya/plugins/create/create_render.py
@@ -40,8 +40,15 @@ class CreateRenderlayer(plugin.RenderlayerCreator):
     def create(self, product_name, instance_data, pre_create_data):
         # Only allow a single render instance to exist
         if self._get_singleton_node():
-            raise CreatorError("A Render instance already exists - only "
-                               "one can be configured.")
+            raise CreatorError(
+                "A Render instance already exists - only one can be "
+                "configured.\n\n"
+                "To render multiple render layers, create extra Render Setup "
+                "Layers via Maya's Render Setup UI.\n"
+                "Then refresh the publisher to detect the new layers for "
+                "rendering.\n\n"
+                "With a render instance present all Render Setup layers in "
+                "your workfile are renderable instances.")
 
         # Apply default project render settings on create
         if self.render_settings.get("apply_render_settings"):


### PR DESCRIPTION
## Changelog Description

Provide better descriptive message on the creation failure when trying to create another "render" instance.

## Additional info

The render instance acts as a Singleton instance. When present all renderlayers in the scene are detected as renderable instances - this might not be clear for newcomers at first and they may expect that clicking Create again will in fact create more Render Setup layers. This improved message provides better guidance to new artists

Before:
![image](https://github.com/ynput/ayon-core/assets/2439881/c34a9a03-126f-41ba-b995-5992e5d4a824)

After:
![image](https://github.com/ynput/ayon-core/assets/2439881/eb04b597-00ff-47d2-9aaf-10148096d9e5)

## Testing notes:

1. Create a render instance.
2. Create it again. (You'll get the error message)
