### PR TITLE
Chore: Prepare data does care only about string values

### DIFF
--- a/client/ayon_core/lib/plugin_tools.py
+++ b/client/ayon_core/lib/plugin_tools.py
@@ -94,8 +94,12 @@ def prepare_template_data(fill_pairs):
     output = {}
     for item in valid_items:
         keys, value = item
-        upper_value = value.upper()
-        capitalized_value = _capitalize_value(value)
+        # Convert only string values
+        if isinstance(value, str):
+            upper_value = value.upper()
+            capitalized_value = _capitalize_value(value)
+        else:
+            upper_value = capitalized_value = value
 
         first_key = keys.pop(0)
         if not keys:


### PR DESCRIPTION
## Changelog Description
Convert only string values in prepare data and keep others unchanged.

## Additional info
Before this PR the function would crash on any other type than string (e.g. on integer).
