### PR TITLE
Chore: Be able to determine if is in AYON launcher process

### DIFF
--- a/client/ayon_core/lib/__init__.py
+++ b/client/ayon_core/lib/__init__.py
@@ -139,6 +139,7 @@ from .path_tools import (
 )
 
 from .ayon_info import (
+    is_in_ayon_launcher_process,
     is_running_from_build,
     is_using_ayon_console,
     is_staging_enabled,
@@ -248,6 +249,7 @@ __all__ = [
 
     "Logger",
 
+    "is_in_ayon_launcher_process",
     "is_running_from_build",
     "is_using_ayon_console",
     "is_staging_enabled",

--- a/client/ayon_core/lib/ayon_info.py
+++ b/client/ayon_core/lib/ayon_info.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import json
 import datetime
 import platform
@@ -23,6 +24,18 @@ def get_ayon_launcher_version():
     with open(version_filepath, "r") as stream:
         exec(stream.read(), content)
     return content["__version__"]
+
+
+def is_in_ayon_launcher_process():
+    """Determine if current process is running from AYON launcher.
+
+    Returns:
+        bool: True if running from AYON launcher.
+
+    """
+    ayon_executable_path = os.path.normpath(os.environ["AYON_EXECUTABLE"])
+    executable_path = os.path.normpath(sys.executable)
+    return ayon_executable_path == executable_path
 
 
 def is_running_from_build():


### PR DESCRIPTION
## Changelog Description
Implemented helper function `is_in_ayon_launcher_process` to determine if current process is AYON launcher.

## Additional info
Some functionality should be available only in AYON launcher process but there is not "unified" function that would help to determine that. This function is simplified and can be enhanced in future if we find out there may be other issues.

## Testing notes:
1. Function `is_in_ayon_launcher_process` returns `True` in AYON launcher process
2. Function `is_in_ayon_launcher_process` returns `False` in any other process (e.g. in maya)

```python
from ayon_core.lib import is_in_ayon_launcher_process

print(is_in_ayon_launcher_process())
```