### PR TITLE
Chore: Move cache item to lib

### DIFF
--- a/client/ayon_core/lib/__init__.py
+++ b/client/ayon_core/lib/__init__.py
@@ -27,6 +27,10 @@ from .local_settings import (
     get_openpype_username,
 )
 from .ayon_connection import initialize_ayon_connection
+from .cache import (
+    CacheItem,
+    NestedCacheItem,
+)
 from .events import (
     emit_event,
     register_event_callback
@@ -156,6 +160,9 @@ __all__ = [
     "get_openpype_username",
 
     "initialize_ayon_connection",
+
+    "CacheItem",
+    "NestedCacheItem",
 
     "emit_event",
     "register_event_callback",

--- a/client/ayon_core/lib/cache.py
+++ b/client/ayon_core/lib/cache.py
@@ -14,7 +14,6 @@ def _default_factory_func():
 class CacheItem:
     """Simple cache item with lifetime and default factory for default value.
 
-
     Default factory should return default value that is used on init
         and on reset.
 
@@ -22,8 +21,8 @@ class CacheItem:
         default_factory (Optional[callable]): Function that returns default
             value used on init and on reset.
         lifetime (Optional[int]): Lifetime of the cache data in seconds.
-    """
 
+    """
     def __init__(self, default_factory=None, lifetime=None):
         if lifetime is None:
             lifetime = 120
@@ -40,8 +39,8 @@ class CacheItem:
 
         Return:
             bool: True if cache is valid, False otherwise.
-        """
 
+        """
         if self._last_update is None:
             return False
 
@@ -72,8 +71,8 @@ class CacheItem:
 
         Returns:
             Any: Any data that are cached.
-        """
 
+        """
         return self._data
 
     def update_data(self, data):
@@ -106,8 +105,8 @@ class NestedCacheItem:
         lifetime (Optional[int]): Lifetime of the cache data in seconds.
         _init_info (Optional[InitInfo]): Private argument. Init info for
             nested cache where created from parent item.
-    """
 
+    """
     def __init__(
         self, levels=1, default_factory=None, lifetime=None, _init_info=None
     ):
@@ -127,8 +126,8 @@ class NestedCacheItem:
 
         Returns:
             Union[NestedCacheItem, CacheItem]: Cache item.
-        """
 
+        """
         cache = self._data_by_key.get(key)
         if cache is None:
             if self._levels > 1:
@@ -150,8 +149,8 @@ class NestedCacheItem:
         Args:
             key (str): Key of the cache item.
             value (Any): Any data that are cached.
-        """
 
+        """
         if self._levels > 1:
             raise AttributeError((
                 "{} does not support '__setitem__'. Lower nested level by {}"
@@ -167,8 +166,8 @@ class NestedCacheItem:
 
         Returns:
             Union[NestedCacheItem, CacheItem]: Cache item.
-        """
 
+        """
         return self[key]
 
     def cached_count(self):
@@ -176,8 +175,8 @@ class NestedCacheItem:
 
         Returns:
             int: Amount of cached items.
-        """
 
+        """
         return len(self._data_by_key)
 
     def clear_key(self, key):
@@ -185,8 +184,8 @@ class NestedCacheItem:
 
         Args:
             key (str): Key of the cache item.
-        """
 
+        """
         self._data_by_key.pop(key, None)
 
     def clear_invalid(self):
@@ -194,8 +193,8 @@ class NestedCacheItem:
 
         Note:
             To clear all cache items use 'reset'.
-        """
 
+        """
         changed = {}
         children_are_nested = self._levels > 1
         for key, cache in tuple(self._data_by_key.items()):
@@ -215,8 +214,8 @@ class NestedCacheItem:
 
         Note:
             To clear only invalid cache items use 'clear_invalid'.
-        """
 
+        """
         self._data_by_key = {}
 
     def set_lifetime(self, lifetime):
@@ -224,8 +223,8 @@ class NestedCacheItem:
 
         Args:
             lifetime (int): Lifetime of the cache data in seconds.
-        """
 
+        """
         self._init_info.lifetime = lifetime
         for cache in self._data_by_key.values():
             cache.set_lifetime(lifetime)
@@ -236,8 +235,8 @@ class NestedCacheItem:
 
         Raises:
             AttributeError: If called on nested cache item.
-        """
 
+        """
         raise AttributeError((
             "{} does not support 'is_valid'. Lower nested level by '{}'"
         ).format(self.__class__.__name__, self._levels))

--- a/client/ayon_core/lib/cache.py
+++ b/client/ayon_core/lib/cache.py
@@ -21,6 +21,7 @@ class CacheItem:
         default_factory (Optional[callable]): Function that returns default
             value used on init and on reset.
         lifetime (Optional[int]): Lifetime of the cache data in seconds.
+            Default lifetime is 120 seconds.
 
     """
     def __init__(self, default_factory=None, lifetime=None):

--- a/client/ayon_core/lib/cache.py
+++ b/client/ayon_core/lib/cache.py
@@ -1,0 +1,243 @@
+import time
+import collections
+
+InitInfo = collections.namedtuple(
+    "InitInfo",
+    ["default_factory", "lifetime"]
+)
+
+
+def _default_factory_func():
+    return None
+
+
+class CacheItem:
+    """Simple cache item with lifetime and default factory for default value.
+
+
+    Default factory should return default value that is used on init
+        and on reset.
+
+    Args:
+        default_factory (Optional[callable]): Function that returns default
+            value used on init and on reset.
+        lifetime (Optional[int]): Lifetime of the cache data in seconds.
+    """
+
+    def __init__(self, default_factory=None, lifetime=None):
+        if lifetime is None:
+            lifetime = 120
+        self._lifetime = lifetime
+        self._last_update = None
+        if default_factory is None:
+            default_factory = _default_factory_func
+        self._default_factory = default_factory
+        self._data = default_factory()
+
+    @property
+    def is_valid(self):
+        """Is cache valid to use.
+
+        Return:
+            bool: True if cache is valid, False otherwise.
+        """
+
+        if self._last_update is None:
+            return False
+
+        return (time.time() - self._last_update) < self._lifetime
+
+    def set_lifetime(self, lifetime):
+        """Change lifetime of cache item.
+
+        Args:
+            lifetime (int): Lifetime of the cache data in seconds.
+        """
+
+        self._lifetime = lifetime
+
+    def set_invalid(self):
+        """Set cache as invalid."""
+
+        self._last_update = None
+
+    def reset(self):
+        """Set cache as invalid and reset data."""
+
+        self._last_update = None
+        self._data = self._default_factory()
+
+    def get_data(self):
+        """Receive cached data.
+
+        Returns:
+            Any: Any data that are cached.
+        """
+
+        return self._data
+
+    def update_data(self, data):
+        self._data = data
+        self._last_update = time.time()
+
+
+class NestedCacheItem:
+    """Helper for cached items stored in nested structure.
+
+    Example:
+        >>> cache = NestedCacheItem(levels=2, default_factory=lambda: 0)
+        >>> cache["a"]["b"].is_valid
+        False
+        >>> cache["a"]["b"].get_data()
+        0
+        >>> cache["a"]["b"] = 1
+        >>> cache["a"]["b"].is_valid
+        True
+        >>> cache["a"]["b"].get_data()
+        1
+        >>> cache.reset()
+        >>> cache["a"]["b"].is_valid
+        False
+
+    Args:
+        levels (int): Number of nested levels where read cache is stored.
+        default_factory (Optional[callable]): Function that returns default
+            value used on init and on reset.
+        lifetime (Optional[int]): Lifetime of the cache data in seconds.
+        _init_info (Optional[InitInfo]): Private argument. Init info for
+            nested cache where created from parent item.
+    """
+
+    def __init__(
+        self, levels=1, default_factory=None, lifetime=None, _init_info=None
+    ):
+        if levels < 1:
+            raise ValueError("Nested levels must be greater than 0")
+        self._data_by_key = {}
+        if _init_info is None:
+            _init_info = InitInfo(default_factory, lifetime)
+        self._init_info = _init_info
+        self._levels = levels
+
+    def __getitem__(self, key):
+        """Get cached data.
+
+        Args:
+            key (str): Key of the cache item.
+
+        Returns:
+            Union[NestedCacheItem, CacheItem]: Cache item.
+        """
+
+        cache = self._data_by_key.get(key)
+        if cache is None:
+            if self._levels > 1:
+                cache = NestedCacheItem(
+                    levels=self._levels - 1,
+                    _init_info=self._init_info
+                )
+            else:
+                cache = CacheItem(
+                    self._init_info.default_factory,
+                    self._init_info.lifetime
+                )
+            self._data_by_key[key] = cache
+        return cache
+
+    def __setitem__(self, key, value):
+        """Update cached data.
+
+        Args:
+            key (str): Key of the cache item.
+            value (Any): Any data that are cached.
+        """
+
+        if self._levels > 1:
+            raise AttributeError((
+                "{} does not support '__setitem__'. Lower nested level by {}"
+            ).format(self.__class__.__name__, self._levels - 1))
+        cache = self[key]
+        cache.update_data(value)
+
+    def get(self, key):
+        """Get cached data.
+
+        Args:
+            key (str): Key of the cache item.
+
+        Returns:
+            Union[NestedCacheItem, CacheItem]: Cache item.
+        """
+
+        return self[key]
+
+    def cached_count(self):
+        """Amount of cached items.
+
+        Returns:
+            int: Amount of cached items.
+        """
+
+        return len(self._data_by_key)
+
+    def clear_key(self, key):
+        """Clear cached item by key.
+
+        Args:
+            key (str): Key of the cache item.
+        """
+
+        self._data_by_key.pop(key, None)
+
+    def clear_invalid(self):
+        """Clear all invalid cache items.
+
+        Note:
+            To clear all cache items use 'reset'.
+        """
+
+        changed = {}
+        children_are_nested = self._levels > 1
+        for key, cache in tuple(self._data_by_key.items()):
+            if children_are_nested:
+                output = cache.clear_invalid()
+                if output:
+                    changed[key] = output
+                if not cache.cached_count():
+                    self._data_by_key.pop(key)
+            elif not cache.is_valid:
+                changed[key] = cache.get_data()
+                self._data_by_key.pop(key)
+        return changed
+
+    def reset(self):
+        """Reset cache.
+
+        Note:
+            To clear only invalid cache items use 'clear_invalid'.
+        """
+
+        self._data_by_key = {}
+
+    def set_lifetime(self, lifetime):
+        """Change lifetime of all children cache items.
+
+        Args:
+            lifetime (int): Lifetime of the cache data in seconds.
+        """
+
+        self._init_info.lifetime = lifetime
+        for cache in self._data_by_key.values():
+            cache.set_lifetime(lifetime)
+
+    @property
+    def is_valid(self):
+        """Raise reasonable error when called on wrong level.
+
+        Raises:
+            AttributeError: If called on nested cache item.
+        """
+
+        raise AttributeError((
+            "{} does not support 'is_valid'. Lower nested level by '{}'"
+        ).format(self.__class__.__name__, self._levels))

--- a/client/ayon_core/lib/cache.py
+++ b/client/ayon_core/lib/cache.py
@@ -110,6 +110,7 @@ class NestedCacheItem:
         default_factory (Optional[callable]): Function that returns default
             value used on init and on reset.
         lifetime (Optional[int]): Lifetime of the cache data in seconds.
+            Default value is based on default value of 'CacheItem'.
         _init_info (Optional[InitInfo]): Private argument. Init info for
             nested cache where created from parent item.
 

--- a/client/ayon_core/lib/cache.py
+++ b/client/ayon_core/lib/cache.py
@@ -76,6 +76,12 @@ class CacheItem:
         return self._data
 
     def update_data(self, data):
+        """Update cache data.
+
+        Args:
+            data (Any): Any data that are cached.
+
+        """
         self._data = data
         self._last_update = time.time()
 

--- a/client/ayon_core/pipeline/anatomy/anatomy.py
+++ b/client/ayon_core/pipeline/anatomy/anatomy.py
@@ -431,13 +431,13 @@ class Anatomy(BaseAnatomy):
     @classmethod
     def get_project_entity_from_cache(cls, project_name):
         project_cache = cls._project_cache[project_name]
-        if project_cache.is_outdated:
+        if not project_cache.is_valid:
             project_cache.update_data(ayon_api.get_project(project_name))
         return copy.deepcopy(project_cache.get_data())
 
     @classmethod
     def get_sitesync_addon(cls):
-        if cls._sitesync_addon_cache.is_outdated:
+        if not cls._sitesync_addon_cache.is_valid:
             manager = AddonsManager()
             cls._sitesync_addon_cache.update_data(
                 manager.get_enabled_addon("sitesync")
@@ -487,14 +487,14 @@ class Anatomy(BaseAnatomy):
         elif not site_name:
             # Use sync server to receive active site name
             project_cache = cls._default_site_id_cache[project_name]
-            if project_cache.is_outdated:
+            if not project_cache.is_valid:
                 project_cache.update_data(
                     sitesync_addon.get_active_site_type(project_name)
                 )
             site_name = project_cache.get_data()
 
         site_cache = cls._root_overrides_cache[project_name][site_name]
-        if site_cache.is_outdated:
+        if not site_cache.is_valid:
             if site_name == "studio":
                 # Handle studio root overrides without sync server
                 # - studio root overrides can be done even without sync server

--- a/client/ayon_core/pipeline/anatomy/anatomy.py
+++ b/client/ayon_core/pipeline/anatomy/anatomy.py
@@ -3,11 +3,16 @@ import re
 import copy
 import platform
 import collections
-import time
 
 import ayon_api
 
-from ayon_core.lib import Logger, get_local_site_id, StringTemplate
+from ayon_core.lib import (
+    Logger,
+    get_local_site_id,
+    StringTemplate,
+    CacheItem,
+    NestedCacheItem,
+)
 from ayon_core.addon import AddonsManager
 
 from .exceptions import RootCombinationError, ProjectNotSet
@@ -397,62 +402,11 @@ class BaseAnatomy(object):
             )
 
 
-class CacheItem:
-    """Helper to cache data.
-
-    Helper does not handle refresh of data and does not mark data as outdated.
-    Who uses the object should check of outdated state on his own will.
-    """
-
-    default_lifetime = 10
-
-    def __init__(self, lifetime=None):
-        self._data = None
-        self._cached = None
-        self._lifetime = lifetime or self.default_lifetime
-
-    @property
-    def data(self):
-        """Cached data/object.
-
-        Returns:
-            Any: Whatever was cached.
-        """
-
-        return self._data
-
-    @property
-    def is_outdated(self):
-        """Item has outdated cache.
-
-        Lifetime of cache item expired or was not yet set.
-
-        Returns:
-            bool: Item is outdated.
-        """
-
-        if self._cached is None:
-            return True
-        return (time.time() - self._cached) > self._lifetime
-
-    def update_data(self, data):
-        """Update cache of data.
-
-        Args:
-            data (Any): Data to cache.
-        """
-
-        self._data = data
-        self._cached = time.time()
-
-
 class Anatomy(BaseAnatomy):
-    _sitesync_addon_cache = CacheItem()
-    _project_cache = collections.defaultdict(CacheItem)
-    _default_site_id_cache = collections.defaultdict(CacheItem)
-    _root_overrides_cache = collections.defaultdict(
-        lambda: collections.defaultdict(CacheItem)
-    )
+    _sitesync_addon_cache = CacheItem(lifetime=10)
+    _project_cache = NestedCacheItem(lifetime=10)
+    _default_site_id_cache = NestedCacheItem(lifetime=10)
+    _root_overrides_cache = NestedCacheItem(2, lifetime=10)
 
     def __init__(
         self, project_name=None, site_name=None, project_entity=None
@@ -479,7 +433,7 @@ class Anatomy(BaseAnatomy):
         project_cache = cls._project_cache[project_name]
         if project_cache.is_outdated:
             project_cache.update_data(ayon_api.get_project(project_name))
-        return copy.deepcopy(project_cache.data)
+        return copy.deepcopy(project_cache.get_data())
 
     @classmethod
     def get_sitesync_addon(cls):
@@ -488,7 +442,7 @@ class Anatomy(BaseAnatomy):
             cls._sitesync_addon_cache.update_data(
                 manager.get_enabled_addon("sitesync")
             )
-        return cls._sitesync_addon_cache.data
+        return cls._sitesync_addon_cache.get_data()
 
     @classmethod
     def _get_studio_roots_overrides(cls, project_name):
@@ -537,7 +491,7 @@ class Anatomy(BaseAnatomy):
                 project_cache.update_data(
                     sitesync_addon.get_active_site_type(project_name)
                 )
-            site_name = project_cache.data
+            site_name = project_cache.get_data()
 
         site_cache = cls._root_overrides_cache[project_name][site_name]
         if site_cache.is_outdated:
@@ -553,4 +507,4 @@ class Anatomy(BaseAnatomy):
                     project_name, site_name
                 )
             site_cache.update_data(roots_overrides)
-        return site_cache.data
+        return site_cache.get_data()

--- a/client/ayon_core/pipeline/anatomy/anatomy.py
+++ b/client/ayon_core/pipeline/anatomy/anatomy.py
@@ -403,10 +403,10 @@ class BaseAnatomy(object):
 
 
 class Anatomy(BaseAnatomy):
-    _sitesync_addon_cache = CacheItem(lifetime=10)
     _project_cache = NestedCacheItem(lifetime=10)
-    _default_site_id_cache = NestedCacheItem(lifetime=10)
-    _root_overrides_cache = NestedCacheItem(2, lifetime=10)
+    _sitesync_addon_cache = CacheItem(lifetime=60)
+    _default_site_id_cache = NestedCacheItem(lifetime=60)
+    _root_overrides_cache = NestedCacheItem(2, lifetime=60)
 
     def __init__(
         self, project_name=None, site_name=None, project_entity=None

--- a/client/ayon_core/tools/common_models/cache.py
+++ b/client/ayon_core/tools/common_models/cache.py
@@ -1,239 +1,31 @@
-import time
-import collections
+import warnings
 
-InitInfo = collections.namedtuple(
-    "InitInfo",
-    ["default_factory", "lifetime"]
+from ayon_core.lib import CacheItem as _CacheItem
+from ayon_core.lib import NestedCacheItem as _NestedCacheItem
+
+
+# Cache classes were moved to `ayon_core.lib.cache`
+class CacheItem(_CacheItem):
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "Used 'CacheItem' from deprecated location "
+            "'ayon_core.tools.common_models', use 'ayon_core.lib' instead.",
+            DeprecationWarning,
+        )
+        super().__init__(*args, **kwargs)
+
+
+class NestedCacheItem(_NestedCacheItem):
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "Used 'NestedCacheItem' from deprecated location "
+            "'ayon_core.tools.common_models', use 'ayon_core.lib' instead.",
+            DeprecationWarning,
+        )
+        super().__init__(*args, **kwargs)
+
+
+__all__ = (
+    "CacheItem",
+    "NestedCacheItem",
 )
-
-
-def _default_factory_func():
-    return None
-
-
-class CacheItem:
-    """Simple cache item with lifetime and default value.
-
-    Args:
-        default_factory (Optional[callable]): Function that returns default
-            value used on init and on reset.
-        lifetime (Optional[int]): Lifetime of the cache data in seconds.
-    """
-
-    def __init__(self, default_factory=None, lifetime=None):
-        if lifetime is None:
-            lifetime = 120
-        self._lifetime = lifetime
-        self._last_update = None
-        if default_factory is None:
-            default_factory = _default_factory_func
-        self._default_factory = default_factory
-        self._data = default_factory()
-
-    @property
-    def is_valid(self):
-        """Is cache valid to use.
-
-        Return:
-            bool: True if cache is valid, False otherwise.
-        """
-
-        if self._last_update is None:
-            return False
-
-        return (time.time() - self._last_update) < self._lifetime
-
-    def set_lifetime(self, lifetime):
-        """Change lifetime of cache item.
-
-        Args:
-            lifetime (int): Lifetime of the cache data in seconds.
-        """
-
-        self._lifetime = lifetime
-
-    def set_invalid(self):
-        """Set cache as invalid."""
-
-        self._last_update = None
-
-    def reset(self):
-        """Set cache as invalid and reset data."""
-
-        self._last_update = None
-        self._data = self._default_factory()
-
-    def get_data(self):
-        """Receive cached data.
-
-        Returns:
-            Any: Any data that are cached.
-        """
-
-        return self._data
-
-    def update_data(self, data):
-        self._data = data
-        self._last_update = time.time()
-
-
-class NestedCacheItem:
-    """Helper for cached items stored in nested structure.
-
-    Example:
-        >>> cache = NestedCacheItem(levels=2, default_factory=lambda: 0)
-        >>> cache["a"]["b"].is_valid
-        False
-        >>> cache["a"]["b"].get_data()
-        0
-        >>> cache["a"]["b"] = 1
-        >>> cache["a"]["b"].is_valid
-        True
-        >>> cache["a"]["b"].get_data()
-        1
-        >>> cache.reset()
-        >>> cache["a"]["b"].is_valid
-        False
-
-    Args:
-        levels (int): Number of nested levels where read cache is stored.
-        default_factory (Optional[callable]): Function that returns default
-            value used on init and on reset.
-        lifetime (Optional[int]): Lifetime of the cache data in seconds.
-        _init_info (Optional[InitInfo]): Private argument. Init info for
-            nested cache where created from parent item.
-    """
-
-    def __init__(
-        self, levels=1, default_factory=None, lifetime=None, _init_info=None
-    ):
-        if levels < 1:
-            raise ValueError("Nested levels must be greater than 0")
-        self._data_by_key = {}
-        if _init_info is None:
-            _init_info = InitInfo(default_factory, lifetime)
-        self._init_info = _init_info
-        self._levels = levels
-
-    def __getitem__(self, key):
-        """Get cached data.
-
-        Args:
-            key (str): Key of the cache item.
-
-        Returns:
-            Union[NestedCacheItem, CacheItem]: Cache item.
-        """
-
-        cache = self._data_by_key.get(key)
-        if cache is None:
-            if self._levels > 1:
-                cache = NestedCacheItem(
-                    levels=self._levels - 1,
-                    _init_info=self._init_info
-                )
-            else:
-                cache = CacheItem(
-                    self._init_info.default_factory,
-                    self._init_info.lifetime
-                )
-            self._data_by_key[key] = cache
-        return cache
-
-    def __setitem__(self, key, value):
-        """Update cached data.
-
-        Args:
-            key (str): Key of the cache item.
-            value (Any): Any data that are cached.
-        """
-
-        if self._levels > 1:
-            raise AttributeError((
-                "{} does not support '__setitem__'. Lower nested level by {}"
-            ).format(self.__class__.__name__, self._levels - 1))
-        cache = self[key]
-        cache.update_data(value)
-
-    def get(self, key):
-        """Get cached data.
-
-        Args:
-            key (str): Key of the cache item.
-
-        Returns:
-            Union[NestedCacheItem, CacheItem]: Cache item.
-        """
-
-        return self[key]
-
-    def cached_count(self):
-        """Amount of cached items.
-
-        Returns:
-            int: Amount of cached items.
-        """
-
-        return len(self._data_by_key)
-
-    def clear_key(self, key):
-        """Clear cached item by key.
-
-        Args:
-            key (str): Key of the cache item.
-        """
-
-        self._data_by_key.pop(key, None)
-
-    def clear_invalid(self):
-        """Clear all invalid cache items.
-
-        Note:
-            To clear all cache items use 'reset'.
-        """
-
-        changed = {}
-        children_are_nested = self._levels > 1
-        for key, cache in tuple(self._data_by_key.items()):
-            if children_are_nested:
-                output = cache.clear_invalid()
-                if output:
-                    changed[key] = output
-                if not cache.cached_count():
-                    self._data_by_key.pop(key)
-            elif not cache.is_valid:
-                changed[key] = cache.get_data()
-                self._data_by_key.pop(key)
-        return changed
-
-    def reset(self):
-        """Reset cache.
-
-        Note:
-            To clear only invalid cache items use 'clear_invalid'.
-        """
-
-        self._data_by_key = {}
-
-    def set_lifetime(self, lifetime):
-        """Change lifetime of all children cache items.
-
-        Args:
-            lifetime (int): Lifetime of the cache data in seconds.
-        """
-
-        self._init_info.lifetime = lifetime
-        for cache in self._data_by_key.values():
-            cache.set_lifetime(lifetime)
-
-    @property
-    def is_valid(self):
-        """Raise reasonable error when called on wront level.
-
-        Raises:
-            AttributeError: If called on nested cache item.
-        """
-
-        raise AttributeError((
-            "{} does not support 'is_valid'. Lower nested level by '{}'"
-        ).format(self.__class__.__name__, self._levels))

--- a/client/ayon_core/tools/common_models/hierarchy.py
+++ b/client/ayon_core/tools/common_models/hierarchy.py
@@ -6,8 +6,7 @@ import ayon_api
 import six
 
 from ayon_core.style import get_default_entity_icon_color
-
-from .cache import NestedCacheItem
+from ayon_core.lib import NestedCacheItem
 
 HIERARCHY_MODEL_SENDER = "hierarchy.model"
 

--- a/client/ayon_core/tools/common_models/projects.py
+++ b/client/ayon_core/tools/common_models/projects.py
@@ -5,8 +5,7 @@ import ayon_api
 import six
 
 from ayon_core.style import get_default_entity_icon_color
-
-from .cache import CacheItem
+from ayon_core.lib import CacheItem
 
 PROJECTS_MODEL_SENDER = "projects.model"
 

--- a/client/ayon_core/tools/common_models/thumbnails.py
+++ b/client/ayon_core/tools/common_models/thumbnails.py
@@ -5,7 +5,7 @@ import collections
 import ayon_api
 import appdirs
 
-from .cache import NestedCacheItem
+from ayon_core.lib import NestedCacheItem
 
 FileInfo = collections.namedtuple(
     "FileInfo",

--- a/client/ayon_core/tools/loader/models/actions.py
+++ b/client/ayon_core/tools/loader/models/actions.py
@@ -6,6 +6,7 @@ import uuid
 
 import ayon_api
 
+from ayon_core.lib import NestedCacheItem
 from ayon_core.pipeline.load import (
     discover_loader_plugins,
     ProductLoaderPlugin,
@@ -17,7 +18,6 @@ from ayon_core.pipeline.load import (
     LoadError,
     IncompatibleLoaderError,
 )
-from ayon_core.tools.common_models import NestedCacheItem
 from ayon_core.tools.loader.abstract import ActionItem
 
 ACTIONS_MODEL_SENDER = "actions.model"

--- a/client/ayon_core/tools/loader/models/products.py
+++ b/client/ayon_core/tools/loader/models/products.py
@@ -5,8 +5,8 @@ import arrow
 import ayon_api
 from ayon_api.operations import OperationsSession
 
+from ayon_core.lib import NestedCacheItem
 from ayon_core.style import get_default_entity_icon_color
-from ayon_core.tools.common_models import NestedCacheItem
 from ayon_core.tools.loader.abstract import (
     ProductTypeItem,
     ProductItem,

--- a/client/ayon_core/tools/loader/models/sitesync.py
+++ b/client/ayon_core/tools/loader/models/sitesync.py
@@ -2,9 +2,8 @@ import collections
 
 from ayon_api import get_representations, get_versions_links
 
-from ayon_core.lib import Logger
+from ayon_core.lib import Logger, NestedCacheItem
 from ayon_core.addon import AddonsManager
-from ayon_core.tools.common_models import NestedCacheItem
 from ayon_core.tools.loader.abstract import ActionItem
 
 DOWNLOAD_IDENTIFIER = "sitesync.download"


### PR DESCRIPTION
## Changelog Description
We have implemented multiple different approaches how to cache data, usually the same. Goal of this PR is to have one in `ayon_core.lib` that can be used across the board. Using the items in `Anatomy` as first step.

## Additional info
The classes were taken from `ayon_core.tools.common_models.cache` where were used for model data. There are 2 classes, one for storing the data, second for nesting them in specific level. The nesting was usually done using lambda functions.

## Testing notes:
1. Anatomy caching still works.
2. Validate implementation of the classes.
