### PR TITLE
Chore: Workfile template builder context usage fix

### DIFF
--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1532,19 +1532,17 @@ class PlaceholderLoadMixin(object):
     def _reduce_last_version_repre_entities(self, repre_contexts):
         """Reduce representations to last verison."""
 
-        mapping = {}
+        version_mapping_by_product_id = {}
         for repre_context in repre_contexts:
-            folder_id = repre_context["folder"]["id"]
             product_id = repre_context["product"]["id"]
             version = repre_context["version"]["version"]
-
-            parents_path = "/".join([folder_id, product_id])
-            version_mapping = mapping.setdefault(parents_path, {})
-
+            version_mapping = version_mapping_by_product_id.setdefault(
+                product_id, {}
+            )
             version_mapping[version].append(repre_context)
 
         output = []
-        for version_mapping in mapping.values():
+        for version_mapping in version_mapping_by_product_id.values():
             last_version = tuple(sorted(version_mapping.keys()))[-1]
             output.extend(version_mapping[last_version])
         return output

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1468,7 +1468,9 @@ class PlaceholderLoadMixin(object):
         product_name_regex = None
         if product_name_regex_value:
             product_name_regex = re.compile(product_name_regex_value)
-        product_type = placeholder.data["family"]
+        product_type = placeholder.data.get("product_type")
+        if product_type is None:
+            product_type = placeholder.data.get("family")
 
         builder_type = placeholder.data["builder_type"]
         folder_ids = []

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1470,7 +1470,7 @@ class PlaceholderLoadMixin(object):
             product_name_regex = re.compile(product_name_regex_value)
         product_type = placeholder.data.get("product_type")
         if product_type is None:
-            product_type = placeholder.data.get("family")
+            product_type = placeholder.data["family"]
 
         builder_type = placeholder.data["builder_type"]
         folder_ids = []

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1582,7 +1582,7 @@ class PlaceholderLoadMixin(object):
             self.project_name, placeholder_representations
         )
         filtered_repre_contexts = self._reduce_last_version_repre_entities(
-            repre_load_contexts
+            repre_load_contexts.values()
         )
         if not filtered_repre_contexts:
             self.log.info((

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1587,14 +1587,14 @@ class PlaceholderLoadMixin(object):
 
         placeholder_representations = self._get_representations(placeholder)
 
-        filtered_representations = []
-        for representation in self._reduce_last_version_repre_entities(
-            placeholder_representations
-        ):
-            repre_id = representation["id"]
-            if repre_id not in ignore_repre_ids:
-                filtered_representations.append(representation)
-
+        filtered_representations = [
+            repre_entity
+            for repre_entity in self._get_representations(placeholder)
+            if repre_entity["id"] not in ignore_repre_ids
+        ]
+        filtered_representations = self._reduce_last_version_repre_entities(
+            filtered_representations
+        )
         if not filtered_representations:
             self.log.info((
                 "There's no representation for this placeholder: {}"

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1530,7 +1530,7 @@ class PlaceholderLoadMixin(object):
         pass
 
     def _reduce_last_version_repre_entities(self, repre_contexts):
-        """Reduce representations to last verison."""
+        """Reduce representations to last version."""
 
         version_mapping_by_product_id = {}
         for repre_context in repre_contexts:

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1539,11 +1539,11 @@ class PlaceholderLoadMixin(object):
             version_mapping = version_mapping_by_product_id.setdefault(
                 product_id, {}
             )
-            version_mapping[version].append(repre_context)
+            version_mapping.setdefault(version, []).append(repre_context)
 
         output = []
         for version_mapping in version_mapping_by_product_id.values():
-            last_version = tuple(sorted(version_mapping.keys()))[-1]
+            last_version = max(version_mapping.keys())
             output.extend(version_mapping[last_version])
         return output
 


### PR DESCRIPTION
## Changelog Description
Do not use data from representation `"context"` values, instead use values from parent entities.

## Additional info
Modification should fix loading of representations without `"asset"` and `"subset"` in their `"context"` values that should be used for template fill. Issue discovered with https://github.com/ynput/ayon-core/pull/330 .

## Testing notes:
1. Workfile template builder should be able to load representations without the values
