### PR TITLE
Chore: Run commnad fix

### DIFF
--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -176,9 +176,9 @@ def run(script):
     #     future versions might remove it.
     first_arg = sys.argv[0]
     if is_running_from_build():
-        comp_path = os.path.join(os.environ["AYON_ROOT"], "start.py")
-    else:
         comp_path = os.getenv("AYON_EXECUTABLE")
+    else:
+        comp_path = os.path.join(os.environ["AYON_ROOT"], "start.py")
     # Compare paths and remove first argument if it is the same as AYON
     if Path(first_arg).resolve() == Path(comp_path).resolve():
         sys.argv.pop(0)


### PR DESCRIPTION
## Changelog Description
Check for correct first argument.

## Additional info
It was checking for start.py when running from build and for python.exe when running from code which is oposite.

## Testing notes:
1. Command `run` should remove first argument correctly.
