### PR TITLE
Hiero: Precollect instances variable fix

### DIFF
--- a/client/ayon_core/hosts/hiero/plugins/publish/precollect_instances.py
+++ b/client/ayon_core/hosts/hiero/plugins/publish/precollect_instances.py
@@ -92,10 +92,6 @@ class PrecollectInstances(pyblish.api.ContextPlugin):
 
             folder_path, folder_name = self._get_folder_data(tag_data)
 
-            product_name = tag_data.get("productName")
-            if product_name is None:
-                product_name = tag_data["subset"]
-
             families = [str(f) for f in tag_data["families"]]
 
             # TODO: remove backward compatibility

--- a/client/ayon_core/hosts/hiero/plugins/publish/precollect_instances.py
+++ b/client/ayon_core/hosts/hiero/plugins/publish/precollect_instances.py
@@ -293,7 +293,7 @@ class PrecollectInstances(pyblish.api.ContextPlugin):
         label += " {}".format(product_name)
 
         data.update({
-            "name": "{}_{}".format(folder_path, subset),
+            "name": "{}_{}".format(folder_path, product_name),
             "label": label,
             "productName": product_name,
             "productType": product_type,


### PR DESCRIPTION
## Changelog Description
Fix variable used to calculate instance name.

## Additional info
There was used variable `subset` instead of `product_name` to calculate instance name. Also removed duplicated code receiving product name from tag data.

## Testing notes:
1. Precollect instances works.
