### PR TITLE
Colorspace: Enhancement of subprocess getters

### DIFF
--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -642,7 +642,15 @@ def get_colorspaces_enumerator_items(
             })
 
     def _sort_key_getter(item):
-        """Use colorspace for sorting."""
+        """Use colorspace for sorting.
+
+        Args:
+            item (tuple[str, str]): Item with colorspace and label.
+
+        Returns:
+            str: Colorspace.
+
+        """
         return item[0]
 
     labeled_colorspaces = []

--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -116,13 +116,21 @@ def has_compatible_ocio_package():
     if CachedData.has_compatible_ocio_package is not None:
         return CachedData.has_compatible_ocio_package
 
+    is_compatible = False
     try:
-        import PyOpenColorIO  # noqa: F401
-        # TODO validate 'PyOpenColorIO' version
-        CachedData.has_compatible_ocio_package = True
-    except ImportError:
-        CachedData.has_compatible_ocio_package = False
+        import PyOpenColorIO
 
+        # Check if PyOpenColorIO is compatible
+        # - version 2.0.0 or higher is required
+        # NOTE version 1 does not have '__version__' attribute
+        if hasattr(PyOpenColorIO, "__version__"):
+            version_parts = PyOpenColorIO.__version__.split(".")
+            major = int(version_parts[0])
+            is_compatible = (major, ) >= (2, )
+    except ImportError:
+        pass
+
+    CachedData.has_compatible_ocio_package = is_compatible
     # compatible
     return CachedData.has_compatible_ocio_package
 

--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -292,7 +292,6 @@ def get_config_file_rules_colorspace_from_filepath(config_path, filepath):
         )
     else:
         result_data = _get_wrapped_with_subprocess(
-            "colorspace",
             "get_config_file_rules_colorspace_from_filepath",
             config_path=config_path,
             filepath=filepath
@@ -321,7 +320,6 @@ def get_config_version_data(config_path):
             version_data = _get_config_version_data(config_path)
         else:
             version_data = _get_wrapped_with_subprocess(
-                "config",
                 "get_config_version_data",
                 config_path=config_path
             )
@@ -432,11 +430,10 @@ def validate_imageio_colorspace_in_config(config_path, colorspace_name):
     return True
 
 
-def _get_wrapped_with_subprocess(command_group, command, **kwargs):
+def _get_wrapped_with_subprocess(command, **kwargs):
     """Get data via subprocess.
 
     Args:
-        command_group (str): command group name
         command (str): command name
         **kwargs: command arguments
 
@@ -448,7 +445,6 @@ def _get_wrapped_with_subprocess(command_group, command, **kwargs):
         args = [
             "run",
             get_ocio_config_script_path(),
-            command_group,
             command
         ]
 
@@ -501,7 +497,6 @@ def get_ocio_config_colorspaces(config_path):
             config_colorspaces = _get_ocio_config_colorspaces(config_path)
         else:
             config_colorspaces = _get_wrapped_with_subprocess(
-                "config",
                 "get_ocio_config_colorspaces",
                 config_path=config_path
             )
@@ -699,7 +694,6 @@ def get_ocio_config_views(config_path):
         return _get_ocio_config_views(config_path)
 
     return _get_wrapped_with_subprocess(
-        "config",
         "get_ocio_config_views",
         config_path=config_path
     )
@@ -1288,7 +1282,6 @@ def get_display_view_colorspace_name(config_path, display, view):
             config_path, display, view
         )
     return _get_wrapped_with_subprocess(
-        "config",
         "get_display_view_colorspace_name",
         config_path=config_path,
         display=display,
@@ -1538,7 +1531,6 @@ def get_colorspace_data_subprocess(config_path):
         dict: colorspace and family in couple
     """
     return _get_wrapped_with_subprocess(
-        "config",
         "get_ocio_config_colorspaces",
         config_path=config_path
     )
@@ -1559,7 +1551,6 @@ def get_views_data_subprocess(config_path):
 
     """
     return _get_wrapped_with_subprocess(
-        "config",
         "get_ocio_config_views",
         config_path=config_path
     )

--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -195,17 +195,6 @@ def get_colorspace_name_from_filepath(
     return colorspace_name
 
 
-# TODO: remove this in future - backward compatibility
-@deprecated("get_imageio_file_rules_colorspace_from_filepath")
-def get_imageio_colorspace_from_filepath(*args, **kwargs):
-    return get_imageio_file_rules_colorspace_from_filepath(*args, **kwargs)
-
-# TODO: remove this in future - backward compatibility
-@deprecated("get_imageio_file_rules_colorspace_from_filepath")
-def get_colorspace_from_filepath(*args, **kwargs):
-    return get_imageio_file_rules_colorspace_from_filepath(*args, **kwargs)
-
-
 def get_imageio_file_rules_colorspace_from_filepath(
     filepath,
     host_name,
@@ -392,21 +381,6 @@ def validate_imageio_colorspace_in_config(config_path, colorspace_name):
                 colorspace_name, config_path)
         )
     return True
-
-
-# TODO: remove this in future - backward compatibility
-@deprecated("_get_wrapped_with_subprocess")
-def get_data_subprocess(config_path, data_type):
-    """[Deprecated] Get data via subprocess
-
-    Wrapper for Python 2 hosts.
-
-    Args:
-        config_path (str): path leading to config.ocio file
-    """
-    return _get_wrapped_with_subprocess(
-        "config", data_type, in_path=config_path,
-    )
 
 
 def _get_wrapped_with_subprocess(command_group, command, **kwargs):
@@ -673,24 +647,6 @@ def get_colorspaces_enumerator_items(
     return labeled_colorspaces
 
 
-# TODO: remove this in future - backward compatibility
-@deprecated("_get_wrapped_with_subprocess")
-def get_colorspace_data_subprocess(config_path):
-    """[Deprecated] Get colorspace data via subprocess
-
-    Wrapper for Python 2 hosts.
-
-    Args:
-        config_path (str): path leading to config.ocio file
-
-    Returns:
-        dict: colorspace and family in couple
-    """
-    return _get_wrapped_with_subprocess(
-        "config", "get_colorspace", in_path=config_path
-    )
-
-
 def get_ocio_config_views(config_path):
     """Get all viewer data
 
@@ -714,71 +670,6 @@ def get_ocio_config_views(config_path):
     from ayon_core.scripts.ocio_wrapper import _get_views_data
 
     return _get_views_data(config_path)
-
-
-# TODO: remove this in future - backward compatibility
-@deprecated("_get_wrapped_with_subprocess")
-def get_views_data_subprocess(config_path):
-    """[Deprecated] Get viewers data via subprocess
-
-    Wrapper for Python 2 hosts.
-
-    Args:
-        config_path (str): path leading to config.ocio file
-
-    Returns:
-        dict: `display/viewer` and viewer data
-    """
-    return _get_wrapped_with_subprocess(
-        "config", "get_views", in_path=config_path
-    )
-
-
-@deprecated("get_imageio_config_preset")
-def get_imageio_config(
-    project_name,
-    host_name,
-    project_settings=None,
-    anatomy_data=None,
-    anatomy=None,
-    env=None
-):
-    """Returns config data from settings
-
-    Config path is formatted in `path` key
-    and original settings input is saved into `template` key.
-
-    Deprecated:
-        Deprecated since '0.3.1' . Use `get_imageio_config_preset` instead.
-
-    Args:
-        project_name (str): project name
-        host_name (str): host name
-        project_settings (Optional[dict]): Project settings.
-        anatomy_data (Optional[dict]): anatomy formatting data.
-        anatomy (Optional[Anatomy]): Anatomy object.
-        env (Optional[dict]): Environment variables.
-
-    Returns:
-        dict: config path data or empty dict
-
-    """
-    if not anatomy_data:
-        from .context_tools import get_current_context_template_data
-        anatomy_data = get_current_context_template_data()
-
-    task_name = anatomy_data.get("task", {}).get("name")
-    folder_path = anatomy_data.get("folder", {}).get("path")
-    return get_imageio_config_preset(
-        project_name,
-        folder_path,
-        task_name,
-        host_name,
-        anatomy=anatomy,
-        project_settings=project_settings,
-        template_data=anatomy_data,
-        env=env,
-    )
 
 
 def _get_global_config_data(
@@ -1435,5 +1326,111 @@ def get_current_context_imageio_config_preset(
         anatomy=anatomy,
         project_settings=project_settings,
         template_data=template_data,
+        env=env,
+    )
+
+
+# --- Deprecated functions ---
+@deprecated("get_imageio_file_rules_colorspace_from_filepath")
+def get_imageio_colorspace_from_filepath(*args, **kwargs):
+    return get_imageio_file_rules_colorspace_from_filepath(*args, **kwargs)
+
+
+@deprecated("get_imageio_file_rules_colorspace_from_filepath")
+def get_colorspace_from_filepath(*args, **kwargs):
+    return get_imageio_file_rules_colorspace_from_filepath(*args, **kwargs)
+
+
+@deprecated("_get_wrapped_with_subprocess")
+def get_colorspace_data_subprocess(config_path):
+    """[Deprecated] Get colorspace data via subprocess
+
+    Wrapper for Python 2 hosts.
+
+    Args:
+        config_path (str): path leading to config.ocio file
+
+    Returns:
+        dict: colorspace and family in couple
+    """
+    return _get_wrapped_with_subprocess(
+        "config", "get_colorspace", in_path=config_path
+    )
+
+
+@deprecated("_get_wrapped_with_subprocess")
+def get_views_data_subprocess(config_path):
+    """[Deprecated] Get viewers data via subprocess
+
+    Wrapper for Python 2 hosts.
+
+    Args:
+        config_path (str): path leading to config.ocio file
+
+    Returns:
+        dict: `display/viewer` and viewer data
+    """
+    return _get_wrapped_with_subprocess(
+        "config", "get_views", in_path=config_path
+    )
+
+
+@deprecated("_get_wrapped_with_subprocess")
+def get_data_subprocess(config_path, data_type):
+    """[Deprecated] Get data via subprocess
+
+    Wrapper for Python 2 hosts.
+
+    Args:
+        config_path (str): path leading to config.ocio file
+    """
+    return _get_wrapped_with_subprocess(
+        "config", data_type, in_path=config_path,
+    )
+
+
+@deprecated("get_imageio_config_preset")
+def get_imageio_config(
+    project_name,
+    host_name,
+    project_settings=None,
+    anatomy_data=None,
+    anatomy=None,
+    env=None
+):
+    """Returns config data from settings
+
+    Config path is formatted in `path` key
+    and original settings input is saved into `template` key.
+
+    Deprecated:
+        Deprecated since '0.3.1' . Use `get_imageio_config_preset` instead.
+
+    Args:
+        project_name (str): project name
+        host_name (str): host name
+        project_settings (Optional[dict]): Project settings.
+        anatomy_data (Optional[dict]): anatomy formatting data.
+        anatomy (Optional[Anatomy]): Anatomy object.
+        env (Optional[dict]): Environment variables.
+
+    Returns:
+        dict: config path data or empty dict
+
+    """
+    if not anatomy_data:
+        from .context_tools import get_current_context_template_data
+        anatomy_data = get_current_context_template_data()
+
+    task_name = anatomy_data.get("task", {}).get("name")
+    folder_path = anatomy_data.get("folder", {}).get("path")
+    return get_imageio_config_preset(
+        project_name,
+        folder_path,
+        task_name,
+        host_name,
+        anatomy=anatomy,
+        project_settings=project_settings,
+        template_data=anatomy_data,
         env=env,
     )

--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -36,10 +36,6 @@ class CachedData:
     }
 
 
-class DeprecatedWarning(DeprecationWarning):
-    pass
-
-
 def deprecated(new_destination):
     """Mark functions as deprecated.
 
@@ -64,13 +60,13 @@ def deprecated(new_destination):
 
         @functools.wraps(decorated_func)
         def wrapper(*args, **kwargs):
-            warnings.simplefilter("always", DeprecatedWarning)
+            warnings.simplefilter("always", DeprecationWarning)
             warnings.warn(
                 (
                     "Call to deprecated function '{}'"
                     "\nFunction was moved or removed.{}"
                 ).format(decorated_func.__name__, warning_message),
-                category=DeprecatedWarning,
+                category=DeprecationWarning,
                 stacklevel=4
             )
             return decorated_func(*args, **kwargs)

--- a/client/ayon_core/scripts/ocio_wrapper.py
+++ b/client/ayon_core/scripts/ocio_wrapper.py
@@ -1,28 +1,31 @@
 """OpenColorIO Wrapper.
 
-Only to be interpreted by Python 3. It is run in subprocess in case
-Python 2 hosts needs to use it. Or it is used as module for Python 3
-processing.
-
-Providing functionality:
-- get_colorspace - console command - python 2
-                 - returning all available color spaces
-                   found in input config path.
-- _get_colorspace_data - python 3 - module function
-                      - returning all available colorspaces
-                        found in input config path.
-- get_views - console command - python 2
-            - returning all available viewers
-              found in input config path.
-- _get_views_data - python 3 - module function
-                 - returning all available viewers
-                   found in input config path.
+Receive OpenColorIO information and store it in JSON format for processed
+that don't have access to OpenColorIO or their version of OpenColorIO is
+not compatible.
 """
 
-import click
 import json
 from pathlib import Path
-import PyOpenColorIO as ocio
+
+import click
+
+from ayon_core.pipeline.colorspace import (
+    has_compatible_ocio_package,
+    get_display_view_colorspace_name,
+    get_config_file_rules_colorspace_from_filepath,
+    get_config_version_data,
+    get_ocio_config_views,
+    get_ocio_config_colorspaces,
+)
+
+
+def _save_output_to_json_file(output, output_path):
+    json_path = Path(output_path)
+    with open(json_path, "w") as stream:
+        json.dump(output, stream)
+
+    print(f"Data are saved to '{json_path}'")
 
 
 @click.group()
@@ -51,383 +54,184 @@ def colorspace():
 
 
 @config.command(
-    name="get_colorspace",
-    help=(
-        "return all colorspaces from config file "
-        "--path input arg is required"
-    )
-)
-@click.option("--in_path", required=True,
-              help="path where to read ocio config file",
-              type=click.Path(exists=True))
-@click.option("--out_path", required=True,
-              help="path where to write output json file",
-              type=click.Path())
-def get_colorspace(in_path, out_path):
+    name="get_ocio_config_colorspaces",
+    help="return all colorspaces from config file")
+@click.option(
+    "--config_path",
+    required=True,
+    help="OCIO config path to read ocio config file.",
+    type=click.Path(exists=True))
+@click.option(
+    "--output_path",
+    required=True,
+    help="path where to write output json file",
+    type=click.Path())
+def _get_ocio_config_colorspaces(config_path, output_path):
     """Aggregate all colorspace to file.
 
-    Python 2 wrapped console command
-
     Args:
-        in_path (str): config file path string
-        out_path (str): temp json file path string
+        config_path (str): config file path string
+        output_path (str): temp json file path string
 
     Example of use:
     > pyton.exe ./ocio_wrapper.py config get_colorspace
-        --in_path=<path> --out_path=<path>
+        --config_path <path> --output_path <path>
     """
-    json_path = Path(out_path)
-
-    out_data = _get_colorspace_data(in_path)
-
-    with open(json_path, "w") as f_:
-        json.dump(out_data, f_)
-
-    print(f"Colorspace data are saved to '{json_path}'")
-
-
-def _get_colorspace_data(config_path):
-    """Return all found colorspace data.
-
-    Args:
-        config_path (str): path string leading to config.ocio
-
-    Raises:
-        IOError: Input config does not exist.
-
-    Returns:
-        dict: aggregated available colorspaces
-    """
-    config_path = Path(config_path)
-
-    if not config_path.is_file():
-        raise IOError(
-            f"Input path `{config_path}` should be `config.ocio` file")
-
-    config = ocio.Config().CreateFromFile(str(config_path))
-
-    colorspace_data = {
-        "roles": {},
-        "colorspaces": {
-            color.getName(): {
-                "family": color.getFamily(),
-                "categories": list(color.getCategories()),
-                "aliases": list(color.getAliases()),
-                "equalitygroup": color.getEqualityGroup(),
-            }
-            for color in config.getColorSpaces()
-        },
-        "displays_views": {
-            f"{view} ({display})": {
-                "display": display,
-                "view": view
-
-            }
-            for display in config.getDisplays()
-            for view in config.getViews(display)
-        },
-        "looks": {}
-    }
-
-    # add looks
-    looks = config.getLooks()
-    if looks:
-        colorspace_data["looks"] = {
-            look.getName(): {"process_space": look.getProcessSpace()}
-            for look in looks
-        }
-
-    # add roles
-    roles = config.getRoles()
-    if roles:
-        colorspace_data["roles"] = {
-            role: {"colorspace": colorspace}
-            for (role, colorspace) in roles
-        }
-
-    return colorspace_data
+    _save_output_to_json_file(
+        get_ocio_config_colorspaces(config_path),
+        output_path
+    )
 
 
 @config.command(
-    name="get_views",
-    help=(
-        "return all viewers from config file "
-        "--path input arg is required"
-    )
-)
-@click.option("--in_path", required=True,
-              help="path where to read ocio config file",
-              type=click.Path(exists=True))
-@click.option("--out_path", required=True,
-              help="path where to write output json file",
-              type=click.Path())
-def get_views(in_path, out_path):
+    name="get_ocio_config_views",
+    help="All viewers from config file")
+@click.option(
+    "--config_path",
+    required=True,
+    help="OCIO config path to read ocio config file.",
+    type=click.Path(exists=True))
+@click.option(
+    "--output_path",
+    required=True,
+    help="path where to write output json file",
+    type=click.Path())
+def _get_ocio_config_views(config_path, output_path):
     """Aggregate all viewers to file.
 
-    Python 2 wrapped console command
-
     Args:
-        in_path (str): config file path string
-        out_path (str): temp json file path string
+        config_path (str): config file path string
+        output_path (str): temp json file path string
 
     Example of use:
     > pyton.exe ./ocio_wrapper.py config get_views \
-        --in_path=<path> --out_path=<path>
+        --config_path <path> --output <path>
     """
-    json_path = Path(out_path)
-
-    out_data = _get_views_data(in_path)
-
-    with open(json_path, "w") as f_:
-        json.dump(out_data, f_)
-
-    print(f"Viewer data are saved to '{json_path}'")
-
-
-def _get_views_data(config_path):
-    """Return all found viewer data.
-
-    Args:
-        config_path (str): path string leading to config.ocio
-
-    Raises:
-        IOError: Input config does not exist.
-
-    Returns:
-        dict: aggregated available viewers
-    """
-    config_path = Path(config_path)
-
-    if not config_path.is_file():
-        raise IOError("Input path should be `config.ocio` file")
-
-    config = ocio.Config().CreateFromFile(str(config_path))
-
-    data_ = {}
-    for display in config.getDisplays():
-        for view in config.getViews(display):
-            colorspace = config.getDisplayViewColorSpaceName(display, view)
-            # Special token. See https://opencolorio.readthedocs.io/en/latest/guides/authoring/authoring.html#shared-views # noqa
-            if colorspace == "<USE_DISPLAY_NAME>":
-                colorspace = display
-
-            data_[f"{display}/{view}"] = {
-                "display": display,
-                "view": view,
-                "colorspace": colorspace
-            }
-
-    return data_
+    _save_output_to_json_file(
+        get_ocio_config_views(config_path),
+        output_path
+    )
 
 
 @config.command(
-    name="get_version",
-    help=(
-        "return major and minor version from config file "
-        "--config_path input arg is required"
-        "--out_path input arg is required"
-    )
-)
-@click.option("--config_path", required=True,
-              help="path where to read ocio config file",
-              type=click.Path(exists=True))
-@click.option("--out_path", required=True,
-              help="path where to write output json file",
-              type=click.Path())
-def get_version(config_path, out_path):
+    name="get_config_version_data",
+    help="Get major and minor version from config file")
+@click.option(
+    "--config_path",
+    required=True,
+    help="OCIO config path to read ocio config file.",
+    type=click.Path(exists=True))
+@click.option(
+    "--output_path",
+    required=True,
+    help="path where to write output json file",
+    type=click.Path())
+def _get_config_version_data(config_path, output_path):
     """Get version of config.
-
-    Python 2 wrapped console command
 
     Args:
         config_path (str): ocio config file path string
-        out_path (str): temp json file path string
+        output_path (str): temp json file path string
 
     Example of use:
     > pyton.exe ./ocio_wrapper.py config get_version \
-        --config_path=<path> --out_path=<path>
+        --config_path <path> --output_path <path>
     """
-    json_path = Path(out_path)
-
-    out_data = _get_version_data(config_path)
-
-    with open(json_path, "w") as f_:
-        json.dump(out_data, f_)
-
-    print(f"Config version data are saved to '{json_path}'")
-
-
-def _get_version_data(config_path):
-    """Return major and minor version info.
-
-    Args:
-        config_path (str): path string leading to config.ocio
-
-    Raises:
-        IOError: Input config does not exist.
-
-    Returns:
-        dict: minor and major keys with values
-    """
-    config_path = Path(config_path)
-
-    if not config_path.is_file():
-        raise IOError("Input path should be `config.ocio` file")
-
-    config = ocio.Config().CreateFromFile(str(config_path))
-
-    return {
-        "major": config.getMajorVersion(),
-        "minor": config.getMinorVersion()
-    }
+    _save_output_to_json_file(
+        get_config_version_data(config_path),
+        output_path
+    )
 
 
 @colorspace.command(
     name="get_config_file_rules_colorspace_from_filepath",
-    help=(
-        "return colorspace from filepath "
-        "--config_path - ocio config file path (input arg is required) "
-        "--filepath - any file path (input arg is required) "
-        "--out_path - temp json file path (input arg is required)"
-    )
-)
-@click.option("--config_path", required=True,
-              help="path where to read ocio config file",
-              type=click.Path(exists=True))
-@click.option("--filepath", required=True,
-              help="path to file to get colorspace from",
-              type=click.Path())
-@click.option("--out_path", required=True,
-              help="path where to write output json file",
-              type=click.Path())
-def get_config_file_rules_colorspace_from_filepath(
-    config_path, filepath, out_path
+    help="Colorspace file rules from filepath")
+@click.option(
+    "--config_path",
+    required=True,
+    help="OCIO config path to read ocio config file.",
+    type=click.Path(exists=True))
+@click.option(
+    "--filepath",
+    equired=True,
+    help="Path to file to get colorspace from.",
+    type=click.Path())
+@click.option(
+    "--output_path",
+    required=True,
+    help="Path where to write output json file.",
+    type=click.Path())
+def _get_config_file_rules_colorspace_from_filepath(
+    config_path, filepath, output_path
 ):
     """Get colorspace from file path wrapper.
-
-    Python 2 wrapped console command
 
     Args:
         config_path (str): config file path string
         filepath (str): path string leading to file
-        out_path (str): temp json file path string
+        output_path (str): temp json file path string
 
     Example of use:
-    > pyton.exe ./ocio_wrapper.py \
+    > python.exe ./ocio_wrapper.py \
         colorspace get_config_file_rules_colorspace_from_filepath \
-        --config_path=<path> --filepath=<path> --out_path=<path>
+        --config_path <path> --filepath <path> --output_path <path>
     """
-    json_path = Path(out_path)
-
-    colorspace = _get_config_file_rules_colorspace_from_filepath(
-        config_path, filepath)
-
-    with open(json_path, "w") as f_:
-        json.dump(colorspace, f_)
-
-    print(f"Colorspace name is saved to '{json_path}'")
-
-
-def _get_config_file_rules_colorspace_from_filepath(config_path, filepath):
-    """Return found colorspace data found in v2 file rules.
-
-    Args:
-        config_path (str): path string leading to config.ocio
-        filepath (str): path string leading to v2 file rules
-
-    Raises:
-        IOError: Input config does not exist.
-
-    Returns:
-        dict: aggregated available colorspaces
-    """
-    config_path = Path(config_path)
-
-    if not config_path.is_file():
-        raise IOError(
-            f"Input path `{config_path}` should be `config.ocio` file")
-
-    config = ocio.Config().CreateFromFile(str(config_path))
-
-    # TODO: use `parseColorSpaceFromString` instead if ocio v1
-    colorspace = config.getColorSpaceFromFilepath(str(filepath))
-
-    return colorspace
-
-
-def _get_display_view_colorspace_name(config_path, display, view):
-    """Returns the colorspace attribute of the (display, view) pair.
-
-    Args:
-        config_path (str): path string leading to config.ocio
-        display (str): display name e.g. "ACES"
-        view (str): view name e.g. "sRGB"
-
-
-    Raises:
-        IOError: Input config does not exist.
-
-    Returns:
-        view color space name (str) e.g. "Output - sRGB"
-    """
-
-    config_path = Path(config_path)
-
-    if not config_path.is_file():
-        raise IOError("Input path should be `config.ocio` file")
-
-    config = ocio.Config.CreateFromFile(str(config_path))
-    colorspace = config.getDisplayViewColorSpaceName(display, view)
-
-    return colorspace
+    _save_output_to_json_file(
+        get_config_file_rules_colorspace_from_filepath(config_path, filepath),
+        output_path
+    )
 
 
 @config.command(
     name="get_display_view_colorspace_name",
     help=(
-        "return default view colorspace name "
-        "for the given display and view "
-        "--path input arg is required"
-    )
-)
-@click.option("--in_path", required=True,
-              help="path where to read ocio config file",
-              type=click.Path(exists=True))
-@click.option("--out_path", required=True,
-              help="path where to write output json file",
-              type=click.Path())
-@click.option("--display", required=True,
-              help="display name",
-              type=click.STRING)
-@click.option("--view", required=True,
-              help="view name",
-              type=click.STRING)
-def get_display_view_colorspace_name(in_path, out_path,
-                                     display, view):
+        "Default view colorspace name for the given display and view"
+    ))
+@click.option(
+    "--config_path",
+    required=True,
+    help="path where to read ocio config file",
+    type=click.Path(exists=True))
+@click.option(
+    "--display",
+    required=True,
+    help="Display name",
+    type=click.STRING)
+@click.option(
+    "--view",
+    required=True,
+    help="view name",
+    type=click.STRING)
+@click.option(
+    "--output_path",
+    required=True,
+    help="path where to write output json file",
+    type=click.Path())
+def _get_display_view_colorspace_name(
+    config_path, display, view, output_path
+):
     """Aggregate view colorspace name to file.
 
     Wrapper command for processes without access to OpenColorIO
 
     Args:
-        in_path (str): config file path string
-        out_path (str): temp json file path string
+        config_path (str): config file path string
+        output_path (str): temp json file path string
         display (str): display name e.g. "ACES"
         view (str): view name e.g. "sRGB"
 
     Example of use:
     > pyton.exe ./ocio_wrapper.py config \
-        get_display_view_colorspace_name --in_path=<path> \
-        --out_path=<path> --display=<display> --view=<view>
+        get_display_view_colorspace_name --config_path <path> \
+        --output_path <path> --display <display> --view <view>
     """
+    _save_output_to_json_file(
+        get_display_view_colorspace_name(config_path, display, view),
+        output_path
+    )
 
-    out_data = _get_display_view_colorspace_name(in_path,
-                                                 display,
-                                                 view)
 
-    with open(out_path, "w") as f:
-        json.dump(out_data, f)
-
-    print(f"Display view colorspace saved to '{out_path}'")
-
-if __name__ == '__main__':
+if __name__ == "__main__":
+    if not has_compatible_ocio_package():
+        raise RuntimeError("OpenColorIO is not available.")
     main()

--- a/client/ayon_core/scripts/ocio_wrapper.py
+++ b/client/ayon_core/scripts/ocio_wrapper.py
@@ -153,7 +153,7 @@ def _get_config_version_data(config_path, output_path):
     type=click.Path(exists=True))
 @click.option(
     "--filepath",
-    equired=True,
+    required=True,
     help="Path to file to get colorspace from.",
     type=click.Path())
 @click.option(

--- a/client/ayon_core/scripts/ocio_wrapper.py
+++ b/client/ayon_core/scripts/ocio_wrapper.py
@@ -33,27 +33,7 @@ def main():
     pass  # noqa: WPS100
 
 
-@main.group()
-def config():
-    """Config related commands group
-
-    Example of use:
-    > pyton.exe ./ocio_wrapper.py config <command> *args
-    """
-    pass  # noqa: WPS100
-
-
-@main.group()
-def colorspace():
-    """Colorspace related commands group
-
-    Example of use:
-    > pyton.exe ./ocio_wrapper.py config <command> *args
-    """
-    pass  # noqa: WPS100
-
-
-@config.command(
+@main.command(
     name="get_ocio_config_colorspaces",
     help="return all colorspaces from config file")
 @click.option(
@@ -83,7 +63,7 @@ def _get_ocio_config_colorspaces(config_path, output_path):
     )
 
 
-@config.command(
+@main.command(
     name="get_ocio_config_views",
     help="All viewers from config file")
 @click.option(
@@ -113,7 +93,7 @@ def _get_ocio_config_views(config_path, output_path):
     )
 
 
-@config.command(
+@main.command(
     name="get_config_version_data",
     help="Get major and minor version from config file")
 @click.option(
@@ -143,7 +123,7 @@ def _get_config_version_data(config_path, output_path):
     )
 
 
-@colorspace.command(
+@main.command(
     name="get_config_file_rules_colorspace_from_filepath",
     help="Colorspace file rules from filepath")
 @click.option(
@@ -182,7 +162,7 @@ def _get_config_file_rules_colorspace_from_filepath(
     )
 
 
-@config.command(
+@main.command(
     name="get_display_view_colorspace_name",
     help=(
         "Default view colorspace name for the given display and view"


### PR DESCRIPTION
## Changelog Description
Move all colorspace logic to `colorspace.py` which is only imported in ocio wrapper.

## Additional info
Wrapper is now just simple cli that calls functions from colorspace and stores result into output json. Code from wrapper was moved to `colorspace.py`. Moved functions areound, deprecated functions are at the bottom.
Validation of compatible `PyOpenColorIO` now also checks version of the module.

## Testing notes:
1. Colorspace logic should work almost anywhere.
