### PR TITLE
Fix AYON shotgrid username passed to Deadline

### DIFF
--- a/client/ayon_core/hosts/hiero/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/hosts/hiero/plugins/publish/extract_thumbnail.py
@@ -4,12 +4,12 @@ import pyblish.api
 from ayon_core.pipeline import publish
 
 
-class ExtractThumnail(publish.Extractor):
+class ExtractThumbnail(publish.Extractor):
     """
-    Extractor for track item's tumnails
+    Extractor for track item's tumbnails
     """
 
-    label = "Extract Thumnail"
+    label = "Extract Thumbnail"
     order = pyblish.api.ExtractorOrder
     families = ["plate", "take"]
     hosts = ["hiero"]
@@ -48,7 +48,7 @@ class ExtractThumnail(publish.Extractor):
         self.log.debug(
             "__ thumb_path: `{}`, frame: `{}`".format(thumbnail, thumb_frame))
 
-        self.log.info("Thumnail was generated to: {}".format(thumb_path))
+        self.log.info("Thumbnail was generated to: {}".format(thumb_path))
         thumb_representation = {
             'files': thumb_file,
             'stagingDir': staging_dir,

--- a/client/ayon_core/modules/deadline/plugins/publish/submit_publish_cache_job.py
+++ b/client/ayon_core/modules/deadline/plugins/publish/submit_publish_cache_job.py
@@ -67,7 +67,7 @@ class ProcessSubmittedCacheJobOnFarm(pyblish.api.InstancePlugin,
         "FTRACK_SERVER",
         "AYON_APP_NAME",
         "AYON_USERNAME",
-        "OPENPYPE_SG_USER",
+        "AYON_SG_USERNAME",
         "KITSU_LOGIN",
         "KITSU_PWD"
     ]

--- a/client/ayon_core/modules/deadline/plugins/publish/submit_publish_job.py
+++ b/client/ayon_core/modules/deadline/plugins/publish/submit_publish_job.py
@@ -130,7 +130,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
         "FTRACK_SERVER",
         "AYON_APP_NAME",
         "AYON_USERNAME",
-        "OPENPYPE_SG_USER",
+        "AYON_SG_USERNAME",
         "KITSU_LOGIN",
         "KITSU_PWD"
     ]

--- a/client/ayon_core/modules/royalrender/plugins/publish/create_publish_royalrender_job.py
+++ b/client/ayon_core/modules/royalrender/plugins/publish/create_publish_royalrender_job.py
@@ -65,7 +65,7 @@ class CreatePublishRoyalRenderJob(pyblish.api.InstancePlugin,
         "FTRACK_SERVER",
         "AYON_APP_NAME",
         "AYON_USERNAME",
-        "OPENPYPE_SG_USER",
+        "AYON_SG_USERNAME",
     ]
     priority = 50
 


### PR DESCRIPTION
## Changelog Description
This fixes a long standing issue where the env var used to set the user to login as in Shotgrid in Deadline wasn't being passed, as reported here https://community.ynput.io/t/shotgrid-integration-addon/63/42

## Testing notes:
1. Submit a Shotgrid publish job to Deadline