### PR TITLE
Fusion: Launch menu hook fix PreLaunchHook import

### DIFF
--- a/client/ayon_core/hosts/fusion/hooks/pre_fusion_launch_menu_hook.py
+++ b/client/ayon_core/hosts/fusion/hooks/pre_fusion_launch_menu_hook.py
@@ -1,5 +1,5 @@
 import os
-from ayon_core.lib import PreLaunchHook
+from ayon_applications import PreLaunchHook
 from ayon_core.hosts.fusion import FUSION_HOST_DIR
 
 


### PR DESCRIPTION
## Changelog Description

Fusion: Launch menu hook fix PreLaunchHook import

## Additional info

Fix after refactor of separating ayon applications addon.

Fixes:
```
WARNING:ayon_core.lib.python_module_tools:Failed to load path: "E:\dev\ayon-core\client\ayon_core\hosts\fusion\hooks\pre_fusion_launch_menu_hook.py"
Traceback (most recent call last):
  File "E:\dev\ayon-core\client\ayon_core\lib\python_module_tools.py", line 92, in modules_from_path
    module = import_filepath(full_path, mod_name)
  File "E:\dev\ayon-core\client\ayon_core\lib\python_module_tools.py", line 38, in import_filepath
    module_loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "E:\dev\ayon-core\client\ayon_core\hosts\fusion\hooks\pre_fusion_launch_menu_hook.py", line 2, in <module>
    from ayon_core.lib import PreLaunchHook
ImportError: cannot import name 'PreLaunchHook' from 'ayon_core.lib' (E:\dev\ayon-core\client\ayon_core\lib\__init__.py)>>> 
```

## Testing notes:
1. Enable launch menu on start in settings
2. The menu should show on fusion launch
3. Also, the console should show no launching errors.
