### PR TITLE
Chore: Small code cleanup

### DIFF
--- a/client/ayon_core/addons/applications/ayon_applications/__init__.py
+++ b/client/ayon_core/addons/applications/ayon_applications/__init__.py
@@ -31,6 +31,7 @@ from .addon import ApplicationsAddon
 
 
 __all__ = (
+    "APPLICATIONS_ADDON_ROOT",
     "DEFAULT_ENV_SUBGROUP",
     "PLATFORM_NAMES",
 

--- a/client/ayon_core/hosts/traypublisher/plugins/create/create_editorial.py
+++ b/client/ayon_core/hosts/traypublisher/plugins/create/create_editorial.py
@@ -402,7 +402,7 @@ or updating already created. Publishing will create OTIO file.
                     ):
                         continue
 
-                    instance = self._make_product_instance(
+                    self._make_product_instance(
                         otio_clip,
                         product_type_preset,
                         deepcopy(base_instance_data),

--- a/client/ayon_core/hosts/unreal/api/__init__.py
+++ b/client/ayon_core/hosts/unreal/api/__init__.py
@@ -28,11 +28,11 @@ from .pipeline import (
 )
 
 __all__ = [
-    "install",
-    "uninstall",
     "UnrealActorCreator",
     "UnrealAssetCreator",
     "Loader",
+    "install",
+    "uninstall",
     "ls",
     "publish",
     "containerise",

--- a/client/ayon_core/hosts/unreal/api/__init__.py
+++ b/client/ayon_core/hosts/unreal/api/__init__.py
@@ -30,6 +30,8 @@ from .pipeline import (
 __all__ = [
     "install",
     "uninstall",
+    "UnrealActorCreator",
+    "UnrealAssetCreator",
     "Loader",
     "ls",
     "publish",

--- a/client/ayon_core/modules/loader_action.py
+++ b/client/ayon_core/modules/loader_action.py
@@ -13,7 +13,7 @@ class LoaderAddon(AYONAddon, ITrayAddon):
         # Add library tool
         self._loader_imported = False
         try:
-            from ayon_core.tools.loader.ui import LoaderWindow
+            from ayon_core.tools.loader.ui import LoaderWindow  # noqa F401
 
             self._loader_imported = True
         except Exception:

--- a/client/ayon_core/scripts/slates/slate_base/base.py
+++ b/client/ayon_core/scripts/slates/slate_base/base.py
@@ -82,20 +82,6 @@ class BaseObj:
     def main_style(self):
         return load_default_style()
 
-    def height(self):
-        raise NotImplementedError(
-            "Attribute `height` is not implemented for <{}>".format(
-                self.__clas__.__name__
-            )
-        )
-
-    def width(self):
-        raise NotImplementedError(
-            "Attribute `width` is not implemented for <{}>".format(
-                self.__clas__.__name__
-            )
-        )
-
     def collect_data(self):
         return None
 

--- a/client/ayon_core/tools/publisher/control_qt.py
+++ b/client/ayon_core/tools/publisher/control_qt.py
@@ -343,8 +343,9 @@ class QtRemotePublishController(BasePublisherController):
 
     @abstractmethod
     def _send_instance_changes_to_client(self):
-        instance_changes = self._get_instance_changes_for_client()
-        # Implement to send 'instance_changes' value to client
+        # TODO Implement to send 'instance_changes' value to client
+        # instance_changes = self._get_instance_changes_for_client()
+        pass
 
     @abstractmethod
     def save_changes(self):

--- a/client/ayon_core/tools/tray/tray.py
+++ b/client/ayon_core/tools/tray/tray.py
@@ -552,7 +552,7 @@ class TrayStarter(QtCore.QObject):
 def main():
     app = get_ayon_qt_app()
 
-    starter = TrayStarter(app)
+    starter = TrayStarter(app)  # noqa F841
 
     if not is_running_from_build() and os.name == "nt":
         import ctypes

--- a/client/ayon_core/tools/utils/color_widgets/color_inputs.py
+++ b/client/ayon_core/tools/utils/color_widgets/color_inputs.py
@@ -562,11 +562,11 @@ class HSLInputs(QtWidgets.QWidget):
             return
 
         self._block_changes = True
-        h, s, l, _ = self.color.getHsl()
+        hue, sat, lum, _ = self.color.getHsl()
 
-        self.input_hue.setValue(h)
-        self.input_sat.setValue(s)
-        self.input_light.setValue(l)
+        self.input_hue.setValue(hue)
+        self.input_sat.setValue(sat)
+        self.input_light.setValue(lum)
 
         self._block_changes = False
 

--- a/client/ayon_core/tools/utils/widgets.py
+++ b/client/ayon_core/tools/utils/widgets.py
@@ -578,7 +578,8 @@ class OptionalAction(QtWidgets.QWidgetAction):
     def set_option_tip(self, options):
         sep = "\n\n"
         if not options or not isinstance(options[0], AbstractAttrDef):
-            mak = (lambda opt: opt["name"] + " :\n    " + opt["help"])
+            def mak(opt):
+                return opt["name"] + " :\n    " + opt["help"]
             self.option_tip = sep.join(mak(opt) for opt in options)
             return
 


### PR DESCRIPTION
## Changelog Description
Small code cleanup. Mark unused variables and imports that have purpose to be ignored by linters, or removed the variables. Added imported variables to `__all__`. Converted lambda to function. Use better variable naming.

## Additional info
PR related to https://github.com/ynput/ayon-core/pull/196.

## Testing notes:
1. Logic did not change. Validate if it's true.
