### PR TITLE
Applications: Define compatibility of addon

### DIFF
--- a/server_addon/applications/package.py
+++ b/server_addon/applications/package.py
@@ -1,3 +1,10 @@
 name = "applications"
 title = "Applications"
 version = "0.2.0"
+
+ayon_server_version = ">=1.0.7"
+ayon_launcher_version = ">=1.0.2"
+ayon_required_addons = {
+    "core": ">0.3.0",
+}
+ayon_compatible_addons = {}


### PR DESCRIPTION
## Changelog Description
Applications addon has defined compatibility.

## Additional info
Changes are related to https://github.com/ynput/ayon-backend/pull/127 as it is new feature, not released on server, and because core 0.3.1 is not yet out, the version of addon is kept at 0.2.0.

## Testing notes:
1. This change can be tested only with https://github.com/ynput/ayon-backend/pull/127
2. It would not be allowed to create bundle with applications 0.2.0 addon and core 0.3.0 or lower.
