### PR TITLE
Maya: Xgen Inventory Actions broken by typo in code

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/inventory/connect_geometry.py
+++ b/client/ayon_core/hosts/maya/plugins/inventory/connect_geometry.py
@@ -37,7 +37,7 @@ class ConnectGeometry(InventoryAction):
             repre_id = container["representation"]
             repre_context = repre_contexts_by_id[repre_id]
 
-            product_type = repre_context["prouct"]["productType"]
+            product_type = repre_context["product"]["productType"]
 
             containers_by_product_type.setdefault(product_type, [])
             containers_by_product_type[product_type].append(container)

--- a/client/ayon_core/hosts/maya/plugins/inventory/connect_xgen.py
+++ b/client/ayon_core/hosts/maya/plugins/inventory/connect_xgen.py
@@ -36,7 +36,7 @@ class ConnectXgen(InventoryAction):
             repre_id = container["representation"]
             repre_context = repre_contexts_by_id[repre_id]
 
-            product_type = repre_context["prouct"]["productType"]
+            product_type = repre_context["product"]["productType"]
 
             containers_by_product_type.setdefault(product_type, [])
             containers_by_product_type[product_type].append(container)

--- a/client/ayon_core/hosts/maya/plugins/inventory/connect_yeti_rig.py
+++ b/client/ayon_core/hosts/maya/plugins/inventory/connect_yeti_rig.py
@@ -39,7 +39,7 @@ class ConnectYetiRig(InventoryAction):
             repre_id = container["representation"]
             repre_context = repre_contexts_by_id[repre_id]
 
-            product_type = repre_context["prouct"]["productType"]
+            product_type = repre_context["product"]["productType"]
 
             containers_by_product_type.setdefault(product_type, [])
             containers_by_product_type[product_type].append(container)


### PR DESCRIPTION
Just fixing typo in ```product``` entity.

