### PR TITLE
Maya: Validate Model Content support for non-unique top group names

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/validate_model_content.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_model_content.py
@@ -79,7 +79,7 @@ class ValidateModelContent(pyblish.api.InstancePlugin,
             return [instance.data["instance_node"]]
 
         # Ensure single top group
-        top_parents = {x.split("|", 2)[1] for x in content_instance}
+        top_parents = {"|" + x.split("|", 2)[1] for x in content_instance}
         if cls.validate_top_group and len(top_parents) != 1:
             cls.log.error(
                 "A model instance must have exactly one top group. "


### PR DESCRIPTION
## Changelog Description

This fixes a bug that an error occurs when the top node name clashes with a child node's name.

## Additional info

To reproduce:

Create e.g.:
```
top_GRP|top_GRP|mesh_GEO
```

Publish the root `top_GRP` as the model.

(Of course this is a bad production example, but it's solely to reproduce the bug. It may also be `asset_GRP|asset_GRP` or whatever)

The issue can also be produced if e.g. `top_GRP` is present anywhere else in the scene that is not inside your current publishing instance, e.g. a temporary backup in the scene:

```
|top_GRP|mesh_GEO    <-- publish this `top_GRP` as model instance
|backup|top_GRP|mesh_GEO   <- artist may e.g. just have this in their workfile as "working data"
```

## Testing notes:

1. Create root node that clashes by node name to another node in the maya scene.
