### PR TITLE
Blender: Qt binding fix for blender 4

### DIFF
--- a/client/ayon_core/hosts/blender/addon.py
+++ b/client/ayon_core/hosts/blender/addon.py
@@ -55,8 +55,7 @@ class BlenderAddon(AYONAddon, IHostAddon):
         )
 
         # Define Qt binding if not defined
-        if not env.get("QT_PREFERRED_BINDING"):
-            env["QT_PREFERRED_BINDING"] = "PySide2"
+        env.pop("QT_PREFERRED_BINDING", None)
 
     def get_launch_hook_paths(self, app):
         if app.host_name != self.host_name:

--- a/client/ayon_core/hosts/blender/hooks/pre_pyside_install.py
+++ b/client/ayon_core/hosts/blender/hooks/pre_pyside_install.py
@@ -31,7 +31,7 @@ class InstallPySideToBlender(PreLaunchHook):
 
     def inner_execute(self):
         # Get blender's python directory
-        version_regex = re.compile(r"^[2-4]\.[0-9]+$")
+        version_regex = re.compile(r"^([2-4])\.[0-9]+$")
 
         platform = system().lower()
         executable = self.launch_context.executable.executable_path
@@ -42,7 +42,8 @@ class InstallPySideToBlender(PreLaunchHook):
         if os.path.basename(executable).lower() != expected_executable:
             self.log.info((
                 f"Executable does not lead to {expected_executable} file."
-                "Can't determine blender's python to check/install PySide2."
+                "Can't determine blender's python to check/install"
+                " Qt binding."
             ))
             return
 
@@ -73,6 +74,12 @@ class InstallPySideToBlender(PreLaunchHook):
             return
 
         version_subfolder = version_subfolders[0]
+        before_blender_4 = False
+        if int(version_regex.match(version_subfolder).group(1)) < 4:
+            before_blender_4 = True
+        # Blender 4 has Python 3.11 which does not support 'PySide2'
+        # QUESTION could we always install PySide6?
+        qt_binding = "PySide2" if before_blender_4 else "PySide6"
 
         python_dir = os.path.join(versions_dir, version_subfolder, "python")
         python_lib = os.path.join(python_dir, "lib")

--- a/client/ayon_core/hosts/blender/hooks/pre_pyside_install.py
+++ b/client/ayon_core/hosts/blender/hooks/pre_pyside_install.py
@@ -80,6 +80,9 @@ class InstallPySideToBlender(PreLaunchHook):
         # Blender 4 has Python 3.11 which does not support 'PySide2'
         # QUESTION could we always install PySide6?
         qt_binding = "PySide2" if before_blender_4 else "PySide6"
+        # Use PySide6 6.6.3 because 6.7.0 had a bug
+        #   - 'QTextEdit' can't be added to 'QBoxLayout'
+        qt_binding_version = None if before_blender_4 else "6.6.3"
 
         python_dir = os.path.join(versions_dir, version_subfolder, "python")
         python_lib = os.path.join(python_dir, "lib")
@@ -130,11 +133,16 @@ class InstallPySideToBlender(PreLaunchHook):
         # Install PySide2 in blender's python
         if platform == "windows":
             result = self.install_pyside_windows(
-                python_executable, qt_binding, before_blender_4
+                python_executable,
+                qt_binding,
+                qt_binding_version,
+                before_blender_4,
             )
         else:
             result = self.install_pyside(
-                python_executable, qt_binding
+                python_executable,
+                qt_binding,
+                qt_binding_version,
             )
 
         if result:
@@ -147,7 +155,11 @@ class InstallPySideToBlender(PreLaunchHook):
             )
 
     def install_pyside_windows(
-        self, python_executable, qt_binding, before_blender_4
+        self,
+        python_executable,
+        qt_binding,
+        qt_binding_version,
+        before_blender_4,
     ):
         """Install PySide2 python module to blender's python.
 
@@ -166,6 +178,9 @@ class InstallPySideToBlender(PreLaunchHook):
         except Exception:
             self.log.warning("Couldn't import \"pywin32\" modules")
             return
+
+        if qt_binding_version:
+            qt_binding = f"{qt_binding}=={qt_binding_version}"
 
         try:
             # Parameters
@@ -212,8 +227,15 @@ class InstallPySideToBlender(PreLaunchHook):
         except pywintypes.error:
             pass
 
-    def install_pyside(self, python_executable, qt_binding):
-        """Install PySide2 python module to blender's python."""
+    def install_pyside(
+        self,
+        python_executable,
+        qt_binding,
+        qt_binding_version,
+    ):
+        """Install Qt binding python module to blender's python."""
+        if qt_binding_version:
+            qt_binding = f"{qt_binding}=={qt_binding_version}"
         try:
             # Parameters
             # - use "-m pip" as module pip to install qt binding and argument


### PR DESCRIPTION
## Changelog Description
Fix installation of Qt binding.

## Additional info
Newer version of blender is using newer version of python which does not support PySide2, but does support PySide6. So PySide6 is used instead. Also new version of python does install the package to different place on windows which is fixed by using `--prefix` leading to blender python root.

## Testing notes:
1. Qt binding is automatically installed to blender 4
2. Blender integration works.
