### PR TITLE
Houdini fails to start because missing settings

### DIFF
--- a/client/ayon_core/hosts/houdini/hooks/set_default_display_and_view.py
+++ b/client/ayon_core/hosts/houdini/hooks/set_default_display_and_view.py
@@ -25,7 +25,12 @@ class SetDefaultDisplayView(PreLaunchHook):
             return
 
         houdini_color_settings = \
-            self.data["project_settings"]["houdini"]["imageio"]["workfile"]
+            self.data["project_settings"]["houdini"]["imageio"].get("workfile", {})
+
+        if not houdini_color_settings:
+            self.log.info("Hook 'SetDefaultDisplayView' requires Houdini "
+                           "addon version >= '0.2.13'")
+            return
 
         if not houdini_color_settings["enabled"]:
             self.log.info(

--- a/client/ayon_core/hosts/houdini/hooks/set_default_display_and_view.py
+++ b/client/ayon_core/hosts/houdini/hooks/set_default_display_and_view.py
@@ -24,8 +24,9 @@ class SetDefaultDisplayView(PreLaunchHook):
         if not OCIO:
             return
 
+        # workfile settings added in '0.2.13'
         houdini_color_settings = \
-            self.data["project_settings"]["houdini"]["imageio"].get("workfile", {})
+            self.data["project_settings"]["houdini"]["imageio"].get("workfile")
 
         if not houdini_color_settings:
             self.log.info("Hook 'SetDefaultDisplayView' requires Houdini "

--- a/client/ayon_core/hosts/houdini/plugins/create/create_review.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_review.py
@@ -18,8 +18,11 @@ class CreateReview(plugin.HoudiniCreator):
 
     def apply_settings(self, project_settings):
         super(CreateReview, self).apply_settings(project_settings)
-        color_settings = project_settings["houdini"]["imageio"].get("workfile", {})
-        if color_settings and color_settings["enabled"]:
+        # workfile settings added in '0.2.13'
+        color_settings = project_settings["houdini"]["imageio"].get(
+            "workfile", {}
+        )
+        if not color_settings.get("enabled"):
             self.review_color_space = color_settings.get("review_color_space")
 
     def create(self, product_name, instance_data, pre_create_data):

--- a/client/ayon_core/hosts/houdini/plugins/create/create_review.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_review.py
@@ -18,8 +18,8 @@ class CreateReview(plugin.HoudiniCreator):
 
     def apply_settings(self, project_settings):
         super(CreateReview, self).apply_settings(project_settings)
-        color_settings = project_settings["houdini"]["imageio"]["workfile"]
-        if color_settings["enabled"]:
+        color_settings = project_settings["houdini"]["imageio"].get("workfile", {})
+        if color_settings and color_settings["enabled"]:
             self.review_color_space = color_settings.get("review_color_space")
 
     def create(self, product_name, instance_data, pre_create_data):

--- a/client/ayon_core/hosts/houdini/plugins/create/create_review.py
+++ b/client/ayon_core/hosts/houdini/plugins/create/create_review.py
@@ -22,7 +22,7 @@ class CreateReview(plugin.HoudiniCreator):
         color_settings = project_settings["houdini"]["imageio"].get(
             "workfile", {}
         )
-        if not color_settings.get("enabled"):
+        if color_settings.get("enabled"):
             self.review_color_space = color_settings.get("review_color_space")
 
     def create(self, product_name, instance_data, pre_create_data):

--- a/client/ayon_core/hosts/houdini/plugins/publish/validate_review_colorspace.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/validate_review_colorspace.py
@@ -46,8 +46,8 @@ class ValidateReviewColorspace(pyblish.api.InstancePlugin,
         apply_plugin_settings_automatically(cls, settings, logger=cls.log)
 
         # Add review color settings
-        color_settings = project_settings["houdini"]["imageio"]["workfile"]
-        if color_settings["enabled"]:
+        color_settings = project_settings["houdini"]["imageio"].get("workfile", {})
+        if color_settings and color_settings["enabled"]:
             cls.review_color_space = color_settings.get("review_color_space")
 
 

--- a/client/ayon_core/hosts/houdini/plugins/publish/validate_review_colorspace.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/validate_review_colorspace.py
@@ -50,7 +50,7 @@ class ValidateReviewColorspace(pyblish.api.InstancePlugin,
             "workfile", {}
         )
         # Add review color settings
-        if not color_settings.get("enabled"):
+        if color_settings.get("enabled"):
             cls.review_color_space = color_settings.get("review_color_space")
 
 

--- a/client/ayon_core/hosts/houdini/plugins/publish/validate_review_colorspace.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/validate_review_colorspace.py
@@ -45,9 +45,12 @@ class ValidateReviewColorspace(pyblish.api.InstancePlugin,
                                        category="houdini")
         apply_plugin_settings_automatically(cls, settings, logger=cls.log)
 
+        # workfile settings added in '0.2.13'
+        color_settings = project_settings["houdini"]["imageio"].get(
+            "workfile", {}
+        )
         # Add review color settings
-        color_settings = project_settings["houdini"]["imageio"].get("workfile", {})
-        if color_settings and color_settings["enabled"]:
+        if not color_settings.get("enabled"):
             cls.review_color_space = color_settings.get("review_color_space")
 
 


### PR DESCRIPTION
## Changelog Description
This error happens when admins update core addon without updating Houdini addon.
which can result in an error in this Houdini hook `SetDefaultDisplayView` and some review publish plugins because an expected Houdini setting won't be available which will raise an error. 
 
An alternative solution to split the Addons which by design won't update the client code of Houdini without uploading the new addon.

## Additional Info
I don't know whether this PR should be merged or we should just wait till the addons be split. 
Maybe @iLLiCiTiT can tell

## Testing notes:
Launching Houdini with the latest develop while not uploading the new Houdini addon shouldn't raise errors. 
you can do so by using Ayon in dev mode and pull latest `develop`.