### PR TITLE
Chore: Fix typos/grammar and docstrings in Workfile Templates

### DIFF
--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -329,7 +329,7 @@ class AbstractTemplateBuilder(object):
         is good practice to check if the same value is not already stored under
         different key or if the key is not already used for something else.
 
-        Key should be self explanatory to content.
+        Key should be self-explanatory to content.
         - wrong: 'folder'
         - good: 'folder_name'
 
@@ -375,7 +375,7 @@ class AbstractTemplateBuilder(object):
         is good practice to check if the same value is not already stored under
         different key or if the key is not already used for something else.
 
-        Key should be self explanatory to content.
+        Key should be self-explanatory to content.
         - wrong: 'folder'
         - good: 'folder_path'
 
@@ -395,7 +395,7 @@ class AbstractTemplateBuilder(object):
         is good practice to check if the same value is not already stored under
         different key or if the key is not already used for something else.
 
-        Key should be self explanatory to content.
+        Key should be self-explanatory to content.
         - wrong: 'folder'
         - good: 'folder_path'
 
@@ -466,7 +466,7 @@ class AbstractTemplateBuilder(object):
 
         return list(sorted(
             placeholders,
-            key=lambda i: i.order
+            key=lambda placeholder: placeholder.order
         ))
 
     def build_template(
@@ -685,7 +685,7 @@ class AbstractTemplateBuilder(object):
             for placeholder in placeholders
         }
         all_processed = len(placeholders) == 0
-        # Counter is checked at the ned of a loop so the loop happens at least
+        # Counter is checked at the end of a loop so the loop happens at least
         #   once.
         iter_counter = 0
         while not all_processed:
@@ -1045,7 +1045,7 @@ class PlaceholderPlugin(object):
 
         Using shared data from builder but stored under plugin identifier.
 
-        Key should be self explanatory to content.
+        Key should be self-explanatory to content.
         - wrong: 'folder'
         - good: 'folder_path'
 
@@ -1085,7 +1085,7 @@ class PlaceholderPlugin(object):
 
         Using shared data from builder but stored under plugin identifier.
 
-        Key should be self explanatory to content.
+        Key should be self-explanatory to content.
         - wrong: 'folder'
         - good: 'folder_path'
 
@@ -1107,10 +1107,10 @@ class PlaceholderItem(object):
     """Item representing single item in scene that is a placeholder to process.
 
     Items are always created and updated by their plugins. Each plugin can use
-    modified class of 'PlacehoderItem' but only to add more options instead of
+    modified class of 'PlaceholderItem' but only to add more options instead of
     new other.
 
-    Scene identifier is used to avoid processing of the palceholder item
+    Scene identifier is used to avoid processing of the placeholder item
     multiple times so must be unique across whole workfile builder.
 
     Args:
@@ -1162,7 +1162,7 @@ class PlaceholderItem(object):
         """Placeholder data which can modify how placeholder is processed.
 
         Possible general keys
-        - order: Can define the order in which is palceholder processed.
+        - order: Can define the order in which is placeholder processed.
                     Lower == earlier.
 
         Other keys are defined by placeholder and should validate them on item
@@ -1264,7 +1264,7 @@ class PlaceholderLoadMixin(object):
         """Unified attribute definitions for load placeholder.
 
         Common function for placeholder plugins used for loading of
-        repsentations. Use it in 'get_placeholder_options'.
+        representations. Use it in 'get_placeholder_options'.
 
         Args:
             plugin (PlaceholderPlugin): Plugin used for loading of

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1267,8 +1267,6 @@ class PlaceholderLoadMixin(object):
         representations. Use it in 'get_placeholder_options'.
 
         Args:
-            plugin (PlaceholderPlugin): Plugin used for loading of
-                representations.
             options (Dict[str, Any]): Already available options which are used
                 as defaults for attributes.
 
@@ -1695,8 +1693,6 @@ class PlaceholderCreateMixin(object):
         publishable instances. Use it with 'get_placeholder_options'.
 
         Args:
-            plugin (PlaceholderPlugin): Plugin used for creating of
-                publish instances.
             options (Dict[str, Any]): Already available options which are used
                 as defaults for attributes.
 

--- a/client/ayon_core/tools/workfile_template_build/lib.py
+++ b/client/ayon_core/tools/workfile_template_build/lib.py
@@ -8,12 +8,12 @@ from ayon_core.tools.utils.dialogs import show_message_dialog
 def open_template_ui(builder, main_window):
     """Open template from `builder`
 
-    Asks user about overwriting current scene and feedsback exceptions.
+    Asks user about overwriting current scene and feedback exceptions.
     """
     result = QtWidgets.QMessageBox.question(
         main_window,
         "Opening template",
-        "Caution! You will loose unsaved changes.\nDo you want to continue?",
+        "Caution! You will lose unsaved changes.\nDo you want to continue?",
         QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No
     )
     if result == QtWidgets.QMessageBox.Yes:


### PR DESCRIPTION
## Changelog Description

Fix some typos/grammar and docstrings in Workfile Templates

## Additional info

n/a

## Testing notes:

1. Review the code changes.
2. Workfile templates should still work (but reviewing code might already suffice, it's mostly cosmetics)