### PR TITLE
Fix validate_unique_names call

### DIFF
--- a/server_addon/deadline/package.py
+++ b/server_addon/deadline/package.py
@@ -1,3 +1,3 @@
 name = "deadline"
 title = "Deadline"
-version = "0.1.10"
+version = "0.1.11"

--- a/server_addon/deadline/server/settings/publish_plugins.py
+++ b/server_addon/deadline/server/settings/publish_plugins.py
@@ -191,7 +191,6 @@ class NukeSubmitDeadlineModel(BaseSettingsModel):
 
     @validator(
         "limit_groups",
-        "env_allowed_keys",
         "env_search_replace_values")
     def validate_unique_names(cls, value):
         ensure_unique_names(value)


### PR DESCRIPTION
## Changelog Description
`validate_unique_names` cannot be used on fields that are just regular `list[str]`, they must be `list[SomethingSomething]`.


## Testing notes:
1. add some env variables in `ayon+settings://deadline/publish/NukeSubmitDeadline/env_allowed_keys`
2. no validation error should be thrown and values should be persisted
