### PR TITLE
Collect AOV names to anatomy data

### DIFF
--- a/client/ayon_core/pipeline/farm/pyblish_functions.py
+++ b/client/ayon_core/pipeline/farm/pyblish_functions.py
@@ -621,9 +621,11 @@ def _create_instances_for_aov(instance, skeleton, aov_filter, additional_data,
         new_instance = deepcopy(skeleton)
         new_instance["productName"] = product_name
         new_instance["productGroup"] = group_name
+        if aov:
+            new_instance["aovName"] = aov
 
         # toggle preview on if multipart is on
-        # Because we cant query the multipartExr data member of each AOV we'll
+        # Because we can't query the multipartExr data member of each AOV we'll
         # need to have hardcoded rule of excluding any renders with
         # "cryptomatte" in the file name from being a multipart EXR. This issue
         # happens with Redshift that forces Cryptomatte renders to be separate

--- a/client/ayon_core/plugins/publish/collect_aovs_to_anatomy_instance_data.py
+++ b/client/ayon_core/plugins/publish/collect_aovs_to_anatomy_instance_data.py
@@ -1,0 +1,22 @@
+import pyblish.api
+
+
+class CollectAOVNameToAnatomyInstanceData(pyblish.api.InstancePlugin):
+    """
+    Collect AOV name to template data.
+
+    Note:
+        This functionality depends on AOV name added by
+        ``submit_publish_job`` plugin and so it only works
+        with Deadline submission.
+
+    """
+    order = pyblish.api.CollectorOrder + 0.499
+    targets = ["farm"]
+    label = "Collect AOV name to template data"
+
+    def process(self, instance):
+        if "aovName" not in instance.data:
+            return
+
+        instance.data["anatomyData"]["aov_name"] = instance.data["aovName"]


### PR DESCRIPTION
## Changelog Description
Simple change to collect AOV names if present on Deadline submission to be used in templates as `aov_name`.

## Additional info
This works only with Deadline submissions, for local renders it needs to be collected elsewhere.

## Testing notes:
1. Submit job with separated AOVs to farm
2. Define anatomy template to use `{aov_name}`
