### PR TITLE
Chore: Correct applications addon version

### DIFF
--- a/client/ayon_core/addon/base.py
+++ b/client/ayon_core/addon/base.py
@@ -50,7 +50,7 @@ IGNORED_MODULES_IN_AYON = set()
 # When addon was moved from ayon-core codebase
 # - this is used to log the missing addon
 MOVED_ADDON_MILESTONE_VERSIONS = {
-    "applications": VersionInfo(2, 0, 0),
+    "applications": VersionInfo(0, 2, 0),
 }
 
 # Inherit from `object` for Python 2 hosts


### PR DESCRIPTION
## Changelog Description
Validate correct version of applications addon.

## Additional info
There was a bug in applications addon version for validation of compatibility with ayon core.

## Testing notes:
1. Applications addon is loaded and applications can be launched.
