### PR TITLE
TVPaint: Fix filename formatting in workflie load plugin

### DIFF
--- a/client/ayon_core/hosts/tvpaint/plugins/load/load_workfile.py
+++ b/client/ayon_core/hosts/tvpaint/plugins/load/load_workfile.py
@@ -1,6 +1,5 @@
 import os
 
-from ayon_core.lib import StringTemplate
 from ayon_core.pipeline import (
     registered_host,
     get_current_context,
@@ -111,8 +110,6 @@ class LoadWorkfile(plugin.Loader):
 
         data["version"] = version
 
-        filename = StringTemplate.format_strict_template(
-            file_template, data
-        )
+        filename = work_template["file"].format_strict(data)
         path = os.path.join(work_root, filename)
         host.save_workfile(path)


### PR DESCRIPTION
## Changelog Description
Workfile load plugin in TVPaint did use unavailable variable for file template.

## Testing notes:
1. Workfile loader works in TVPaint.
