### PR TITLE
Houdini: Transfer Render Targets settings from pre create to instance when creating ROP instances

### DIFF
--- a/client/ayon_core/hosts/houdini/plugins/create/create_arnold_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_arnold_rop.py
@@ -18,6 +18,12 @@ class CreateArnoldRop(plugin.HoudiniCreator):
 
     def create(self, product_name, instance_data, pre_create_data):
         import hou
+        # Transfer settings from pre create to instance
+        creator_attributes = instance_data.setdefault(
+            "creator_attributes", dict())
+        for key in ["render_target"]:
+            if key in pre_create_data:
+                creator_attributes[key] = pre_create_data[key]
 
         # Remove the active, we are checking the bypass flag of the nodes
         instance_data.pop("active", None)

--- a/client/ayon_core/hosts/houdini/plugins/create/create_arnold_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_arnold_rop.py
@@ -21,9 +21,7 @@ class CreateArnoldRop(plugin.HoudiniCreator):
         # Transfer settings from pre create to instance
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())
-        for key in ["render_target"]:
-            if key in pre_create_data:
-                creator_attributes[key] = pre_create_data[key]
+        creator_attributes.update(pre_create_data)
 
         # Remove the active, we are checking the bypass flag of the nodes
         instance_data.pop("active", None)

--- a/client/ayon_core/hosts/houdini/plugins/create/create_karma_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_karma_rop.py
@@ -19,9 +19,7 @@ class CreateKarmaROP(plugin.HoudiniCreator):
         # Transfer settings from pre create to instance
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())
-        for key in ["render_target"]:
-            if key in pre_create_data:
-                creator_attributes[key] = pre_create_data[key]
+        creator_attributes.update(pre_create_data)
 
         instance_data.pop("active", None)
         instance_data.update({"node_type": "karma"})

--- a/client/ayon_core/hosts/houdini/plugins/create/create_karma_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_karma_rop.py
@@ -16,6 +16,12 @@ class CreateKarmaROP(plugin.HoudiniCreator):
 
     def create(self, product_name, instance_data, pre_create_data):
         import hou  # noqa
+        # Transfer settings from pre create to instance
+        creator_attributes = instance_data.setdefault(
+            "creator_attributes", dict())
+        for key in ["render_target"]:
+            if key in pre_create_data:
+                creator_attributes[key] = pre_create_data[key]
 
         instance_data.pop("active", None)
         instance_data.update({"node_type": "karma"})

--- a/client/ayon_core/hosts/houdini/plugins/create/create_mantra_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_mantra_rop.py
@@ -16,6 +16,12 @@ class CreateMantraROP(plugin.HoudiniCreator):
 
     def create(self, product_name, instance_data, pre_create_data):
         import hou  # noqa
+        # Transfer settings from pre create to instance
+        creator_attributes = instance_data.setdefault(
+            "creator_attributes", dict())
+        for key in ["render_target"]:
+            if key in pre_create_data:
+                creator_attributes[key] = pre_create_data[key]
 
         instance_data.pop("active", None)
         instance_data.update({"node_type": "ifd"})

--- a/client/ayon_core/hosts/houdini/plugins/create/create_mantra_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_mantra_rop.py
@@ -19,9 +19,7 @@ class CreateMantraROP(plugin.HoudiniCreator):
         # Transfer settings from pre create to instance
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())
-        for key in ["render_target"]:
-            if key in pre_create_data:
-                creator_attributes[key] = pre_create_data[key]
+        creator_attributes.update(pre_create_data)
 
         instance_data.pop("active", None)
         instance_data.update({"node_type": "ifd"})

--- a/client/ayon_core/hosts/houdini/plugins/create/create_redshift_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_redshift_rop.py
@@ -21,6 +21,12 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
     render_target = "farm_split"
 
     def create(self, product_name, instance_data, pre_create_data):
+        # Transfer settings from pre create to instance
+        creator_attributes = instance_data.setdefault(
+            "creator_attributes", dict())
+        for key in ["render_target"]:
+            if key in pre_create_data:
+                creator_attributes[key] = pre_create_data[key]
 
         instance_data.pop("active", None)
         instance_data.update({"node_type": "Redshift_ROP"})

--- a/client/ayon_core/hosts/houdini/plugins/create/create_redshift_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_redshift_rop.py
@@ -24,9 +24,7 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
         # Transfer settings from pre create to instance
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())
-        for key in ["render_target"]:
-            if key in pre_create_data:
-                creator_attributes[key] = pre_create_data[key]
+        creator_attributes.update(pre_create_data)
 
         instance_data.pop("active", None)
         instance_data.update({"node_type": "Redshift_ROP"})

--- a/client/ayon_core/hosts/houdini/plugins/create/create_vray_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_vray_rop.py
@@ -23,9 +23,7 @@ class CreateVrayROP(plugin.HoudiniCreator):
         # Transfer settings from pre create to instance
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())
-        for key in ["render_target"]:
-            if key in pre_create_data:
-                creator_attributes[key] = pre_create_data[key]
+        creator_attributes.update(pre_create_data)
 
         instance_data.pop("active", None)
         instance_data.update({"node_type": "vray_renderer"})

--- a/client/ayon_core/hosts/houdini/plugins/create/create_vray_rop.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_vray_rop.py
@@ -20,6 +20,12 @@ class CreateVrayROP(plugin.HoudiniCreator):
     render_target = "farm_split"
 
     def create(self, product_name, instance_data, pre_create_data):
+        # Transfer settings from pre create to instance
+        creator_attributes = instance_data.setdefault(
+            "creator_attributes", dict())
+        for key in ["render_target"]:
+            if key in pre_create_data:
+                creator_attributes[key] = pre_create_data[key]
 
         instance_data.pop("active", None)
         instance_data.update({"node_type": "vray_renderer"})


### PR DESCRIPTION
## Changelog Description
Transfer the render target setting from pre-create data to instance data, making sure the setting in the creator tab aligning to that in the publish tab

## Additional info
n/a

## Testing notes:
1. Create ROP instance
2. Choose your preferred render option(local, farm)
3. Go to Publish Tab and check the related setting
4. It should be aligned with what you set in the creator.
