### PR TITLE
Fusion: Fix comp repair folder settings

### DIFF
--- a/client/ayon_core/hosts/fusion/api/lib.py
+++ b/client/ayon_core/hosts/fusion/api/lib.py
@@ -169,7 +169,7 @@ def validate_comp_prefs(comp=None, force_repair=False):
         def _on_repair():
             attributes = dict()
             for key, comp_key, _label in validations:
-                value = folder_value[key]
+                value = folder_attributes[key]
                 comp_key_full = "Comp.FrameFormat.{}".format(comp_key)
                 attributes[comp_key_full] = value
             comp.SetPrefs(attributes)


### PR DESCRIPTION
## Changelog Description

Fix comp repair folder settings

## Additional info

Fixes:
```python
Traceback (most recent call last):
  File "E:\dev\ayon-core\client\ayon_core\hosts\fusion\api\lib.py", line 172, in _on_repair
    value = folder_attributes[key]
TypeError: 'float' object is not subscriptable
```

## Testing notes:

1. Save fusion comp with different settings than current folder
2. The "repair" button on the popup should work.
