### PR TITLE
Chore: Use `set` for representation name attribute in LoadPlugin

### DIFF
--- a/client/ayon_core/hosts/aftereffects/plugins/load/load_background.py
+++ b/client/ayon_core/hosts/aftereffects/plugins/load/load_background.py
@@ -21,7 +21,7 @@ class BackgroundLoader(api.AfterEffectsLoader):
     """
     label = "Load JSON Background"
     product_types = {"background"}
-    representations = ["json"]
+    representations = {"json"}
 
     def load(self, context, name=None, namespace=None, data=None):
         stub = self.get_stub()

--- a/client/ayon_core/hosts/aftereffects/plugins/load/load_file.py
+++ b/client/ayon_core/hosts/aftereffects/plugins/load/load_file.py
@@ -20,7 +20,7 @@ class FileLoader(api.AfterEffectsLoader):
         "review",
         "audio",
     }
-    representations = ["*"]
+    representations = {"*"}
 
     def load(self, context, name=None, namespace=None, data=None):
         stub = self.get_stub()

--- a/client/ayon_core/hosts/blender/plugins/load/import_workfile.py
+++ b/client/ayon_core/hosts/blender/plugins/load/import_workfile.py
@@ -43,7 +43,7 @@ class AppendBlendLoader(plugin.AssetLoader):
         so you could also use it as a new base.
     """
 
-    representations = ["blend"]
+    representations = {"blend"}
     product_types = {"workfile"}
 
     label = "Append Workfile"
@@ -68,7 +68,7 @@ class ImportBlendLoader(plugin.AssetLoader):
         so you could also use it as a new base.
     """
 
-    representations = ["blend"]
+    representations = {"blend"}
     product_types = {"workfile"}
 
     label = "Import Workfile"

--- a/client/ayon_core/hosts/blender/plugins/load/load_abc.py
+++ b/client/ayon_core/hosts/blender/plugins/load/load_abc.py
@@ -27,7 +27,7 @@ class CacheModelLoader(plugin.AssetLoader):
         At least for now it only supports Alembic files.
     """
     product_types = {"model", "pointcache", "animation"}
-    representations = ["abc"]
+    representations = {"abc"}
 
     label = "Load Alembic"
     icon = "code-fork"

--- a/client/ayon_core/hosts/blender/plugins/load/load_action.py
+++ b/client/ayon_core/hosts/blender/plugins/load/load_action.py
@@ -25,7 +25,7 @@ class BlendActionLoader(plugin.AssetLoader):
     """
 
     product_types = {"action"}
-    representations = ["blend"]
+    representations = {"blend"}
 
     label = "Link Action"
     icon = "code-fork"

--- a/client/ayon_core/hosts/blender/plugins/load/load_animation.py
+++ b/client/ayon_core/hosts/blender/plugins/load/load_animation.py
@@ -17,7 +17,7 @@ class BlendAnimationLoader(plugin.AssetLoader):
     """
 
     product_types = {"animation"}
-    representations = ["blend"]
+    representations = {"blend"}
 
     label = "Link Animation"
     icon = "code-fork"

--- a/client/ayon_core/hosts/blender/plugins/load/load_audio.py
+++ b/client/ayon_core/hosts/blender/plugins/load/load_audio.py
@@ -21,7 +21,7 @@ class AudioLoader(plugin.AssetLoader):
     """Load audio in Blender."""
 
     product_types = {"audio"}
-    representations = ["wav"]
+    representations = {"wav"}
 
     label = "Load Audio"
     icon = "volume-up"

--- a/client/ayon_core/hosts/blender/plugins/load/load_blend.py
+++ b/client/ayon_core/hosts/blender/plugins/load/load_blend.py
@@ -21,7 +21,7 @@ class BlendLoader(plugin.AssetLoader):
     """Load assets from a .blend file."""
 
     product_types = {"model", "rig", "layout", "camera"}
-    representations = ["blend"]
+    representations = {"blend"}
 
     label = "Append Blend"
     icon = "code-fork"

--- a/client/ayon_core/hosts/blender/plugins/load/load_blendscene.py
+++ b/client/ayon_core/hosts/blender/plugins/load/load_blendscene.py
@@ -19,7 +19,7 @@ class BlendSceneLoader(plugin.AssetLoader):
     """Load assets from a .blend file."""
 
     product_types = {"blendScene"}
-    representations = ["blend"]
+    representations = {"blend"}
 
     label = "Append Blend"
     icon = "code-fork"

--- a/client/ayon_core/hosts/blender/plugins/load/load_camera_abc.py
+++ b/client/ayon_core/hosts/blender/plugins/load/load_camera_abc.py
@@ -24,7 +24,7 @@ class AbcCameraLoader(plugin.AssetLoader):
     """
 
     product_types = {"camera"}
-    representations = ["abc"]
+    representations = {"abc"}
 
     label = "Load Camera (ABC)"
     icon = "code-fork"

--- a/client/ayon_core/hosts/blender/plugins/load/load_camera_fbx.py
+++ b/client/ayon_core/hosts/blender/plugins/load/load_camera_fbx.py
@@ -24,7 +24,7 @@ class FbxCameraLoader(plugin.AssetLoader):
     """
 
     product_types = {"camera"}
-    representations = ["fbx"]
+    representations = {"fbx"}
 
     label = "Load Camera (FBX)"
     icon = "code-fork"

--- a/client/ayon_core/hosts/blender/plugins/load/load_fbx.py
+++ b/client/ayon_core/hosts/blender/plugins/load/load_fbx.py
@@ -24,7 +24,7 @@ class FbxModelLoader(plugin.AssetLoader):
     """
 
     product_types = {"model", "rig"}
-    representations = ["fbx"]
+    representations = {"fbx"}
 
     label = "Load FBX"
     icon = "code-fork"

--- a/client/ayon_core/hosts/blender/plugins/load/load_layout_json.py
+++ b/client/ayon_core/hosts/blender/plugins/load/load_layout_json.py
@@ -27,7 +27,7 @@ class JsonLayoutLoader(plugin.AssetLoader):
     """Load layout published from Unreal."""
 
     product_types = {"layout"}
-    representations = ["json"]
+    representations = {"json"}
 
     label = "Load Layout"
     icon = "code-fork"

--- a/client/ayon_core/hosts/blender/plugins/load/load_look.py
+++ b/client/ayon_core/hosts/blender/plugins/load/load_look.py
@@ -24,7 +24,7 @@ class BlendLookLoader(plugin.AssetLoader):
     """
 
     product_types = {"look"}
-    representations = ["json"]
+    representations = {"json"}
 
     label = "Load Look"
     icon = "code-fork"

--- a/client/ayon_core/hosts/flame/plugins/load/load_clip.py
+++ b/client/ayon_core/hosts/flame/plugins/load/load_clip.py
@@ -18,7 +18,7 @@ class LoadClip(opfapi.ClipLoader):
     """
 
     product_types = {"render2d", "source", "plate", "render", "review"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = set(
         ext.lstrip(".") for ext in IMAGE_EXTENSIONS.union(VIDEO_EXTENSIONS)
     )

--- a/client/ayon_core/hosts/flame/plugins/load/load_clip_batch.py
+++ b/client/ayon_core/hosts/flame/plugins/load/load_clip_batch.py
@@ -17,7 +17,7 @@ class LoadClipBatch(opfapi.ClipLoader):
     """
 
     product_types = {"render2d", "source", "plate", "render", "review"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = set(
         ext.lstrip(".") for ext in IMAGE_EXTENSIONS.union(VIDEO_EXTENSIONS)
     )

--- a/client/ayon_core/hosts/fusion/plugins/load/actions.py
+++ b/client/ayon_core/hosts/fusion/plugins/load/actions.py
@@ -17,7 +17,7 @@ class FusionSetFrameRangeLoader(load.LoaderPlugin):
         "pointcache",
         "render",
     }
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"*"}
 
     label = "Set frame range"
@@ -54,7 +54,7 @@ class FusionSetFrameRangeWithHandlesLoader(load.LoaderPlugin):
         "pointcache",
         "render",
     }
-    representations = ["*"]
+    representations = {"*"}
 
     label = "Set frame range (with handles)"
     order = 12

--- a/client/ayon_core/hosts/fusion/plugins/load/load_alembic.py
+++ b/client/ayon_core/hosts/fusion/plugins/load/load_alembic.py
@@ -13,7 +13,7 @@ class FusionLoadAlembicMesh(load.LoaderPlugin):
     """Load Alembic mesh into Fusion"""
 
     product_types = {"pointcache", "model"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"abc"}
 
     label = "Load alembic mesh"

--- a/client/ayon_core/hosts/fusion/plugins/load/load_fbx.py
+++ b/client/ayon_core/hosts/fusion/plugins/load/load_fbx.py
@@ -13,7 +13,7 @@ class FusionLoadFBXMesh(load.LoaderPlugin):
     """Load FBX mesh into Fusion"""
 
     product_types = {"*"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = {
         "3ds",
         "amc",

--- a/client/ayon_core/hosts/fusion/plugins/load/load_sequence.py
+++ b/client/ayon_core/hosts/fusion/plugins/load/load_sequence.py
@@ -137,7 +137,7 @@ class FusionLoadSequence(load.LoaderPlugin):
         "image",
         "online",
     }
-    representations = ["*"]
+    representations = {"*"}
     extensions = set(
         ext.lstrip(".") for ext in IMAGE_EXTENSIONS.union(VIDEO_EXTENSIONS)
     )

--- a/client/ayon_core/hosts/fusion/plugins/load/load_usd.py
+++ b/client/ayon_core/hosts/fusion/plugins/load/load_usd.py
@@ -17,7 +17,7 @@ class FusionLoadUSD(load.LoaderPlugin):
     """
 
     product_types = {"*"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"usd", "usda", "usdz"}
 
     label = "Load USD"

--- a/client/ayon_core/hosts/fusion/plugins/load/load_workfile.py
+++ b/client/ayon_core/hosts/fusion/plugins/load/load_workfile.py
@@ -15,7 +15,7 @@ class FusionLoadWorkfile(load.LoaderPlugin):
     """Load the content of a workfile into Fusion"""
 
     product_types = {"workfile"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"comp"}
 
     label = "Load Workfile"

--- a/client/ayon_core/hosts/harmony/api/README.md
+++ b/client/ayon_core/hosts/harmony/api/README.md
@@ -590,7 +590,7 @@ class ImageSequenceLoader(load.LoaderPlugin):
         "reference",
         "review",
     }
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"jpeg", "png", "jpg"}
 
     def load(self, context, name=None, namespace=None, data=None):

--- a/client/ayon_core/hosts/harmony/plugins/load/load_audio.py
+++ b/client/ayon_core/hosts/harmony/plugins/load/load_audio.py
@@ -36,7 +36,7 @@ class ImportAudioLoader(load.LoaderPlugin):
     """Import audio."""
 
     product_types = {"shot", "audio"}
-    representations = ["wav"]
+    representations = {"wav"}
     label = "Import Audio"
 
     def load(self, context, name=None, namespace=None, data=None):

--- a/client/ayon_core/hosts/harmony/plugins/load/load_background.py
+++ b/client/ayon_core/hosts/harmony/plugins/load/load_background.py
@@ -234,7 +234,7 @@ class BackgroundLoader(load.LoaderPlugin):
     Stores the imported asset in a container named after the asset.
     """
     product_types = {"background"}
-    representations = ["json"]
+    representations = {"json"}
 
     def load(self, context, name=None, namespace=None, data=None):
 

--- a/client/ayon_core/hosts/harmony/plugins/load/load_imagesequence.py
+++ b/client/ayon_core/hosts/harmony/plugins/load/load_imagesequence.py
@@ -28,7 +28,7 @@ class ImageSequenceLoader(load.LoaderPlugin):
         "reference",
         "review",
     }
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"jpeg", "png", "jpg"}
 
     def load(self, context, name=None, namespace=None, data=None):

--- a/client/ayon_core/hosts/harmony/plugins/load/load_palette.py
+++ b/client/ayon_core/hosts/harmony/plugins/load/load_palette.py
@@ -12,7 +12,7 @@ class ImportPaletteLoader(load.LoaderPlugin):
     """Import palettes."""
 
     product_types = {"palette", "harmony.palette"}
-    representations = ["plt"]
+    representations = {"plt"}
     label = "Import Palette"
 
     def load(self, context, name=None, namespace=None, data=None):

--- a/client/ayon_core/hosts/harmony/plugins/load/load_template.py
+++ b/client/ayon_core/hosts/harmony/plugins/load/load_template.py
@@ -24,7 +24,7 @@ class TemplateLoader(load.LoaderPlugin):
     """
 
     product_types = {"template", "workfile"}
-    representations = ["*"]
+    representations = {"*"}
     label = "Load Template"
     icon = "gift"
 

--- a/client/ayon_core/hosts/harmony/plugins/load/load_template_workfile.py
+++ b/client/ayon_core/hosts/harmony/plugins/load/load_template_workfile.py
@@ -14,7 +14,7 @@ class ImportTemplateLoader(load.LoaderPlugin):
     """Import templates."""
 
     product_types = {"harmony.template", "workfile"}
-    representations = ["*"]
+    representations = {"*"}
     label = "Import Template"
 
     def load(self, context, name=None, namespace=None, data=None):
@@ -61,5 +61,5 @@ class ImportWorkfileLoader(ImportTemplateLoader):
     """Import workfiles."""
 
     product_types = {"workfile"}
-    representations = ["zip"]
+    representations = {"zip"}
     label = "Import Workfile"

--- a/client/ayon_core/hosts/hiero/plugins/load/load_clip.py
+++ b/client/ayon_core/hosts/hiero/plugins/load/load_clip.py
@@ -16,7 +16,7 @@ class LoadClip(phiero.SequenceLoader):
     """
 
     product_types = {"render2d", "source", "plate", "render", "review"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = set(
         ext.lstrip(".") for ext in IMAGE_EXTENSIONS.union(VIDEO_EXTENSIONS)
     )

--- a/client/ayon_core/hosts/hiero/plugins/load/load_effects.py
+++ b/client/ayon_core/hosts/hiero/plugins/load/load_effects.py
@@ -15,7 +15,7 @@ class LoadEffects(load.LoaderPlugin):
     """Loading colorspace soft effect exported from nukestudio"""
 
     product_types = {"effect"}
-    representations = ["*"]
+    representations = {"*"}
     extension = {"json"}
 
     label = "Load Effects"

--- a/client/ayon_core/hosts/houdini/plugins/load/actions.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/actions.py
@@ -15,7 +15,7 @@ class SetFrameRangeLoader(load.LoaderPlugin):
         "vdbcache",
         "usd",
     }
-    representations = ["abc", "vdb", "usd"]
+    representations = {"abc", "vdb", "usd"}
 
     label = "Set frame range"
     order = 11
@@ -52,7 +52,7 @@ class SetFrameRangeWithHandlesLoader(load.LoaderPlugin):
         "vdbcache",
         "usd",
     }
-    representations = ["abc", "vdb", "usd"]
+    representations = {"abc", "vdb", "usd"}
 
     label = "Set frame range (with handles)"
     order = 12

--- a/client/ayon_core/hosts/houdini/plugins/load/load_alembic.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_alembic.py
@@ -11,7 +11,7 @@ class AbcLoader(load.LoaderPlugin):
 
     product_types = {"model", "animation", "pointcache", "gpuCache"}
     label = "Load Alembic"
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"abc"}
     order = -10
     icon = "code-fork"

--- a/client/ayon_core/hosts/houdini/plugins/load/load_alembic_archive.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_alembic_archive.py
@@ -11,7 +11,7 @@ class AbcArchiveLoader(load.LoaderPlugin):
 
     product_types = {"model", "animation", "pointcache", "gpuCache"}
     label = "Load Alembic as Archive"
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"abc"}
     order = -5
     icon = "code-fork"

--- a/client/ayon_core/hosts/houdini/plugins/load/load_ass.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_ass.py
@@ -13,7 +13,7 @@ class AssLoader(load.LoaderPlugin):
 
     product_types = {"ass"}
     label = "Load Arnold Procedural"
-    representations = ["ass"]
+    representations = {"ass"}
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_core/hosts/houdini/plugins/load/load_bgeo.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_bgeo.py
@@ -14,9 +14,9 @@ class BgeoLoader(load.LoaderPlugin):
 
     label = "Load bgeo"
     product_types = {"model", "pointcache", "bgeo"}
-    representations = [
+    representations = {
         "bgeo", "bgeosc", "bgeogz",
-        "bgeo.sc", "bgeo.gz", "bgeo.lzma", "bgeo.bz2"]
+        "bgeo.sc", "bgeo.gz", "bgeo.lzma", "bgeo.bz2"}
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_core/hosts/houdini/plugins/load/load_camera.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_camera.py
@@ -89,7 +89,7 @@ class CameraLoader(load.LoaderPlugin):
 
     product_types = {"camera"}
     label = "Load Camera (abc)"
-    representations = ["abc"]
+    representations = {"abc"}
     order = -10
 
     icon = "code-fork"

--- a/client/ayon_core/hosts/houdini/plugins/load/load_fbx.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_fbx.py
@@ -17,7 +17,7 @@ class FbxLoader(load.LoaderPlugin):
     order = -10
 
     product_types = {"*"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"fbx"}
 
     def load(self, context, name=None, namespace=None, data=None):

--- a/client/ayon_core/hosts/houdini/plugins/load/load_filepath.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_filepath.py
@@ -22,7 +22,7 @@ class FilePathLoader(load.LoaderPlugin):
     icon = "link"
     color = "white"
     product_types = {"*"}
-    representations = ["*"]
+    representations = {"*"}
 
     def load(self, context, name=None, namespace=None, data=None):
 

--- a/client/ayon_core/hosts/houdini/plugins/load/load_hda.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_hda.py
@@ -12,7 +12,7 @@ class HdaLoader(load.LoaderPlugin):
 
     product_types = {"hda"}
     label = "Load Hda"
-    representations = ["hda"]
+    representations = {"hda"}
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_core/hosts/houdini/plugins/load/load_image.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_image.py
@@ -54,7 +54,7 @@ class ImageLoader(load.LoaderPlugin):
         "online",
     }
     label = "Load Image (COP2)"
-    representations = ["*"]
+    representations = {"*"}
     order = -10
 
     icon = "code-fork"

--- a/client/ayon_core/hosts/houdini/plugins/load/load_redshift_proxy.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_redshift_proxy.py
@@ -15,7 +15,7 @@ class RedshiftProxyLoader(load.LoaderPlugin):
 
     product_types = {"redshiftproxy"}
     label = "Load Redshift Proxy"
-    representations = ["rs"]
+    representations = {"rs"}
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_core/hosts/houdini/plugins/load/load_usd_layer.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_usd_layer.py
@@ -14,7 +14,7 @@ class USDSublayerLoader(load.LoaderPlugin):
         "usdCamera",
     }
     label = "Sublayer USD"
-    representations = ["usd", "usda", "usdlc", "usdnc", "abc"]
+    representations = {"usd", "usda", "usdlc", "usdnc", "abc"}
     order = 1
 
     icon = "code-fork"

--- a/client/ayon_core/hosts/houdini/plugins/load/load_usd_reference.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_usd_reference.py
@@ -14,7 +14,7 @@ class USDReferenceLoader(load.LoaderPlugin):
         "usdCamera",
     }
     label = "Reference USD"
-    representations = ["usd", "usda", "usdlc", "usdnc", "abc"]
+    representations = {"usd", "usda", "usdlc", "usdnc", "abc"}
     order = -8
 
     icon = "code-fork"

--- a/client/ayon_core/hosts/houdini/plugins/load/load_usd_sop.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_usd_sop.py
@@ -9,7 +9,7 @@ class SopUsdImportLoader(load.LoaderPlugin):
 
     label = "Load USD to SOPs"
     product_types = {"*"}
-    representations = ["usd"]
+    representations = {"usd"}
     order = -6
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_core/hosts/houdini/plugins/load/load_vdb.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/load_vdb.py
@@ -13,7 +13,7 @@ class VdbLoader(load.LoaderPlugin):
 
     product_types = {"vdbcache"}
     label = "Load VDB"
-    representations = ["vdb"]
+    representations = {"vdb"}
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_core/hosts/houdini/plugins/load/show_usdview.py
+++ b/client/ayon_core/hosts/houdini/plugins/load/show_usdview.py
@@ -10,7 +10,7 @@ class ShowInUsdview(load.LoaderPlugin):
     """Open USD file in usdview"""
 
     label = "Show in usdview"
-    representations = ["*"]
+    representations = {"*"}
     product_types = {"*"}
     extensions = {"usd", "usda", "usdlc", "usdnc", "abc"}
     order = 15

--- a/client/ayon_core/hosts/max/plugins/load/load_camera_fbx.py
+++ b/client/ayon_core/hosts/max/plugins/load/load_camera_fbx.py
@@ -19,7 +19,7 @@ class FbxLoader(load.LoaderPlugin):
     """Fbx Loader."""
 
     product_types = {"camera"}
-    representations = ["fbx"]
+    representations = {"fbx"}
     order = -9
     icon = "code-fork"
     color = "white"

--- a/client/ayon_core/hosts/max/plugins/load/load_max_scene.py
+++ b/client/ayon_core/hosts/max/plugins/load/load_max_scene.py
@@ -78,7 +78,7 @@ class MaxSceneLoader(load.LoaderPlugin):
         "model",
     }
 
-    representations = ["max"]
+    representations = {"max"}
     order = -8
     icon = "code-fork"
     color = "green"

--- a/client/ayon_core/hosts/max/plugins/load/load_model.py
+++ b/client/ayon_core/hosts/max/plugins/load/load_model.py
@@ -16,7 +16,7 @@ class ModelAbcLoader(load.LoaderPlugin):
 
     product_types = {"model"}
     label = "Load Model with Alembic"
-    representations = ["abc"]
+    representations = {"abc"}
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_core/hosts/max/plugins/load/load_model_fbx.py
+++ b/client/ayon_core/hosts/max/plugins/load/load_model_fbx.py
@@ -18,7 +18,7 @@ class FbxModelLoader(load.LoaderPlugin):
     """Fbx Model Loader."""
 
     product_types = {"model"}
-    representations = ["fbx"]
+    representations = {"fbx"}
     order = -9
     icon = "code-fork"
     color = "white"

--- a/client/ayon_core/hosts/max/plugins/load/load_model_obj.py
+++ b/client/ayon_core/hosts/max/plugins/load/load_model_obj.py
@@ -20,7 +20,7 @@ class ObjLoader(load.LoaderPlugin):
     """Obj Loader."""
 
     product_types = {"model"}
-    representations = ["obj"]
+    representations = {"obj"}
     order = -9
     icon = "code-fork"
     color = "white"

--- a/client/ayon_core/hosts/max/plugins/load/load_model_usd.py
+++ b/client/ayon_core/hosts/max/plugins/load/load_model_usd.py
@@ -24,7 +24,7 @@ class ModelUSDLoader(load.LoaderPlugin):
 
     product_types = {"model"}
     label = "Load Model(USD)"
-    representations = ["usda"]
+    representations = {"usda"}
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_core/hosts/max/plugins/load/load_pointcache.py
+++ b/client/ayon_core/hosts/max/plugins/load/load_pointcache.py
@@ -20,7 +20,7 @@ class AbcLoader(load.LoaderPlugin):
 
     product_types = {"camera", "animation", "pointcache"}
     label = "Load Alembic"
-    representations = ["abc"]
+    representations = {"abc"}
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_core/hosts/max/plugins/load/load_pointcache_ornatrix.py
+++ b/client/ayon_core/hosts/max/plugins/load/load_pointcache_ornatrix.py
@@ -23,7 +23,7 @@ class OxAbcLoader(load.LoaderPlugin):
 
     product_types = {"camera", "animation", "pointcache"}
     label = "Load Alembic with Ornatrix"
-    representations = ["abc"]
+    representations = {"abc"}
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_core/hosts/max/plugins/load/load_pointcloud.py
+++ b/client/ayon_core/hosts/max/plugins/load/load_pointcloud.py
@@ -18,7 +18,7 @@ class PointCloudLoader(load.LoaderPlugin):
     """Point Cloud Loader."""
 
     product_types = {"pointcloud"}
-    representations = ["prt"]
+    representations = {"prt"}
     order = -8
     icon = "code-fork"
     color = "green"

--- a/client/ayon_core/hosts/max/plugins/load/load_redshift_proxy.py
+++ b/client/ayon_core/hosts/max/plugins/load/load_redshift_proxy.py
@@ -24,7 +24,7 @@ class RedshiftProxyLoader(load.LoaderPlugin):
 
     label = "Load Redshift Proxy"
     product_types = {"redshiftproxy"}
-    representations = ["rs"]
+    representations = {"rs"}
     order = -9
     icon = "code-fork"
     color = "white"

--- a/client/ayon_core/hosts/max/plugins/load/load_tycache.py
+++ b/client/ayon_core/hosts/max/plugins/load/load_tycache.py
@@ -17,7 +17,7 @@ class TyCacheLoader(load.LoaderPlugin):
     """TyCache Loader."""
 
     product_types = {"tycache"}
-    representations = ["tyc"]
+    representations = {"tyc"}
     order = -8
     icon = "code-fork"
     color = "green"

--- a/client/ayon_core/hosts/maya/plugins/load/_load_animation.py
+++ b/client/ayon_core/hosts/maya/plugins/load/_load_animation.py
@@ -51,7 +51,7 @@ class AbcLoader(ayon_core.hosts.maya.api.plugin.ReferenceLoader):
         "camera",
         "pointcache",
     }
-    representations = ["abc"]
+    representations = {"abc"}
 
     label = "Reference animation"
     order = -10
@@ -81,7 +81,7 @@ class FbxLoader(ayon_core.hosts.maya.api.plugin.ReferenceLoader):
         "animation",
         "camera",
     }
-    representations = ["fbx"]
+    representations = {"fbx"}
 
     label = "Reference animation"
     order = -10

--- a/client/ayon_core/hosts/maya/plugins/load/actions.py
+++ b/client/ayon_core/hosts/maya/plugins/load/actions.py
@@ -19,7 +19,7 @@ class SetFrameRangeLoader(load.LoaderPlugin):
         "proxyAbc",
         "pointcache",
     }
-    representations = ["abc"]
+    representations = {"abc"}
 
     label = "Set frame range"
     order = 11
@@ -54,7 +54,7 @@ class SetFrameRangeWithHandlesLoader(load.LoaderPlugin):
         "proxyAbc",
         "pointcache",
     }
-    representations = ["abc"]
+    representations = {"abc"}
 
     label = "Set frame range (with handles)"
     order = 12
@@ -94,7 +94,7 @@ class ImportMayaLoader(ayon_core.hosts.maya.api.plugin.Loader):
         so you could also use it as a new base.
 
     """
-    representations = ["ma", "mb", "obj"]
+    representations = {"ma", "mb", "obj"}
     product_types = {
         "model",
         "pointcache",

--- a/client/ayon_core/hosts/maya/plugins/load/load_arnold_standin.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_arnold_standin.py
@@ -31,7 +31,7 @@ class ArnoldStandinLoader(load.LoaderPlugin):
     product_types = {
         "ass", "animation", "model", "proxyAbc", "pointcache", "usd"
     }
-    representations = ["ass", "abc", "usda", "usdc", "usd"]
+    representations = {"ass", "abc", "usda", "usdc", "usd"}
 
     label = "Load as Arnold standin"
     order = -5

--- a/client/ayon_core/hosts/maya/plugins/load/load_assembly.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_assembly.py
@@ -13,7 +13,7 @@ from ayon_core.hosts.maya.api import setdress
 class AssemblyLoader(load.LoaderPlugin):
 
     product_types = {"assembly"}
-    representations = ["json"]
+    representations = {"json"}
 
     label = "Load Set Dress"
     order = -9

--- a/client/ayon_core/hosts/maya/plugins/load/load_audio.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_audio.py
@@ -13,7 +13,7 @@ class AudioLoader(load.LoaderPlugin):
 
     product_types = {"audio"}
     label = "Load audio"
-    representations = ["wav"]
+    representations = {"wav"}
     icon = "volume-up"
     color = "orange"
 

--- a/client/ayon_core/hosts/maya/plugins/load/load_gpucache.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_gpucache.py
@@ -14,7 +14,7 @@ class GpuCacheLoader(load.LoaderPlugin):
     """Load Alembic as gpuCache"""
 
     product_types = {"model", "animation", "proxyAbc", "pointcache"}
-    representations = ["abc", "gpu_cache"]
+    representations = {"abc", "gpu_cache"}
 
     label = "Load Gpu Cache"
     order = -5

--- a/client/ayon_core/hosts/maya/plugins/load/load_image.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_image.py
@@ -93,7 +93,7 @@ class FileNodeLoader(load.LoaderPlugin):
 
     product_types = {"image", "plate", "render"}
     label = "Load file node"
-    representations = ["exr", "tif", "png", "jpg"]
+    representations = {"exr", "tif", "png", "jpg"}
     icon = "image"
     color = "orange"
     order = 2

--- a/client/ayon_core/hosts/maya/plugins/load/load_image_plane.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_image_plane.py
@@ -89,7 +89,7 @@ class ImagePlaneLoader(load.LoaderPlugin):
 
     product_types = {"image", "plate", "render"}
     label = "Load imagePlane"
-    representations = ["mov", "exr", "preview", "png", "jpg"]
+    representations = {"mov", "exr", "preview", "png", "jpg"}
     icon = "image"
     color = "orange"
 
@@ -171,7 +171,7 @@ class ImagePlaneLoader(load.LoaderPlugin):
             plug = "{}.{}".format(image_plane_shape, attr)
             cmds.setAttr(plug, value)
 
-        movie_representations = ["mov", "preview"]
+        movie_representations = {"mov", "preview"}
         if context["representation"]["name"] in movie_representations:
             cmds.setAttr(image_plane_shape + ".type", 2)
 

--- a/client/ayon_core/hosts/maya/plugins/load/load_look.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_look.py
@@ -18,7 +18,7 @@ class LookLoader(ayon_core.hosts.maya.api.plugin.ReferenceLoader):
     """Specific loader for lookdev"""
 
     product_types = {"look"}
-    representations = ["ma"]
+    representations = {"ma"}
 
     label = "Reference look"
     order = -10

--- a/client/ayon_core/hosts/maya/plugins/load/load_matchmove.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_matchmove.py
@@ -9,7 +9,7 @@ class MatchmoveLoader(load.LoaderPlugin):
     """
 
     product_types = {"matchmove"}
-    representations = ["py", "mel"]
+    representations = {"py", "mel"}
     defaults = ["Camera", "Object", "Mocap"]
 
     label = "Run matchmove script"

--- a/client/ayon_core/hosts/maya/plugins/load/load_maya_usd.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_maya_usd.py
@@ -17,7 +17,7 @@ class MayaUsdLoader(load.LoaderPlugin):
     """Read USD data in a Maya USD Proxy"""
 
     product_types = {"model", "usd", "pointcache", "animation"}
-    representations = ["usd", "usda", "usdc", "usdz", "abc"]
+    representations = {"usd", "usda", "usdc", "usdz", "abc"}
 
     label = "Load USD to Maya Proxy"
     order = -1

--- a/client/ayon_core/hosts/maya/plugins/load/load_multiverse_usd.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_multiverse_usd.py
@@ -28,7 +28,7 @@ class MultiverseUsdLoader(load.LoaderPlugin):
         "pointcache",
         "animation",
     }
-    representations = ["usd", "usda", "usdc", "usdz", "abc"]
+    representations = {"usd", "usda", "usdc", "usdz", "abc"}
 
     label = "Load USD to Multiverse"
     order = -10

--- a/client/ayon_core/hosts/maya/plugins/load/load_multiverse_usd_over.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_multiverse_usd_over.py
@@ -20,7 +20,7 @@ class MultiverseUsdOverLoader(load.LoaderPlugin):
     """Reference file"""
 
     product_types = {"mvUsdOverride"}
-    representations = ["usda", "usd", "udsz"]
+    representations = {"usda", "usd", "udsz"}
 
     label = "Load Usd Override into Compound"
     order = -10

--- a/client/ayon_core/hosts/maya/plugins/load/load_redshift_proxy.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_redshift_proxy.py
@@ -23,7 +23,7 @@ class RedshiftProxyLoader(load.LoaderPlugin):
     """Load Redshift proxy"""
 
     product_types = {"redshiftproxy"}
-    representations = ["rs"]
+    representations = {"rs"}
 
     label = "Import Redshift Proxy"
     order = -10

--- a/client/ayon_core/hosts/maya/plugins/load/load_reference.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_reference.py
@@ -107,7 +107,7 @@ class ReferenceLoader(plugin.ReferenceLoader):
         "matchmove",
     }
 
-    representations = ["ma", "abc", "fbx", "mb"]
+    representations = {"ma", "abc", "fbx", "mb"}
 
     label = "Reference"
     order = -10
@@ -269,7 +269,7 @@ class MayaUSDReferenceLoader(ReferenceLoader):
 
     label = "Reference Maya USD"
     product_types = {"usd"}
-    representations = ["usd"]
+    representations = {"usd"}
     extensions = {"usd", "usda", "usdc"}
 
     options = ReferenceLoader.options + [

--- a/client/ayon_core/hosts/maya/plugins/load/load_rendersetup.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_rendersetup.py
@@ -52,7 +52,7 @@ class RenderSetupLoader(load.LoaderPlugin):
     """Load json preset for RenderSetup overwriting current one."""
 
     product_types = {"rendersetup"}
-    representations = ["json"]
+    representations = {"json"}
     defaults = ['Main']
 
     label = "Load RenderSetup template"

--- a/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_arnold.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_arnold.py
@@ -13,7 +13,7 @@ class LoadVDBtoArnold(load.LoaderPlugin):
     """Load OpenVDB for Arnold in aiVolume"""
 
     product_types = {"vdbcache"}
-    representations = ["vdb"]
+    representations = {"vdb"}
 
     label = "Load VDB to Arnold"
     icon = "cloud"

--- a/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_redshift.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_redshift.py
@@ -19,7 +19,7 @@ class LoadVDBtoRedShift(load.LoaderPlugin):
     """
 
     product_types = {"vdbcache"}
-    representations = ["vdb"]
+    representations = {"vdb"}
 
     label = "Load VDB to RedShift"
     icon = "cloud"

--- a/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_vray.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_vdb_to_vray.py
@@ -78,7 +78,7 @@ class LoadVDBtoVRay(load.LoaderPlugin):
     """Load OpenVDB in a V-Ray Volume Grid"""
 
     product_types = {"vdbcache"}
-    representations = ["vdb"]
+    representations = {"vdb"}
 
     label = "Load VDB to VRay"
     icon = "cloud"

--- a/client/ayon_core/hosts/maya/plugins/load/load_vrayproxy.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_vrayproxy.py
@@ -28,7 +28,7 @@ class VRayProxyLoader(load.LoaderPlugin):
     """Load VRay Proxy with Alembic or VrayMesh."""
 
     product_types = {"vrayproxy", "model", "pointcache", "animation"}
-    representations = ["vrmesh", "abc"]
+    representations = {"vrmesh", "abc"}
 
     label = "Import VRay Proxy"
     order = -10

--- a/client/ayon_core/hosts/maya/plugins/load/load_vrayscene.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_vrayscene.py
@@ -18,7 +18,7 @@ class VRaySceneLoader(load.LoaderPlugin):
     """Load Vray scene"""
 
     product_types = {"vrayscene_layer"}
-    representations = ["vrscene"]
+    representations = {"vrscene"}
 
     label = "Import VRay Scene"
     order = -10

--- a/client/ayon_core/hosts/maya/plugins/load/load_xgen.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_xgen.py
@@ -21,7 +21,7 @@ class XgenLoader(ayon_core.hosts.maya.api.plugin.ReferenceLoader):
     """Load Xgen as reference"""
 
     product_types = {"xgen"}
-    representations = ["ma", "mb"]
+    representations = {"ma", "mb"}
 
     label = "Reference Xgen"
     icon = "code-fork"

--- a/client/ayon_core/hosts/maya/plugins/load/load_yeti_cache.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_yeti_cache.py
@@ -37,7 +37,7 @@ class YetiCacheLoader(load.LoaderPlugin):
     """Load Yeti Cache with one or more Yeti nodes"""
 
     product_types = {"yeticache", "yetiRig"}
-    representations = ["fur"]
+    representations = {"fur"}
 
     label = "Load Yeti Cache"
     order = -9

--- a/client/ayon_core/hosts/maya/plugins/load/load_yeti_rig.py
+++ b/client/ayon_core/hosts/maya/plugins/load/load_yeti_rig.py
@@ -8,7 +8,7 @@ class YetiRigLoader(plugin.ReferenceLoader):
     """This loader will load Yeti rig."""
 
     product_types = {"yetiRig"}
-    representations = ["ma"]
+    representations = {"ma"}
 
     label = "Load Yeti Rig"
     order = -9

--- a/client/ayon_core/hosts/nuke/plugins/load/actions.py
+++ b/client/ayon_core/hosts/nuke/plugins/load/actions.py
@@ -19,7 +19,7 @@ class SetFrameRangeLoader(load.LoaderPlugin):
         "yeticache",
         "pointcache",
     }
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"*"}
 
     label = "Set frame range"
@@ -53,7 +53,7 @@ class SetFrameRangeWithHandlesLoader(load.LoaderPlugin):
         "yeticache",
         "pointcache",
     }
-    representations = ["*"]
+    representations = {"*"}
 
     label = "Set frame range (with handles)"
     order = 12

--- a/client/ayon_core/hosts/nuke/plugins/load/load_backdrop.py
+++ b/client/ayon_core/hosts/nuke/plugins/load/load_backdrop.py
@@ -22,7 +22,7 @@ class LoadBackdropNodes(load.LoaderPlugin):
     """Loading Published Backdrop nodes (workfile, nukenodes)"""
 
     product_types = {"workfile", "nukenodes"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"nk"}
 
     label = "Import Nuke Nodes"

--- a/client/ayon_core/hosts/nuke/plugins/load/load_camera_abc.py
+++ b/client/ayon_core/hosts/nuke/plugins/load/load_camera_abc.py
@@ -21,7 +21,7 @@ class AlembicCameraLoader(load.LoaderPlugin):
     """
 
     product_types = {"camera"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"abc"}
 
     label = "Load Alembic Camera"

--- a/client/ayon_core/hosts/nuke/plugins/load/load_clip.py
+++ b/client/ayon_core/hosts/nuke/plugins/load/load_clip.py
@@ -42,7 +42,7 @@ class LoadClip(plugin.NukeLoader):
         "prerender",
         "review",
     }
-    representations = ["*"]
+    representations = {"*"}
     extensions = set(
         ext.lstrip(".") for ext in IMAGE_EXTENSIONS.union(VIDEO_EXTENSIONS)
     )

--- a/client/ayon_core/hosts/nuke/plugins/load/load_effects.py
+++ b/client/ayon_core/hosts/nuke/plugins/load/load_effects.py
@@ -19,7 +19,7 @@ class LoadEffects(load.LoaderPlugin):
     """Loading colorspace soft effect exported from nukestudio"""
 
     product_types = {"effect"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"json"}
 
     label = "Load Effects - nodes"

--- a/client/ayon_core/hosts/nuke/plugins/load/load_effects_ip.py
+++ b/client/ayon_core/hosts/nuke/plugins/load/load_effects_ip.py
@@ -20,7 +20,7 @@ class LoadEffectsInputProcess(load.LoaderPlugin):
     """Loading colorspace soft effect exported from nukestudio"""
 
     product_types = {"effect"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"json"}
 
     label = "Load Effects - Input Process"

--- a/client/ayon_core/hosts/nuke/plugins/load/load_gizmo.py
+++ b/client/ayon_core/hosts/nuke/plugins/load/load_gizmo.py
@@ -22,7 +22,7 @@ class LoadGizmo(load.LoaderPlugin):
     """Loading nuke Gizmo"""
 
     product_types = {"gizmo"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"nk"}
 
     label = "Load Gizmo"

--- a/client/ayon_core/hosts/nuke/plugins/load/load_gizmo_ip.py
+++ b/client/ayon_core/hosts/nuke/plugins/load/load_gizmo_ip.py
@@ -24,7 +24,7 @@ class LoadGizmoInputProcess(load.LoaderPlugin):
     """Loading colorspace soft effect exported from nukestudio"""
 
     product_types = {"gizmo"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"nk"}
 
     label = "Load Gizmo - Input Process"

--- a/client/ayon_core/hosts/nuke/plugins/load/load_image.py
+++ b/client/ayon_core/hosts/nuke/plugins/load/load_image.py
@@ -32,7 +32,7 @@ class LoadImage(load.LoaderPlugin):
         "review",
         "image",
     }
-    representations = ["*"]
+    representations = {"*"}
     extensions = set(
         ext.lstrip(".") for ext in IMAGE_EXTENSIONS
     )

--- a/client/ayon_core/hosts/nuke/plugins/load/load_matchmove.py
+++ b/client/ayon_core/hosts/nuke/plugins/load/load_matchmove.py
@@ -8,7 +8,7 @@ class MatchmoveLoader(load.LoaderPlugin):
     """
 
     product_types = {"matchmove"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"py"}
 
     defaults = ["Camera", "Object"]

--- a/client/ayon_core/hosts/nuke/plugins/load/load_model.py
+++ b/client/ayon_core/hosts/nuke/plugins/load/load_model.py
@@ -19,7 +19,7 @@ class AlembicModelLoader(load.LoaderPlugin):
     """
 
     product_types = {"model", "pointcache", "animation"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"abc"}
 
     label = "Load Alembic"

--- a/client/ayon_core/hosts/nuke/plugins/load/load_ociolook.py
+++ b/client/ayon_core/hosts/nuke/plugins/load/load_ociolook.py
@@ -21,7 +21,7 @@ class LoadOcioLookNodes(load.LoaderPlugin):
     """Loading Ocio look to the nuke.Node graph"""
 
     product_types = {"ociolook"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"json"}
 
     label = "Load OcioLook [nodes]"

--- a/client/ayon_core/hosts/nuke/plugins/load/load_script_precomp.py
+++ b/client/ayon_core/hosts/nuke/plugins/load/load_script_precomp.py
@@ -17,7 +17,7 @@ class LinkAsGroup(load.LoaderPlugin):
     """Copy the published file to be pasted at the desired location"""
 
     product_types = {"workfile", "nukenodes"}
-    representations = ["*"]
+    representations = {"*"}
     extensions = {"nk"}
 
     label = "Load Precomp"

--- a/client/ayon_core/hosts/photoshop/api/README.md
+++ b/client/ayon_core/hosts/photoshop/api/README.md
@@ -207,7 +207,7 @@ class ImageLoader(load.LoaderPlugin):
     """
 
     families = ["image"]
-    representations = ["*"]
+    representations = {"*"}
 
     def load(self, context, name=None, namespace=None, data=None):
         path = self.filepath_from_context(context)

--- a/client/ayon_core/hosts/photoshop/plugins/load/load_image.py
+++ b/client/ayon_core/hosts/photoshop/plugins/load/load_image.py
@@ -12,7 +12,7 @@ class ImageLoader(photoshop.PhotoshopLoader):
     """
 
     product_types = {"image", "render"}
-    representations = ["*"]
+    representations = {"*"}
 
     def load(self, context, name=None, namespace=None, data=None):
         stub = self.get_stub()

--- a/client/ayon_core/hosts/photoshop/plugins/load/load_image_from_sequence.py
+++ b/client/ayon_core/hosts/photoshop/plugins/load/load_image_from_sequence.py
@@ -25,7 +25,7 @@ class ImageFromSequenceLoader(photoshop.PhotoshopLoader):
     """
 
     product_types = {"render"}
-    representations = ["*"]
+    representations = {"*"}
     options = []
 
     def load(self, context, name=None, namespace=None, data=None):

--- a/client/ayon_core/hosts/photoshop/plugins/load/load_reference.py
+++ b/client/ayon_core/hosts/photoshop/plugins/load/load_reference.py
@@ -15,7 +15,7 @@ class ReferenceLoader(photoshop.PhotoshopLoader):
     """
 
     product_types = {"image", "render"}
-    representations = ["*"]
+    representations = {"*"}
 
     def load(self, context, name=None, namespace=None, data=None):
         stub = self.get_stub()

--- a/client/ayon_core/hosts/resolve/plugins/load/load_clip.py
+++ b/client/ayon_core/hosts/resolve/plugins/load/load_clip.py
@@ -20,7 +20,7 @@ class LoadClip(plugin.TimelineItemLoader):
 
     product_types = {"render2d", "source", "plate", "render", "review"}
 
-    representations = ["*"]
+    representations = {"*"}
     extensions = set(
         ext.lstrip(".") for ext in IMAGE_EXTENSIONS.union(VIDEO_EXTENSIONS)
     )

--- a/client/ayon_core/hosts/substancepainter/plugins/load/load_mesh.py
+++ b/client/ayon_core/hosts/substancepainter/plugins/load/load_mesh.py
@@ -18,7 +18,7 @@ class SubstanceLoadProjectMesh(load.LoaderPlugin):
     """Load mesh for project"""
 
     product_types = {"*"}
-    representations = ["abc", "fbx", "obj", "gltf", "usd", "usda", "usdc"]
+    representations = {"abc", "fbx", "obj", "gltf", "usd", "usda", "usdc"}
 
     label = "Load mesh"
     order = -10

--- a/client/ayon_core/hosts/tvpaint/plugins/load/load_image.py
+++ b/client/ayon_core/hosts/tvpaint/plugins/load/load_image.py
@@ -7,7 +7,7 @@ class ImportImage(plugin.Loader):
     """Load image or image sequence to TVPaint as new layer."""
 
     product_types = {"render", "image", "background", "plate", "review"}
-    representations = ["*"]
+    representations = {"*"}
 
     label = "Import Image"
     order = 1

--- a/client/ayon_core/hosts/tvpaint/plugins/load/load_reference_image.py
+++ b/client/ayon_core/hosts/tvpaint/plugins/load/load_reference_image.py
@@ -18,7 +18,7 @@ class LoadImage(plugin.Loader):
     """Load image or image sequence to TVPaint as new layer."""
 
     product_types = {"render", "image", "background", "plate", "review"}
-    representations = ["*"]
+    representations = {"*"}
 
     label = "Load Image"
     order = 1

--- a/client/ayon_core/hosts/tvpaint/plugins/load/load_sound.py
+++ b/client/ayon_core/hosts/tvpaint/plugins/load/load_sound.py
@@ -23,7 +23,7 @@ class ImportSound(plugin.Loader):
     """
 
     product_types = {"audio", "review", "plate"}
-    representations = ["*"]
+    representations = {"*"}
 
     label = "Import Sound"
     order = 1

--- a/client/ayon_core/hosts/tvpaint/plugins/load/load_workfile.py
+++ b/client/ayon_core/hosts/tvpaint/plugins/load/load_workfile.py
@@ -25,7 +25,7 @@ class LoadWorkfile(plugin.Loader):
     """Load workfile."""
 
     product_types = {"workfile"}
-    representations = ["tvpp"]
+    representations = {"tvpp"}
 
     label = "Load Workfile"
 

--- a/client/ayon_core/hosts/unreal/plugins/load/load_alembic_animation.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_alembic_animation.py
@@ -16,7 +16,7 @@ class AnimationAlembicLoader(plugin.Loader):
 
     product_types = {"animation"}
     label = "Import Alembic Animation"
-    representations = ["abc"]
+    representations = {"abc"}
     icon = "cube"
     color = "orange"
 

--- a/client/ayon_core/hosts/unreal/plugins/load/load_animation.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_animation.py
@@ -22,7 +22,7 @@ class AnimationFBXLoader(plugin.Loader):
 
     product_types = {"animation"}
     label = "Import FBX Animation"
-    representations = ["fbx"]
+    representations = {"fbx"}
     icon = "cube"
     color = "orange"
 

--- a/client/ayon_core/hosts/unreal/plugins/load/load_camera.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_camera.py
@@ -30,7 +30,7 @@ class CameraLoader(plugin.Loader):
 
     product_types = {"camera"}
     label = "Load Camera"
-    representations = ["fbx"]
+    representations = {"fbx"}
     icon = "cube"
     color = "orange"
 

--- a/client/ayon_core/hosts/unreal/plugins/load/load_geometrycache_abc.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_geometrycache_abc.py
@@ -21,7 +21,7 @@ class PointCacheAlembicLoader(plugin.Loader):
 
     product_types = {"model", "pointcache"}
     label = "Import Alembic Point Cache"
-    representations = ["abc"]
+    representations = {"abc"}
     icon = "cube"
     color = "orange"
 

--- a/client/ayon_core/hosts/unreal/plugins/load/load_layout.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_layout.py
@@ -41,7 +41,7 @@ class LayoutLoader(plugin.Loader):
     """Load Layout from a JSON file"""
 
     product_types = {"layout"}
-    representations = ["json"]
+    representations = {"json"}
 
     label = "Load Layout"
     icon = "code-fork"

--- a/client/ayon_core/hosts/unreal/plugins/load/load_layout_existing.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_layout_existing.py
@@ -22,7 +22,7 @@ class ExistingLayoutLoader(plugin.Loader):
     """
 
     product_types = {"layout"}
-    representations = ["json"]
+    representations = {"json"}
 
     label = "Load Layout on Existing Scene"
     icon = "code-fork"

--- a/client/ayon_core/hosts/unreal/plugins/load/load_skeletalmesh_abc.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_skeletalmesh_abc.py
@@ -20,7 +20,7 @@ class SkeletalMeshAlembicLoader(plugin.Loader):
 
     product_types = {"pointcache", "skeletalMesh"}
     label = "Import Alembic Skeletal Mesh"
-    representations = ["abc"]
+    representations = {"abc"}
     icon = "cube"
     color = "orange"
 

--- a/client/ayon_core/hosts/unreal/plugins/load/load_skeletalmesh_fbx.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_skeletalmesh_fbx.py
@@ -20,7 +20,7 @@ class SkeletalMeshFBXLoader(plugin.Loader):
 
     product_types = {"rig", "skeletalMesh"}
     label = "Import FBX Skeletal Mesh"
-    representations = ["fbx"]
+    representations = {"fbx"}
     icon = "cube"
     color = "orange"
 

--- a/client/ayon_core/hosts/unreal/plugins/load/load_staticmesh_abc.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_staticmesh_abc.py
@@ -20,7 +20,7 @@ class StaticMeshAlembicLoader(plugin.Loader):
 
     product_types = {"model", "staticMesh"}
     label = "Import Alembic Static Mesh"
-    representations = ["abc"]
+    representations = {"abc"}
     icon = "cube"
     color = "orange"
 

--- a/client/ayon_core/hosts/unreal/plugins/load/load_staticmesh_fbx.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_staticmesh_fbx.py
@@ -20,7 +20,7 @@ class StaticMeshFBXLoader(plugin.Loader):
 
     product_types = {"model", "staticMesh"}
     label = "Import FBX Static Mesh"
-    representations = ["fbx"]
+    representations = {"fbx"}
     icon = "cube"
     color = "orange"
 

--- a/client/ayon_core/hosts/unreal/plugins/load/load_uasset.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_uasset.py
@@ -17,7 +17,7 @@ class UAssetLoader(plugin.Loader):
 
     product_types = {"uasset"}
     label = "Load UAsset"
-    representations = ["uasset"]
+    representations = {"uasset"}
     icon = "cube"
     color = "orange"
 
@@ -166,6 +166,6 @@ class UMapLoader(UAssetLoader):
 
     product_types = {"uasset"}
     label = "Load Level"
-    representations = ["umap"]
+    representations = {"umap"}
 
     extension = "umap"

--- a/client/ayon_core/hosts/unreal/plugins/load/load_yeticache.py
+++ b/client/ayon_core/hosts/unreal/plugins/load/load_yeticache.py
@@ -17,7 +17,7 @@ class YetiLoader(plugin.Loader):
 
     product_types = {"yeticacheUE"}
     label = "Import Yeti"
-    representations = ["abc"]
+    representations = {"abc"}
     icon = "pagelines"
     color = "orange"
 

--- a/client/ayon_core/pipeline/load/plugins.py
+++ b/client/ayon_core/pipeline/load/plugins.py
@@ -162,6 +162,15 @@ class LoaderPlugin(list):
 
     @classmethod
     def get_representations(cls):
+        """Representation names with which is plugin compatible.
+
+        Empty set makes the plugin incompatible with any representation. To
+            allow compatibility with all representations use '{"*"}'.
+
+        Returns:
+            set[str]: Names with which is plugin compatible.
+
+        """
         return cls.representations
 
     @classmethod

--- a/client/ayon_core/pipeline/load/plugins.py
+++ b/client/ayon_core/pipeline/load/plugins.py
@@ -24,7 +24,7 @@ class LoaderPlugin(list):
     """
 
     product_types = set()
-    representations = []
+    representations = set()
     extensions = {"*"}
     order = 0
     is_multiple_contexts_compatible = False

--- a/client/ayon_core/plugins/load/copy_file.py
+++ b/client/ayon_core/plugins/load/copy_file.py
@@ -5,7 +5,7 @@ from ayon_core.pipeline import load
 class CopyFile(load.LoaderPlugin):
     """Copy the published file to be pasted at the desired location"""
 
-    representations = ["*"]
+    representations = {"*"}
     product_types = {"*"}
 
     label = "Copy File"

--- a/client/ayon_core/plugins/load/copy_file_path.py
+++ b/client/ayon_core/plugins/load/copy_file_path.py
@@ -5,7 +5,7 @@ from ayon_core.pipeline import load
 
 class CopyFilePath(load.LoaderPlugin):
     """Copy published file path to clipboard"""
-    representations = ["*"]
+    representations = {"*"}
     product_types = {"*"}
 
     label = "Copy File Path"

--- a/client/ayon_core/plugins/load/delete_old_versions.py
+++ b/client/ayon_core/plugins/load/delete_old_versions.py
@@ -26,7 +26,7 @@
 #     is_multiple_contexts_compatible = True
 #     sequence_splitter = "__sequence_splitter__"
 #
-#     representations = ["*"]
+#     representations = {"*"}
 #     product_types = {"*"}
 #     tool_names = ["library_loader"]
 #

--- a/client/ayon_core/plugins/load/delivery.py
+++ b/client/ayon_core/plugins/load/delivery.py
@@ -28,7 +28,7 @@ class Delivery(load.ProductLoaderPlugin):
     is_multiple_contexts_compatible = True
     sequence_splitter = "__sequence_splitter__"
 
-    representations = ["*"]
+    representations = {"*"}
     product_types = {"*"}
     tool_names = ["library_loader"]
 

--- a/client/ayon_core/plugins/load/open_file.py
+++ b/client/ayon_core/plugins/load/open_file.py
@@ -19,7 +19,7 @@ class OpenFile(load.LoaderPlugin):
     """Open Image Sequence or Video with system default"""
 
     product_types = {"render2d"}
-    representations = ["*"]
+    representations = {"*"}
 
     label = "Open"
     order = -10

--- a/client/ayon_core/plugins/load/push_to_library.py
+++ b/client/ayon_core/plugins/load/push_to_library.py
@@ -11,7 +11,7 @@ class PushToLibraryProject(load.ProductLoaderPlugin):
 
     is_multiple_contexts_compatible = True
 
-    representations = ["*"]
+    representations = {"*"}
     product_types = {"*"}
 
     label = "Push to Library project"


### PR DESCRIPTION
## Changelog Description
Use `set` instead of `list` to define compatible representation names.

## Additional info
This does not break backwards compatibility, using `list` is still possible. The change just helps to define ideal typehint, which is set.

## Testing notes:
Loaders are shown in UI.
