### PR TITLE
Chore: Mark known bare except handling with noqa

### DIFF
--- a/client/ayon_core/hosts/blender/api/lib.py
+++ b/client/ayon_core/hosts/blender/api/lib.py
@@ -33,7 +33,7 @@ def load_scripts(paths):
         if register:
             try:
                 register()
-            except:
+            except:  # noqa E722
                 traceback.print_exc()
         else:
             print("\nWarning! '%s' has no register function, "
@@ -45,7 +45,7 @@ def load_scripts(paths):
         if unregister:
             try:
                 unregister()
-            except:
+            except:  # noqa E722
                 traceback.print_exc()
 
     def test_reload(mod):
@@ -57,7 +57,7 @@ def load_scripts(paths):
 
         try:
             return importlib.reload(mod)
-        except:
+        except:  # noqa E722
             traceback.print_exc()
 
     def test_register(mod):

--- a/client/ayon_core/hosts/photoshop/plugins/create/create_image.py
+++ b/client/ayon_core/hosts/photoshop/plugins/create/create_image.py
@@ -53,7 +53,7 @@ class ImageCreator(Creator):
             stub.select_layers(stub.get_layers())
             try:
                 group = stub.group_selected_layers(product_name_from_ui)
-            except:
+            except:  # noqa E722
                 raise CreatorError("Cannot group locked Background layer!")
             groups_to_create.append(group)
 

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -2053,7 +2053,7 @@ class CreateContext:
             exc_info = sys.exc_info()
             self.log.warning(error_message.format(identifier, exc_info[1]))
 
-        except:
+        except:  # noqa: E722
             add_traceback = True
             exc_info = sys.exc_info()
             self.log.warning(
@@ -2163,7 +2163,7 @@ class CreateContext:
                 exc_info = sys.exc_info()
                 self.log.warning(error_message.format(identifier, exc_info[1]))
 
-            except:
+            except:  # noqa: E722
                 failed = True
                 add_traceback = True
                 exc_info = sys.exc_info()
@@ -2197,7 +2197,7 @@ class CreateContext:
             try:
                 convertor.find_instances()
 
-            except:
+            except:  # noqa: E722
                 failed_info.append(
                     prepare_failed_convertor_operation_info(
                         convertor.identifier, sys.exc_info()
@@ -2373,7 +2373,7 @@ class CreateContext:
                 exc_info = sys.exc_info()
                 self.log.warning(error_message.format(identifier, exc_info[1]))
 
-            except:
+            except:  # noqa: E722
                 failed = True
                 add_traceback = True
                 exc_info = sys.exc_info()
@@ -2440,7 +2440,7 @@ class CreateContext:
                     error_message.format(identifier, exc_info[1])
                 )
 
-            except:
+            except:  # noqa: E722
                 failed = True
                 add_traceback = True
                 exc_info = sys.exc_info()
@@ -2546,7 +2546,7 @@ class CreateContext:
             try:
                 self.run_convertor(convertor_identifier)
 
-            except:
+            except:  # noqa: E722
                 failed_info.append(
                     prepare_failed_convertor_operation_info(
                         convertor_identifier, sys.exc_info()

--- a/client/ayon_core/tools/adobe_webserver/app.py
+++ b/client/ayon_core/tools/adobe_webserver/app.py
@@ -109,7 +109,7 @@ class WebServerTool:
         try:
             sock.bind((host_name, port))
             result = False
-        except:
+        except:  # noqa E722
             print("Port is in use")
 
         return result


### PR DESCRIPTION
## Changelog Description
Bare except error capture is ignored for linters.

## Additional info
PR related to https://github.com/ynput/ayon-core/pull/196. The bare except is usually used when the raised exception does not inherit from python `BaseException` (e.g. in Houdini).