### PR TITLE
Chore: Fix import in create ayon addons

### DIFF
--- a/server_addon/create_ayon_addons.py
+++ b/server_addon/create_ayon_addons.py
@@ -5,7 +5,7 @@ import shutil
 import argparse
 import zipfile
 import types
-import importlib
+import importlib.machinery
 import platform
 import collections
 from pathlib import Path


### PR DESCRIPTION
## Changelog Description
Fix import of `importlib.machinery` in create package script.

## Testing notes:
1. Create ayon addons script works.
