### PR TITLE
Bugfix: Fix delivery action in tray loader

### DIFF
--- a/client/ayon_core/plugins/load/delivery.py
+++ b/client/ayon_core/plugins/load/delivery.py
@@ -291,10 +291,7 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         templates = {}
         for template_name, value in anatomy.templates["delivery"].items():
             directory_template = value["directory"]
-            if (
-                not isinstance(directory_template, str)
-                or not directory_template.startswith('{root')
-            ):
+            if not directory_template.startswith('{root'):
                 continue
 
             templates[template_name] = value

--- a/client/ayon_core/plugins/load/delivery.py
+++ b/client/ayon_core/plugins/load/delivery.py
@@ -294,7 +294,8 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
             if not directory_template.startswith("{root"):
                 self.log.warning(
                     "Skipping template '%s' because directory template does "
-                    "not start with `{root`", template_name
+                    "not start with `{root` in value: %s",
+                    template_name, directory_template
                 )
                 continue
 

--- a/client/ayon_core/plugins/load/delivery.py
+++ b/client/ayon_core/plugins/load/delivery.py
@@ -129,8 +129,8 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
 
         input_layout.addRow("Selected representations", selected_label)
         input_layout.addRow("Delivery template", dropdown)
-        input_layout.addRow("Template directory", template_dir_label)
-        input_layout.addRow("Template file", template_file_label)
+        input_layout.addRow("Directory template", template_dir_label)
+        input_layout.addRow("File template", template_file_label)
         input_layout.addRow("Renumber Frame", renumber_frame)
         input_layout.addRow("Renumber start frame", first_frame_start)
         input_layout.addRow("Root", root_line_edit)

--- a/client/ayon_core/plugins/load/delivery.py
+++ b/client/ayon_core/plugins/load/delivery.py
@@ -291,7 +291,7 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         templates = {}
         for template_name, value in anatomy.templates["delivery"].items():
             directory_template = value["directory"]
-            if not directory_template.startswith('{root'):
+            if not directory_template.startswith("{root"):
                 continue
 
             templates[template_name] = value

--- a/client/ayon_core/plugins/load/delivery.py
+++ b/client/ayon_core/plugins/load/delivery.py
@@ -292,6 +292,10 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         for template_name, value in anatomy.templates["delivery"].items():
             directory_template = value["directory"]
             if not directory_template.startswith("{root"):
+                self.log.warning(
+                    "Skipping template '%s' because directory template does "
+                    "not start with `{root`", template_name
+                )
                 continue
 
             templates[template_name] = value

--- a/client/ayon_core/plugins/load/delivery.py
+++ b/client/ayon_core/plugins/load/delivery.py
@@ -91,9 +91,15 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
             longest_key = max(self.templates.keys(), key=len)
             dropdown.setMinimumContentsLength(len(longest_key))
 
-        template_label = QtWidgets.QLabel()
-        template_label.setCursor(QtGui.QCursor(QtCore.Qt.IBeamCursor))
-        template_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+        template_dir_label = QtWidgets.QLabel()
+        template_dir_label.setCursor(QtGui.QCursor(QtCore.Qt.IBeamCursor))
+        template_dir_label.setTextInteractionFlags(
+            QtCore.Qt.TextSelectableByMouse)
+
+        template_file_label = QtWidgets.QLabel()
+        template_file_label.setCursor(QtGui.QCursor(QtCore.Qt.IBeamCursor))
+        template_file_label.setTextInteractionFlags(
+            QtCore.Qt.TextSelectableByMouse)
 
         renumber_frame = QtWidgets.QCheckBox()
 
@@ -123,7 +129,8 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
 
         input_layout.addRow("Selected representations", selected_label)
         input_layout.addRow("Delivery template", dropdown)
-        input_layout.addRow("Template value", template_label)
+        input_layout.addRow("Template directory", template_dir_label)
+        input_layout.addRow("Template file", template_file_label)
         input_layout.addRow("Renumber Frame", renumber_frame)
         input_layout.addRow("Renumber start frame", first_frame_start)
         input_layout.addRow("Root", root_line_edit)
@@ -151,7 +158,8 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         layout.addWidget(text_area)
 
         self.selected_label = selected_label
-        self.template_label = template_label
+        self.template_dir_label = template_dir_label
+        self.template_file_label = template_file_label
         self.dropdown = dropdown
         self.first_frame_start = first_frame_start
         self.renumber_frame = renumber_frame
@@ -282,10 +290,10 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         """Adds list of delivery templates from Anatomy to dropdown."""
         templates = {}
         for template_name, value in anatomy.templates["delivery"].items():
-            path_template = value["path"]
+            directory_template = value["directory"]
             if (
-                not isinstance(path_template, str)
-                or not path_template.startswith('{root')
+                not isinstance(directory_template, str)
+                or not directory_template.startswith('{root')
             ):
                 continue
 
@@ -350,7 +358,8 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         name = self.dropdown.currentText()
         template_value = self.templates.get(name)
         if template_value:
-            self.template_label.setText(template_value)
+            self.template_dir_label.setText(template_value["directory"])
+            self.template_file_label.setText(template_value["file"])
             self.btn_delivery.setEnabled(bool(self._get_selected_repres()))
 
     def _update_progress(self, uploaded):


### PR DESCRIPTION
## Changelog Description

Fix delivery action after recent refactoring of ayon core.

## Additional info

Fixes #351 

Since directory and file is now separate in the delivery templates I've also made them two labels in the delivery UI for better clarity as to what is what.

![image](https://github.com/ynput/ayon-core/assets/2439881/ec8db7bb-0c07-46da-a8c4-e2124ed32557)

## Testing notes:

1. Set up a delivery template in Anatomy settings `ayon+anatomy://PROJECTNAME/templates/delivery`, for example like these examples:

```json
[
  {
    "name": "client",
    "directory": "{root[work]}/{folder[name]}/{product[name]}",
    "file": "{folder[name]}_{product[name]}_{@version}<_{output}><.{@frame}>.{ext}"
  },
  {
    "name": "previews",
    "directory": "{root[work]}",
    "file": "{folder[name]}_{product[name]}_{@version}<_{output}><.{@frame}>.{ext}"
  },
  {
    "name": "per_asset",
    "directory": "{root[work]}/{folder[name]}",
    "file": "{folder[name]}_{product[name]}_{@version}<_{output}><.{@frame}>.{ext}"
  },
  {
    "name": "main",
    "directory": "{root[work]}/{project[name]}/delivery/{yyyy}-{mm}-{dd}/{hierarchy}/{folder[name]}/",
    "file": "{project[code]}_{folder[name]}_{task[short]}_{@version}<_{output}><.{@frame}>.{ext}"
  }
]
```

2. In Tray Launcher open the Loader
3. Using the `Delivery` action in the tray loader initiate a delivery to an output root.
