### PR TITLE
Maya: optional shader stripping for model

### DIFF
--- a/client/ayon_core/hosts/maya/plugins/create/create_model.py
+++ b/client/ayon_core/hosts/maya/plugins/create/create_model.py
@@ -39,5 +39,9 @@ class CreateModel(plugin.MayaCreator):
                     placeholder="attr1, attr2"),
             TextDef("attrPrefix",
                     label="Custom Attributes Prefix",
-                    placeholder="prefix1, prefix2")
+                    placeholder="prefix1, prefix2"),
+            BoolDef("strip_shaders",
+                    label="Strip Shaders",
+                    tooltip="Remove shaders from the geometry",
+                    default=True),
         ]

--- a/client/ayon_core/hosts/maya/plugins/publish/extract_obj.py
+++ b/client/ayon_core/hosts/maya/plugins/publish/extract_obj.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 import os
+from contextlib import nullcontext
 
-from maya import cmds
 import pyblish.api
-from ayon_core.pipeline import publish
 from ayon_core.hosts.maya.api import lib
+from ayon_core.pipeline import publish
+from maya import cmds
 
 
 class ExtractObj(publish.Extractor):
@@ -45,6 +46,8 @@ class ExtractObj(publish.Extractor):
         if not cmds.pluginInfo('objExport', query=True, loaded=True):
             cmds.loadPlugin('objExport')
 
+        strip_shader = instance.data.get("strip_shaders", True)
+
         # Export
         with lib.no_display_layers(instance):
             with lib.displaySmoothness(members,
@@ -54,7 +57,7 @@ class ExtractObj(publish.Extractor):
                                        pointsShaded=1,
                                        polygonObject=1):
                 with lib.shader(members,
-                                shadingEngine="initialShadingGroup"):
+                                shadingEngine="initialShadingGroup") if strip_shader else nullcontext():  # noqa: E501:
                     with lib.maintained_selection():
                         cmds.select(members, noExpand=True)
                         cmds.file(path,

--- a/server_addon/maya/server/settings/creators.py
+++ b/server_addon/maya/server/settings/creators.py
@@ -54,7 +54,8 @@ class BasicExportMeshModel(BaseSettingsModel):
     default_variants: list[str] = SettingsField(
         default_factory=list,
         title="Default Products"
-    )
+    ),
+    strip_shaders: bool = SettingsField(title="Strip Shaders")
 
 
 class CreateAnimationModel(BaseSettingsModel):
@@ -292,7 +293,8 @@ DEFAULT_CREATORS_SETTINGS = {
             "Main",
             "Proxy",
             "Sculpt"
-        ]
+        ],
+        "strip_shaders": True,
     },
     "CreatePointCache": {
         "enabled": True,


### PR DESCRIPTION
## Changelog Description
Shaders are stripped from the model during extraction in Maya. This is adding option to disable that feature to retain shaders if needed.

## Additional info
This is affecting OBJ extractor and Maya Scene model extractor. Default behavior is backwards compatible (stripping on), can be configured in creator settings.

## Testing notes:
1. create model in Maya
2. disable shader stripping option
3. publish
4. load model - shaders should still be there
