### PR TITLE
Maya: Collect File Dependencies fix `apply_settings` signature

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/publish/collect_file_dependencies.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/collect_file_dependencies.py
@@ -12,7 +12,7 @@ class CollectFileDependencies(pyblish.api.ContextPlugin):
     families = ["renderlayer"]
 
     @classmethod
-    def apply_settings(cls, project_settings, system_settings):
+    def apply_settings(cls, project_settings):
         # Disable plug-in if not used for deadline submission anyway
         settings = project_settings["deadline"]["publish"]["MayaSubmitDeadline"]  # noqa
         cls.enabled = settings.get("asset_dependencies", True)


### PR DESCRIPTION
## Changelog Description

Fix Collect File Dependencies fix `apply_settings` signature

## Additional info

Fixes error:
```python
# ==============================
# CollectFileDependencies.apply_settings() missing 1 required positional argument: 'system_settings'
# ==============================
# Traceback (most recent call last):
#   File "E:\dev\ayon-core\client\ayon_core\pipeline\publish\lib.py", line 450, in filter_pyblish_plugins
#     plugin.apply_settings(project_settings)
TypeError: CollectFileDependencies.apply_settings() missing 1 required positional argument: 'system_settings'
```

**Note:**

Also, looking at the `apply_settings` logic this may actually only work if the deadline plug-in is enabled. Since it's so specific to Deadline, should we move it into the Deadline plug-ins instead? So that no errors should be generated for Collect File Dependencies plug-in (e.g. on publisher reset) if no deadline package is in current bundle and the saved settings, so `project_settings.deadline` may not exist.

@iLLiCiTiT thoughts?

## Testing notes:

1. Resetting publisher in maya should now show this warning.
2. Collect File Dependencies plug-in should work as intended when enabled.

