### PR TITLE
Maya: Publish camera preserve image plane size

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/extract_camera_mayaScene.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/extract_camera_mayaScene.py
@@ -299,4 +299,10 @@ def transfer_image_planes(source_cameras, target_cameras,
 
 def _attach_image_plane(camera, image_plane):
     cmds.imagePlane(image_plane, edit=True, detach=True)
+
+    # Attaching to a camera resets it to identity size, so we counter that
+    size_x = cmds.getAttr(f"{image_plane}.sizeX")
+    size_y = cmds.getAttr(f"{image_plane}.sizeY")
     cmds.imagePlane(image_plane, edit=True, camera=camera)
+    cmds.setAttr(f"{image_plane}.sizeX", size_x)
+    cmds.setAttr(f"{image_plane}.sizeY", size_y)


### PR DESCRIPTION
## Changelog Description

Preserve (customized) image plane sizing on camera publishing

## Additional info

Fixes #411 

## Testing notes:

1. Apply an image plane to the camera
2. Change the Placement > "size" of the image plane
3. Publish the camera
4. The image plane's placement should be preserved

For completeness sake - also test some other attributes, like "Fit", "Offset", "Depth", "Rotate", etc. that an artist may customize on Image Planes - those values should also be preserved.