### PR TITLE
Chore: Support adding tools group environment per task level

### DIFF
--- a/server_addon/applications/client/ayon_applications/utils.py
+++ b/server_addon/applications/client/ayon_applications/utils.py
@@ -281,13 +281,15 @@ def prepare_app_environments(
         app.environment
     ]
 
-    folder_entity = data.get("folder_entity")
+    entity = data.get("task_entity")
+    if not entity:
+        entity = data.get("folder_entity")
     # Add tools environments
     groups_by_name = {}
     tool_by_group_name = collections.defaultdict(dict)
-    if folder_entity:
+    if entity:
         # Make sure each tool group can be added only once
-        for key in folder_entity["attrib"].get("tools") or []:
+        for key in entity["attrib"].get("tools") or []:
             tool = app.manager.tools.get(key)
             if not tool or not tool.is_valid_for_app(app):
                 continue

--- a/server_addon/applications/client/ayon_applications/utils.py
+++ b/server_addon/applications/client/ayon_applications/utils.py
@@ -286,12 +286,15 @@ def prepare_app_environments(
     # Add tools environments
     groups_by_name = {}
     tool_by_group_name = collections.defaultdict(dict)
+    tools = None
     if task_entity:
-        # Make sure each tool group can be added only once
-        tools_group_by_entity = task_entity["attrib"].get("tools")
-        if folder_entity and not tools_group_by_entity:
-            tools_group_by_entity = folder_entity["attrib"].get("tools")
-        for key in tools_group_by_entity or []:
+        tools = task_entity["attrib"].get("tools")
+
+    if tools is None and folder_entity:
+        tools = folder_entity["attrib"].get("tools")
+
+    if tools:
+        for key in tools:
             tool = app.manager.tools.get(key)
             if not tool or not tool.is_valid_for_app(app):
                 continue

--- a/server_addon/applications/client/ayon_applications/utils.py
+++ b/server_addon/applications/client/ayon_applications/utils.py
@@ -287,17 +287,24 @@ def prepare_app_environments(
     groups_by_name = {}
     tool_by_group_name = collections.defaultdict(dict)
     if task_entity:
-        groups_by_name, environments, app_and_tool_labels = (
-            get_tool_group_enviornment_by_entities(app, task_entity, groups_by_name,
-                                                   tool_by_group_name, environments,
-                                                    app_and_tool_labels)
-        )
-    elif folder_entity:
-        groups_by_name, environments, app_and_tool_labels = (
-            get_tool_group_enviornment_by_entities(app, folder_entity, groups_by_name,
-                                                   tool_by_group_name, environments,
-                                                   app_and_tool_labels)
-        )
+        # Make sure each tool group can be added only once
+        tools_group_by_entity = task_entity["attrib"].get("tools")
+        if folder_entity and not tools_group_by_entity:
+            tools_group_by_entity = folder_entity["attrib"].get("tools")
+        for key in tools_group_by_entity or []:
+            tool = app.manager.tools.get(key)
+            if not tool or not tool.is_valid_for_app(app):
+                continue
+            groups_by_name[tool.group.name] = tool.group
+            tool_by_group_name[tool.group.name][tool.name] = tool
+
+        for group_name in sorted(groups_by_name.keys()):
+            group = groups_by_name[group_name]
+            environments.append(group.environment)
+            for tool_name in sorted(tool_by_group_name[group_name].keys()):
+                tool = tool_by_group_name[group_name][tool_name]
+                environments.append(tool.environment)
+                app_and_tool_labels.append(tool.full_name)
 
     log.debug(
         "Will add environments for apps and tools: {}".format(
@@ -349,37 +356,6 @@ def prepare_app_environments(
     data["env"].update(final_env)
     for key in keys_to_remove:
         data["env"].pop(key, None)
-
-
-def get_tool_group_enviornment_by_entities(app, entity, groups_by_name,
-                                           tool_by_group_name, environments,
-                                           app_and_tool_labels):
-    """Function to get tool group environment by entities
-
-    Args:
-        app (dict): application
-        entity (dict): entity
-        groups_by_name (dict): group by name
-        tool_by_group_name (dict): tools by group name
-        environments (list): enviornments
-        app_and_tool_labels (list): full name of the application
-    """
-    # Make sure each tool group can be added only once
-    for key in entity["attrib"].get("tools") or []:
-        tool = app.manager.tools.get(key)
-        if not tool or not tool.is_valid_for_app(app):
-            continue
-        groups_by_name[tool.group.name] = tool.group
-        tool_by_group_name[tool.group.name][tool.name] = tool
-
-    for group_name in sorted(groups_by_name.keys()):
-        group = groups_by_name[group_name]
-        environments.append(group.environment)
-        for tool_name in sorted(tool_by_group_name[group_name].keys()):
-            tool = tool_by_group_name[group_name][tool_name]
-            environments.append(tool.environment)
-            app_and_tool_labels.append(tool.full_name)
-    return groups_by_name, environments, app_and_tool_labels
 
 
 def apply_project_environments_value(

--- a/server_addon/applications/package.py
+++ b/server_addon/applications/package.py
@@ -1,6 +1,6 @@
 name = "applications"
 title = "Applications"
-version = "0.2.1"
+version = "0.2.2"
 
 ayon_server_version = ">=1.0.7"
 ayon_launcher_version = ">=1.0.2"


### PR DESCRIPTION
## Changelog Description
The PR is to add support of the tools group environment per task level, as the current tools group environment only support for per folder level. If there is empty list of tools group setting up per task level, it will use the tools group per folder level instead if the tools group for the folder level is not empty.

## Additional info
It doesn't work well with Redshift in 3dsmax when both folder and task level has added Redshift as tools group. It will crash 3dsmax during launching it.


## Testing notes:
1. Go to` AYON server -> Studio Settings -> Application addon` to set up your environment for external plugins (e.g. Arnold, Redshift, Yeti)
2. Go to Project -> Select your project
3. Editor -> folder -> task
4. Set up your tools group for your task
![image](https://github.com/ynput/ayon-core/assets/64118225/a51e51f4-0cd5-4b08-987e-239b26abd5f2)
