### PR TITLE
Workfile Templates: Delete placeholder if Keep Placeholder is not enabled

### DIFF
--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1599,6 +1599,8 @@ class PlaceholderLoadMixin(object):
             self.log.info((
                 "There's no representation for this placeholder: {}"
             ).format(placeholder.scene_identifier))
+            if not placeholder.data.get("keep_placeholder", True):
+                self.delete_placeholder(placeholder)
             return
 
         repre_load_contexts = get_representation_contexts(


### PR DESCRIPTION
## Changelog Description

If a load placeholder plugin did **not** end up loading any content it would not be removed when Keep Placeholder was disabled.

## Additional info

Extracted from #327 

## Testing notes:

1. Build a workfile template with a load placeholder that does **not** load anything
2. Make sure the template is build with Keep Placeholders OFF.
3. The placeholder should be deleted after the build.