### PR TITLE
TrayPublisher: adds new editorial exchange package product

### DIFF
--- a/client/ayon_core/hosts/traypublisher/plugins/create/create_editorial_package.py
+++ b/client/ayon_core/hosts/traypublisher/plugins/create/create_editorial_package.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+from ayon_core.pipeline import (
+    CreatedInstance,
+)
+
+from ayon_core.lib.attribute_definitions import FileDef
+from ayon_core.hosts.traypublisher.api.plugin import TrayPublishCreator
+
+
+class EditorialPackageCreator(TrayPublishCreator):
+    """Creates instance for OTIO file from published folder.
+
+    Folder contains OTIO file and exported .mov files. Process should publish
+    whole folder as single `editorial_pckg` product type and (possibly) convert
+    .mov files into different format and copy them into `publish` `resources`
+    subfolder.
+    """
+    identifier = "editorial_pckg"
+    label = "Editorial package"
+    product_type = "editorial_pckg"
+    description = "Publish folder with OTIO file and resources"
+
+    # Position batch creator after simple creators
+    order = 120
+
+
+    def get_icon(self):
+        return "fa.folder"
+
+    def create(self, product_name, instance_data, pre_create_data):
+        folder_path = pre_create_data.get("folder_path")
+        if not folder_path:
+            return
+
+        instance_data["creator_attributes"] = {
+            "path": (Path(folder_path["directory"]) /
+                     Path(folder_path["filenames"][0])).as_posix()
+        }
+
+        # Create new instance
+        new_instance = CreatedInstance(self.product_type, product_name,
+                                       instance_data, self)
+        self._store_new_instance(new_instance)
+
+    def get_pre_create_attr_defs(self):
+        # Use same attributes as for instance attributes
+        return [
+            FileDef(
+                "folder_path",
+                folders=True,
+                single_item=True,
+                extensions=[],
+                allow_sequences=False,
+                label="Folder path"
+            )
+        ]
+
+    def get_detail_description(self):
+        return """# Publish folder with OTIO file and video clips
+
+        Folder contains OTIO file and exported .mov files. Process should 
+        publish whole folder as single `editorial_pckg` product type and 
+        (possibly) convert .mov files into different format and copy them into 
+        `publish` `resources` subfolder.
+        """

--- a/client/ayon_core/hosts/traypublisher/plugins/publish/collect_editorial_package.py
+++ b/client/ayon_core/hosts/traypublisher/plugins/publish/collect_editorial_package.py
@@ -1,0 +1,58 @@
+"""Produces instance.data["editorial_pckg"] data used during integration.
+
+Requires:
+    instance.data["creator_attributes"]["path"] - from creator
+
+Provides:
+    instance -> editorial_pckg (dict):
+                    folder_path (str)
+                    otio_path   (str) - from dragged folder
+                    resource_paths (list)
+
+"""
+import os
+
+import pyblish.api
+
+from ayon_core.lib.transcoding import VIDEO_EXTENSIONS
+
+
+class CollectEditorialPackage(pyblish.api.InstancePlugin):
+    """Collects path to OTIO file and resources"""
+
+    label = "Collect Editorial Package"
+    order = pyblish.api.CollectorOrder - 0.1
+
+    hosts = ["traypublisher"]
+    families = ["editorial_pckg"]
+
+    def process(self, instance):
+        folder_path = instance.data["creator_attributes"].get("path")
+        if not folder_path or not os.path.exists(folder_path):
+            self.log.info((
+                "Instance doesn't contain collected existing folder path."
+            ))
+            return
+
+        instance.data["editorial_pckg"] = {}
+        instance.data["editorial_pckg"]["folder_path"] = folder_path
+
+        otio_path, resource_paths = (
+            self._get_otio_and_resource_paths(folder_path))
+
+        instance.data["editorial_pckg"]["otio_path"] = otio_path
+        instance.data["editorial_pckg"]["resource_paths"] = resource_paths
+
+    def _get_otio_and_resource_paths(self, folder_path):
+        otio_path = None
+        resource_paths = []
+
+        file_names = os.listdir(folder_path)
+        for filename in file_names:
+            _, ext = os.path.splitext(filename)
+            file_path = os.path.join(folder_path, filename)
+            if ext == ".otio":
+                otio_path = file_path
+            elif ext in VIDEO_EXTENSIONS:
+                resource_paths.append(file_path)
+        return otio_path, resource_paths

--- a/client/ayon_core/hosts/traypublisher/plugins/publish/extract_editorial_pckg.py
+++ b/client/ayon_core/hosts/traypublisher/plugins/publish/extract_editorial_pckg.py
@@ -1,0 +1,122 @@
+import os.path
+import opentimelineio
+
+import pyblish.api
+
+from ayon_core.pipeline import publish
+
+
+class ExtractEditorialPackage(publish.Extractor):
+    """Replaces movie paths in otio file with publish rootless
+
+    Prepares movie resources for integration.
+    TODO introduce conversion to .mp4
+    """
+
+    label = "Extract Editorial Package"
+    order = pyblish.api.ExtractorOrder - 0.45
+    hosts = ["traypublisher"]
+    families = ["editorial_pckg"]
+
+    def process(self, instance):
+        editorial_pckg_data = instance.data.get("editorial_pckg")
+
+        otio_path = editorial_pckg_data["otio_path"]
+        otio_basename = os.path.basename(otio_path)
+        staging_dir = self.staging_dir(instance)
+
+        editorial_pckg_repre = {
+            'name': "editorial_pckg",
+            'ext': "otio",
+            'files': otio_basename,
+            "stagingDir": staging_dir,
+        }
+        otio_staging_path = os.path.join(staging_dir, otio_basename)
+
+        instance.data["representations"].append(editorial_pckg_repre)
+
+        publish_path = self._get_published_path(instance)
+        publish_folder = os.path.dirname(publish_path)
+        publish_resource_folder = os.path.join(publish_folder, "resources")
+
+        resource_paths = editorial_pckg_data["resource_paths"]
+        transfers = self._get_transfers(resource_paths,
+                                        publish_resource_folder)
+        if not "transfers" in instance.data:
+            instance.data["transfers"] = []
+        instance.data["transfers"] = transfers
+
+        source_to_rootless = self._get_resource_path_mapping(instance,
+                                                             transfers)
+
+        otio_data = editorial_pckg_data["otio_data"]
+        otio_data = self._replace_target_urls(otio_data, source_to_rootless)
+
+        opentimelineio.adapters.write_to_file(otio_data, otio_staging_path)
+
+        self.log.info("Added Editorial Package representation: {}".format(
+            editorial_pckg_repre))
+
+    def _get_resource_path_mapping(self, instance, transfers):
+        """Returns dict of {source_mov_path: rootless_published_path}."""
+        replace_paths = {}
+        anatomy = instance.context.data["anatomy"]
+        for source, destination in transfers:
+            rootless_path = self._get_rootless(anatomy, destination)
+            source_file_name = os.path.basename(source)
+            replace_paths[source_file_name] = rootless_path
+        return replace_paths
+
+    def _get_transfers(self, resource_paths, publish_resource_folder):
+        """Returns list of tuples (source, destination) movie paths."""
+        transfers = []
+        for res_path in resource_paths:
+            res_basename = os.path.basename(res_path)
+            pub_res_path = os.path.join(publish_resource_folder, res_basename)
+            transfers.append((res_path, pub_res_path))
+        return transfers
+
+    def _replace_target_urls(self, otio_data, replace_paths):
+        """Replace original movie paths with published rootles ones."""
+        for track in otio_data.tracks:
+            for clip in track:
+                # Check if the clip has a media reference
+                if clip.media_reference is not None:
+                    # Access the target_url from the media reference
+                    target_url = clip.media_reference.target_url
+                    if not target_url:
+                        continue
+                    file_name = os.path.basename(target_url)
+                    replace_value = replace_paths.get(file_name)
+                    if replace_value:
+                        clip.media_reference.target_url = replace_value
+
+        return otio_data
+
+    def _get_rootless(self, anatomy, path):
+        """Try to find rootless {root[work]} path from `path`"""
+        success, rootless_path = anatomy.find_root_template_from_path(
+            path)
+        if not success:
+            # `rootless_path` is not set to `output_dir` if none of roots match
+            self.log.warning(
+               f"Could not find root path for remapping '{path}'."
+            )
+            rootless_path = path
+
+        return rootless_path
+
+    def _get_published_path(self, instance):
+        """Calculates expected `publish` folder"""
+        # determine published path from Anatomy.
+        template_data = instance.data.get("anatomyData")
+        rep = instance.data["representations"][0]
+        template_data["representation"] = rep.get("name")
+        template_data["ext"] = rep.get("ext")
+        template_data["comment"] = None
+
+        anatomy = instance.context.data["anatomy"]
+        template_data["root"] = anatomy.roots
+        template = anatomy.get_template_item("publish", "default", "path")
+        template_filled = template.format_strict(template_data)
+        return os.path.normpath(template_filled)

--- a/client/ayon_core/hosts/traypublisher/plugins/publish/validate_editorial_package.py
+++ b/client/ayon_core/hosts/traypublisher/plugins/publish/validate_editorial_package.py
@@ -1,0 +1,70 @@
+import os
+import opentimelineio
+
+import pyblish.api
+from ayon_core.pipeline import PublishValidationError
+
+
+class ValidateEditorialPackage(pyblish.api.InstancePlugin):
+    """Checks that published folder contains all resources from otio
+
+    Currently checks only by file names and expects flat structure.
+    It ignores path to resources in otio file as folder might be dragged in and
+    published from different location than it was created.
+    """
+
+    label = "Validate Editorial Package"
+    order = pyblish.api.ValidatorOrder - 0.49
+
+    hosts = ["traypublisher"]
+    families = ["editorial_pckg"]
+
+    def process(self, instance):
+        editorial_pckg_data = instance.data.get("editorial_pckg")
+        if not editorial_pckg_data:
+            raise PublishValidationError(
+                f"Editorial package not collected")
+
+        folder_path = editorial_pckg_data["folder_path"]
+
+        otio_path = editorial_pckg_data["otio_path"]
+        if not otio_path:
+            raise PublishValidationError(
+                f"Folder {folder_path} missing otio file")
+
+        resource_paths = editorial_pckg_data["resource_paths"]
+
+        resource_file_names = {os.path.basename(path)
+                               for path in resource_paths}
+
+        otio_data = opentimelineio.adapters.read_from_file(otio_path)
+
+        target_urls = self._get_all_target_urls(otio_data)
+        missing_files = set()
+        for target_url in target_urls:
+            target_basename = os.path.basename(target_url)
+            if target_basename not in resource_file_names:
+                missing_files.add(target_basename)
+
+        if missing_files:
+            raise PublishValidationError("Otio file contains missing files "
+                                         f"'{missing_files}'.")
+
+        instance.data["editorial_pckg"]["otio_data"] = otio_data
+
+    def _get_all_target_urls(self, otio_data):
+        target_urls = []
+
+        # Iterate through tracks, clips, or other elements
+        for track in otio_data.tracks:
+            for clip in track:
+                # Check if the clip has a media reference
+                if clip.media_reference is not None:
+                    # Access the target_url from the media reference
+                    target_url = clip.media_reference.target_url
+                    if target_url:
+                        target_urls.append(target_url)
+
+        return target_urls
+
+

--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -169,6 +169,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 "yeticacheUE",
                 "tycache",
                 "csv_ingest_file",
+                "editorial_pckg"
                 ]
 
     default_template_name = "publish"


### PR DESCRIPTION
## Changelog Description
This PR adds new `editorial_pckg` product which should contain `OTIO` file with .mov resources in same folder. Idea is to easily publish whole folder containing OTIO and movie files via Traypublisher.

## Additional info
Still WIP - conversion to .mp4 missing.

## Testing notes:
1. start with this step
2. follow this step
