### PR TITLE
Maya: Validate Maya Workspace fix report not formatting the root dir variable

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/validate_scene_set_workspace.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/validate_scene_set_workspace.py
@@ -46,6 +46,6 @@ class ValidateSceneSetWorkspace(pyblish.api.ContextPlugin):
             raise PublishValidationError(
                 "Maya workspace is not set correctly.\n\n"
                 f"Current workfile `{scene_name}` is not inside the "
-                "current Maya project root directory `{root_dir}`.\n\n"
+                f"current Maya project root directory `{root_dir}`.\n\n"
                 "Please use Workfile app to re-save."
             )


### PR DESCRIPTION
## Changelog Description

Fix formatting of `root_dir` variable.

## Additional info

n/a

## Testing notes:

1. Open a file that is not in the current workspace of your context
2. The validation report should list the folder it should be in, instead of printing `{root_dir}` as text.