### PR TITLE
Fix usage of `BaseServerAddon` when only imported for type checking

### DIFF
--- a/server_addon/deadline/server/settings/main.py
+++ b/server_addon/deadline/server/settings/main.py
@@ -22,7 +22,7 @@ class ServerListSubmodel(BaseSettingsModel):
 
 
 async def defined_deadline_ws_name_enum_resolver(
-    addon: BaseServerAddon,
+    addon: "BaseServerAddon",
     settings_variant: str = "production",
     project_name: str | None = None,
 ) -> list[str]:


### PR DESCRIPTION
## Changelog Description

Fix Deadline Server addon.

## Additional info

Fixes:
```
Failed to initialize addon /addons/deadline/0.1.10

    Traceback (most recent call last):
      File "/backend/ayon_server/addons/definition.py", line 92, in versions
        self.init_addon(version_dir)
      File "/backend/ayon_server/addons/definition.py", line 156, in init_addon
        module = import_module(vname, server_module_path)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/backend/ayon_server/addons/utils.py", line 18, in import_module
        spec.loader.exec_module(module)
      File "<frozen importlib._bootstrap_external>", line 940, in exec_module
      File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
      File "/addons/deadline/0.1.10/server/__init__.py", line 6, in <module>
        from .settings import DeadlineSettings, DEFAULT_VALUES
      File "/addons/deadline/0.1.10/server/settings/__init__.py", line 1, in <module>
        from .main import (
      File "/addons/deadline/0.1.10/server/settings/main.py", line 25, in <module>
        addon: BaseServerAddon,
               ^^^^^^^^^^^^^^^
    NameError: name 'BaseServerAddon' is not defined
```

## Testing notes:

1. Create deadline addon
2. Upload deadline addon
3. Restart server
4. Deadline addon should work