### PR TITLE
Houdini local render: support adding review family to the render

### DIFF
--- a/client/ayon_core/hosts/houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/collect_local_render_instances.py
@@ -78,21 +78,20 @@ class CollectLocalRenderInstances(pyblish.api.InstancePlugin):
                 "productType": product_type,
                 "productName": product_name,
                 "productGroup": product_group,
-                "tags": [],
-                "families": ["render.local.hou"],
+                "families": ["render.local.hou", "review"],
                 "instance_node": instance.data["instance_node"],
                 "representations": [
                     {
                         "stagingDir": staging_dir,
                         "ext": ext,
                         "name": ext,
+                        "tags": ["review"],
                         "files": aov_filenames,
                         "frameStart": instance.data["frameStartHandle"],
                         "frameEnd": instance.data["frameEndHandle"]
                     }
                 ]
             })
-        self.log.debug(aov_instance.data)
 
         # Remove Mantra instance
         # I can't remove it here as I still need it to trigger the render.

--- a/client/ayon_core/hosts/houdini/plugins/publish/collect_review_data.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/collect_review_data.py
@@ -8,7 +8,8 @@ class CollectHoudiniReviewData(pyblish.api.InstancePlugin):
     label = "Collect Review Data"
     # This specific order value is used so that
     # this plugin runs after CollectRopFrameRange
-    order = pyblish.api.CollectorOrder + 0.1
+    # Also after CollectLocalRenderInstances
+    order = pyblish.api.CollectorOrder + 0.13
     hosts = ["houdini"]
     families = ["review"]
 
@@ -28,7 +29,8 @@ class CollectHoudiniReviewData(pyblish.api.InstancePlugin):
         ropnode_path = instance.data["instance_node"]
         ropnode = hou.node(ropnode_path)
 
-        camera_path = ropnode.parm("camera").eval()
+        # Get camera based on the instance_node type.
+        camera_path = self._get_camera_path(ropnode)
         camera_node = hou.node(camera_path)
         if not camera_node:
             self.log.warning("No valid camera node found on review node: "
@@ -55,3 +57,17 @@ class CollectHoudiniReviewData(pyblish.api.InstancePlugin):
         # Store focal length in `burninDataMembers`
         burnin_members = instance.data.setdefault("burninDataMembers", {})
         burnin_members["focalLength"] = focal_length
+
+    def _get_camera_path(self, ropnode):
+        if ropnode.type().name() in {
+            "opengl", "karma", "ifd", "arnold"
+        }:
+            return ropnode.parm("camera").eval()
+
+        elif ropnode.type().name() == "Redshift_ROP":
+            return ropnode.parm("RS_renderCamera").eval()
+
+        elif ropnode.type().name() == "vray_renderer":
+            return ropnode.parm("render_camera").eval()
+
+        return ""

--- a/client/ayon_core/hosts/houdini/plugins/publish/extract_opengl.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/extract_opengl.py
@@ -17,6 +17,10 @@ class ExtractOpenGL(publish.Extractor):
 
     def process(self, instance):
         ropnode = hou.node(instance.data.get("instance_node"))
+        if ropnode.type().name() != "opengl":
+            self.log.debug("Skipping OpenGl extraction. Rop node {} "
+                           "is not an OpenGl node.".format(ropnode.path()))
+            return
 
         output = ropnode.evalParm("picture")
         staging_dir = os.path.normpath(os.path.dirname(output))

--- a/client/ayon_core/hosts/houdini/plugins/publish/validate_review_colorspace.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/validate_review_colorspace.py
@@ -33,6 +33,13 @@ class ValidateReviewColorspace(pyblish.api.InstancePlugin,
 
     def process(self, instance):
 
+        rop_node = hou.node(instance.data["instance_node"])
+
+        if rop_node.type().name() != "opengl":
+            self.log.debug("Skipping Validation. Rop node {} "
+                           "is not an OpenGl node.".format(rop_node.path()))
+            return
+
         if not self.is_active(instance.data):
             return
 
@@ -43,7 +50,6 @@ class ValidateReviewColorspace(pyblish.api.InstancePlugin,
             )
             return
 
-        rop_node = hou.node(instance.data["instance_node"])
         if rop_node.evalParm("colorcorrect") != 2:
             # any colorspace settings other than default requires
             # 'Color Correct' parm to be set to 'OpenColorIO'

--- a/client/ayon_core/hosts/houdini/plugins/publish/validate_scene_review.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/validate_scene_review.py
@@ -19,6 +19,10 @@ class ValidateSceneReview(pyblish.api.InstancePlugin):
 
         report = []
         instance_node = hou.node(instance.data.get("instance_node"))
+        if instance_node.type().name() != "opengl":
+            self.log.debug("Skipping Validation. Rop node {} "
+                           "is not an OpenGl node.".format(instance_node.path()))
+            return
 
         invalid = self.get_invalid_scene_path(instance_node)
         if invalid:


### PR DESCRIPTION
## Changelog Description
support adding review family to the render
Follow up to https://github.com/ynput/ayon-core/pull/328

- [ ] To do: Make it optional.

## Additional Info
I'm not sure about my idea to add review family to render.
So, I made it here in a separate PR.

## Testing notes:
1. on testing https://github.com/ynput/ayon-core/pull/328
2. create a a render instance and select `"Local machine rendering"` or `"Use existing frames (local)"`
3. Published render should include a `mp4` file with burnins. 

## Demo
https://github.com/ynput/ayon-core/assets/20871534/f825205e-8073-4244-b0c5-240402c650d0


