### PR TITLE
Workfiles: Select latest workfile automatically

### DIFF
--- a/client/ayon_core/tools/workfiles/widgets/files_widget_workarea.py
+++ b/client/ayon_core/tools/workfiles/widgets/files_widget_workarea.py
@@ -416,9 +416,11 @@ class WorkAreaFilesWidget(QtWidgets.QWidget):
 
         # Find the row with latest date modified
         latest_index = max(
-            (self._proxy_model.index(i, 0) for
-             i in range(self._proxy_model.rowCount())),
-            key=lambda model_index: model_index.date(DATE_MODIFIED_ROLE)
+            (
+                self._proxy_model.index(idx, 0)
+                for idx in range(self._proxy_model.rowCount())
+            ),
+            key=lambda model_index: model_index.data(DATE_MODIFIED_ROLE)
         )
 
         # Select row of latest modified

--- a/client/ayon_core/tools/workfiles/widgets/files_widget_workarea.py
+++ b/client/ayon_core/tools/workfiles/widgets/files_widget_workarea.py
@@ -414,16 +414,20 @@ class WorkAreaFilesWidget(QtWidgets.QWidget):
         ):
             return
 
-        first_index = self._proxy_model.index(0, 0)
-        last_index = self._proxy_model.index(
-            0, self._proxy_model.columnCount() - 1
+        # Find the row with latest date modified
+        latest_index = max(
+            (self._proxy_model.index(i, 0) for
+             i in range(self._proxy_model.rowCount())),
+            key=lambda model_index: model_index.date(DATE_MODIFIED_ROLE)
         )
-        selection = QtCore.QItemSelection(first_index, last_index)
-        seleciton_model = self._view.selectionModel()
-        seleciton_model.select(
-            selection,
+
+        # Select row of latest modified
+        selection_model = self._view.selectionModel()
+        selection_model.select(
+            latest_index,
             (
                 QtCore.QItemSelectionModel.ClearAndSelect
                 | QtCore.QItemSelectionModel.Current
+                | QtCore.QItemSelectionModel.Rows
             )
         )

--- a/client/ayon_core/tools/workfiles/widgets/files_widget_workarea.py
+++ b/client/ayon_core/tools/workfiles/widgets/files_widget_workarea.py
@@ -20,6 +20,8 @@ class WorkAreaFilesModel(QtGui.QStandardItemModel):
         controller (AbstractWorkfilesFrontend): The control object.
     """
 
+    refreshed = QtCore.Signal()
+
     def __init__(self, controller):
         super(WorkAreaFilesModel, self).__init__()
 
@@ -163,6 +165,12 @@ class WorkAreaFilesModel(QtGui.QStandardItemModel):
             self._fill_items()
 
     def _fill_items(self):
+        try:
+            self._fill_items_impl()
+        finally:
+            self.refreshed.emit()
+
+    def _fill_items_impl(self):
         folder_id = self._selected_folder_id
         task_id = self._selected_task_id
         if not folder_id or not task_id:
@@ -285,6 +293,7 @@ class WorkAreaFilesWidget(QtWidgets.QWidget):
         selection_model.selectionChanged.connect(self._on_selection_change)
         view.double_clicked.connect(self._on_mouse_double_click)
         view.customContextMenuRequested.connect(self._on_context_menu)
+        model.refreshed.connect(self._on_model_refresh)
 
         controller.register_event_callback(
             "expected_selection_changed",
@@ -298,6 +307,7 @@ class WorkAreaFilesWidget(QtWidgets.QWidget):
         self._controller = controller
 
         self._published_mode = False
+        self._change_selection_on_refresh = True
 
     def set_published_mode(self, published_mode):
         """Set the published mode.
@@ -379,7 +389,9 @@ class WorkAreaFilesWidget(QtWidgets.QWidget):
         if not workfile_info["current"]:
             return
 
+        self._change_selection_on_refresh = False
         self._model.refresh()
+        self._change_selection_on_refresh = True
 
         workfile_name = workfile_info["name"]
         if (
@@ -393,4 +405,25 @@ class WorkAreaFilesWidget(QtWidgets.QWidget):
 
         self._controller.expected_workfile_selected(
             event["folder"]["id"], event["task"]["name"], workfile_name
+        )
+
+    def _on_model_refresh(self):
+        if (
+            not self._change_selection_on_refresh
+            or self._proxy_model.rowCount() < 1
+        ):
+            return
+
+        first_index = self._proxy_model.index(0, 0)
+        last_index = self._proxy_model.index(
+            0, self._proxy_model.columnCount() - 1
+        )
+        selection = QtCore.QItemSelection(first_index, last_index)
+        seleciton_model = self._view.selectionModel()
+        seleciton_model.select(
+            selection,
+            (
+                QtCore.QItemSelectionModel.ClearAndSelect
+                | QtCore.QItemSelectionModel.Current
+            )
         )

--- a/client/ayon_core/tools/workfiles/widgets/window.py
+++ b/client/ayon_core/tools/workfiles/widgets/window.py
@@ -118,11 +118,11 @@ class WorkfilesToolWindow(QtWidgets.QWidget):
         overlay_invalid_host = InvalidHostOverlay(self)
         overlay_invalid_host.setVisible(False)
 
-        first_show_timer = QtCore.QTimer()
-        first_show_timer.setSingleShot(True)
-        first_show_timer.setInterval(50)
+        show_timer = QtCore.QTimer()
+        show_timer.setSingleShot(True)
+        show_timer.setInterval(50)
 
-        first_show_timer.timeout.connect(self._on_first_show)
+        show_timer.timeout.connect(self._on_show)
 
         controller.register_event_callback(
             "save_as.finished",
@@ -159,7 +159,7 @@ class WorkfilesToolWindow(QtWidgets.QWidget):
         self._tasks_widget = tasks_widget
         self._side_panel = side_panel
 
-        self._first_show_timer = first_show_timer
+        self._show_timer = show_timer
 
         self._post_init()
 
@@ -287,9 +287,9 @@ class WorkfilesToolWindow(QtWidgets.QWidget):
 
     def showEvent(self, event):
         super(WorkfilesToolWindow, self).showEvent(event)
+        self._show_timer.start()
         if self._first_show:
             self._first_show = False
-            self._first_show_timer.start()
             self.setStyleSheet(style.load_stylesheet())
 
     def keyPressEvent(self, event):
@@ -303,9 +303,8 @@ class WorkfilesToolWindow(QtWidgets.QWidget):
 
         pass
 
-    def _on_first_show(self):
-        if not self._controller_refreshed:
-            self.refresh()
+    def _on_show(self):
+        self.refresh()
 
     def _on_file_text_filter_change(self, text):
         self._files_widget.set_text_filter(text)


### PR DESCRIPTION
## Changelog Description

By default select the file with the latest date modified..

## Additional info

Fixes #434 

Note: in some odd cases where an artists saves over an older version than that file will have the latest date modified and hence will be selected. It's not the latest version, but latest date modified.

## Testing notes:

1. Open workfiles tool
2. Browsing different tasks and folders should always default to selecting the latest workfile.
3. It should feel logical for the majority of production cases.
4. Clicking refresh in the UI should not change the selection.