### PR TITLE
Substance Painter: add missing 8k option into texture export size setting in the texture creator

### DIFF
--- a/client/ayon_core/hosts/substancepainter/plugins/create/create_textures.py
+++ b/client/ayon_core/hosts/substancepainter/plugins/create/create_textures.py
@@ -144,7 +144,8 @@ class CreateTextures(Creator):
                         9: "512",
                         10: "1024",
                         11: "2048",
-                        12: "4096"
+                        12: "4096",
+                        13: "8192"
                     },
                     default=None,
                     label="Size"),


### PR DESCRIPTION
## Changelog Description
This PR is to add missing 8k option into texture size setting in the texture creator

## Additional info
n/a

## Testing notes:
1. Launch Substance Painter
2. The `Size` Setting of Create TextureSet now supports the 8k texture exports.