### PR TITLE
Chore: Validate Content plugin settings

### DIFF
--- a/client/ayon_core/plugins/publish/validate_containers.py
+++ b/client/ayon_core/plugins/publish/validate_containers.py
@@ -45,9 +45,15 @@ class ValidateContainers(
             return
 
         # Disable if no profile is found for the current host
+        profiles = (
+            settings
+            ["core"]
+            ["publish"]
+            ["ValidateContainers"]
+            ["plugin_state_profiles"]
+        )
         profile = filter_profiles(
-            settings["core"]["publish"]["ValidateContainers"]["profiles"],
-            {"host_names": get_current_host_name()}
+            profiles, {"host_names": get_current_host_name()}
         )
         if not profile:
             cls.enabled = False

--- a/client/ayon_core/plugins/publish/validate_containers.py
+++ b/client/ayon_core/plugins/publish/validate_containers.py
@@ -1,6 +1,11 @@
 import pyblish.api
+
+from ayon_core.lib import filter_profiles
+from ayon_core.host import ILoadHost
 from ayon_core.pipeline.load import any_outdated_containers
 from ayon_core.pipeline import (
+    get_current_host_name,
+    registered_host,
     PublishXmlValidationError,
     OptionalPyblishPluginMixin
 )
@@ -18,16 +23,43 @@ class ShowInventory(pyblish.api.Action):
         host_tools.show_scene_inventory()
 
 
-class ValidateContainers(OptionalPyblishPluginMixin,
-                         pyblish.api.ContextPlugin):
-
+class ValidateContainers(
+    OptionalPyblishPluginMixin,
+    pyblish.api.ContextPlugin
+):
     """Containers are must be updated to latest version on publish."""
 
     label = "Validate Outdated Containers"
     order = pyblish.api.ValidatorOrder
-    hosts = ["maya", "houdini", "nuke", "harmony", "photoshop", "aftereffects"]
+
     optional = True
     actions = [ShowInventory]
+
+    @classmethod
+    def apply_settings(cls, settings):
+        # Disable plugin if host does not inherit from 'ILoadHost'
+        # - not a host that can load containers
+        host = registered_host()
+        if not isinstance(host, ILoadHost):
+            cls.enabled = False
+            return
+
+        # Disable if no profile is found for the current host
+        profile = filter_profiles(
+            settings["core"]["publish"]["ValidateContainers"]["profiles"],
+            {"host_names": get_current_host_name()}
+        )
+        if not profile:
+            cls.enabled = False
+            return
+
+        # Apply settings from profile
+        for attr_name in {
+            "enabled",
+            "optional",
+            "active",
+        }:
+            setattr(cls, attr_name, profile[attr_name])
 
     def process(self, context):
         if not self.is_active(context.data):

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -81,7 +81,8 @@ class ValidateContainersModel(BaseSettingsModel):
 
     _isGroup = True
     plugin_state_profiles: list[ValidateContainersProfile] = SettingsField(
-        default_factory=list
+        default_factory=list,
+        title="Plugin enable state profiles",
     )
 
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -67,9 +67,9 @@ class ValidateContainersProfile(BaseSettingsModel):
         title="Host names"
     )
     # Profile values
-    enabled: bool = SettingsField(True)
-    optional: bool = SettingsField(True)
-    active: bool = SettingsField(True)
+    enabled: bool = SettingsField(True, title="Enabled")
+    optional: bool = SettingsField(True, title="Optional")
+    active: bool = SettingsField(True, title="Active")
 
 
 class ValidateContainersModel(BaseSettingsModel):

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -80,7 +80,7 @@ class ValidateContainersModel(BaseSettingsModel):
     """
 
     _isGroup = True
-    profiles: list[ValidateContainersProfile] = SettingsField(
+    plugin_state_profiles: list[ValidateContainersProfile] = SettingsField(
         default_factory=list
     )
 
@@ -886,7 +886,7 @@ DEFAULT_PUBLISH_VALUES = {
         "active": True
     },
     "ValidateContainers": {
-        "profiles": [
+        "plugin_state_profiles": [
             {
                 # Default host names are based on original
                 #   filter of ValidateContainer pyblish plugin

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -59,6 +59,32 @@ class CollectFramesFixDefModel(BaseSettingsModel):
     )
 
 
+class ValidateContainersProfile(BaseSettingsModel):
+    _layout = "expanded"
+    # Filtering
+    host_names: list[str] = SettingsField(
+        default_factory=list,
+        title="Host names"
+    )
+    # Profile values
+    enabled: bool = SettingsField(True)
+    optional: bool = SettingsField(True)
+    active: bool = SettingsField(True)
+
+
+class ValidateContainersModel(BaseSettingsModel):
+    """Validate if Publishing intent was selected.
+
+    It is possible to disable validation for specific publishing context
+    with profiles.
+    """
+
+    _isGroup = True
+    profiles: list[ValidateContainersProfile] = SettingsField(
+        default_factory=list
+    )
+
+
 class ValidateIntentProfile(BaseSettingsModel):
     _layout = "expanded"
     hosts: list[str] = SettingsField(default_factory=list, title="Host names")
@@ -770,6 +796,10 @@ class PublishPuginsModel(BaseSettingsModel):
         default_factory=ValidateBaseModel,
         title="Validate Version"
     )
+    ValidateContainers: ValidateContainersModel = SettingsField(
+        default_factory=ValidateContainersModel,
+        title="Validate Containers"
+    )
     ValidateIntent: ValidateIntentModel = SettingsField(
         default_factory=ValidateIntentModel,
         title="Validate Intent"
@@ -854,6 +884,25 @@ DEFAULT_PUBLISH_VALUES = {
         "enabled": True,
         "optional": False,
         "active": True
+    },
+    "ValidateContainers": {
+        "profiles": [
+            {
+                # Default host names are based on original
+                #   filter of ValidateContainer pyblish plugin
+                "host_names": [
+                    "maya",
+                    "houdini",
+                    "nuke",
+                    "harmony",
+                    "photoshop",
+                    "aftereffects"
+                ],
+                "enabled": True,
+                "optional": True,
+                "active": True
+            }
+        ]
     },
     "ValidateIntent": {
         "enabled": False,

--- a/server_addon/aftereffects/package.py
+++ b/server_addon/aftereffects/package.py
@@ -1,3 +1,3 @@
 name = "aftereffects"
 title = "AfterEffects"
-version = "0.1.3"
+version = "0.1.4"

--- a/server_addon/aftereffects/server/settings/publish_plugins.py
+++ b/server_addon/aftereffects/server/settings/publish_plugins.py
@@ -22,12 +22,6 @@ class ValidateSceneSettingsModel(BaseSettingsModel):
     )
 
 
-class ValidateContainersModel(BaseSettingsModel):
-    enabled: bool = SettingsField(True, title="Enabled")
-    optional: bool = SettingsField(True, title="Optional")
-    active: bool = SettingsField(True, title="Active")
-
-
 class AfterEffectsPublishPlugins(BaseSettingsModel):
     CollectReview: CollectReviewPluginModel = SettingsField(
         default_factory=CollectReviewPluginModel,
@@ -36,10 +30,6 @@ class AfterEffectsPublishPlugins(BaseSettingsModel):
     ValidateSceneSettings: ValidateSceneSettingsModel = SettingsField(
         default_factory=ValidateSceneSettingsModel,
         title="Validate Scene Settings",
-    )
-    ValidateContainers: ValidateContainersModel = SettingsField(
-        default_factory=ValidateContainersModel,
-        title="Validate Containers",
     )
 
 
@@ -58,9 +48,4 @@ AE_PUBLISH_PLUGINS_DEFAULTS = {
             ".*"
         ]
     },
-    "ValidateContainers": {
-        "enabled": True,
-        "optional": True,
-        "active": True,
-    }
 }

--- a/server_addon/harmony/package.py
+++ b/server_addon/harmony/package.py
@@ -1,3 +1,3 @@
 name = "harmony"
 title = "Harmony"
-version = "0.1.2"
+version = "0.1.3"

--- a/server_addon/harmony/server/settings/main.py
+++ b/server_addon/harmony/server/settings/main.py
@@ -45,11 +45,6 @@ DEFAULT_HARMONY_SETTING = {
             "optional": True,
             "active": True
         },
-        "ValidateContainers": {
-            "enabled": True,
-            "optional": True,
-            "active": True
-        },
         "ValidateSceneSettings": {
             "enabled": True,
             "optional": True,

--- a/server_addon/harmony/server/settings/publish_plugins.py
+++ b/server_addon/harmony/server/settings/publish_plugins.py
@@ -18,14 +18,6 @@ class ValidateAudioPlugin(BaseSettingsModel):
     active: bool = SettingsField(True, title="Active")
 
 
-class ValidateContainersPlugin(BaseSettingsModel):
-    """Check if loaded container is scene are latest versions."""
-    _isGroup = True
-    enabled: bool = True
-    optional: bool = SettingsField(False, title="Optional")
-    active: bool = SettingsField(True, title="Active")
-
-
 class ValidateSceneSettingsPlugin(BaseSettingsModel):
     """Validate if FrameStart, FrameEnd and Resolution match shot data in DB.
        Use regular expressions to limit validations only on particular asset
@@ -61,11 +53,6 @@ class HarmonyPublishPlugins(BaseSettingsModel):
     ValidateAudio: ValidateAudioPlugin = SettingsField(
         title="Validate Audio",
         default_factory=ValidateAudioPlugin,
-    )
-
-    ValidateContainers: ValidateContainersPlugin = SettingsField(
-        title="Validate Containers",
-        default_factory=ValidateContainersPlugin,
     )
 
     ValidateSceneSettings: ValidateSceneSettingsPlugin = SettingsField(

--- a/server_addon/houdini/package.py
+++ b/server_addon/houdini/package.py
@@ -1,3 +1,3 @@
 name = "houdini"
 title = "Houdini"
-version = "0.2.14"
+version = "0.2.15"

--- a/server_addon/houdini/server/settings/publish.py
+++ b/server_addon/houdini/server/settings/publish.py
@@ -77,10 +77,6 @@ class PublishPluginsModel(BaseSettingsModel):
         default_factory=CollectLocalRenderInstancesModel,
         title="Collect Local Render Instances."
     )
-    ValidateContainers: BasicValidateModel = SettingsField(
-        default_factory=BasicValidateModel,
-        title="Validate Latest Containers.",
-        section="Validators")
     ValidateInstanceInContextHoudini: BasicValidateModel = SettingsField(
         default_factory=BasicValidateModel,
         title="Validate Instance is in same Context.")
@@ -118,11 +114,6 @@ DEFAULT_HOUDINI_PUBLISH_SETTINGS = {
                 ".*([Bb]eauty).*"
             ]
         }
-    },
-    "ValidateContainers": {
-        "enabled": True,
-        "optional": True,
-        "active": True
     },
     "ValidateInstanceInContextHoudini": {
         "enabled": True,

--- a/server_addon/maya/package.py
+++ b/server_addon/maya/package.py
@@ -1,3 +1,3 @@
 name = "maya"
 title = "Maya"
-version = "0.1.19"
+version = "0.1.20"

--- a/server_addon/maya/server/settings/publishers.py
+++ b/server_addon/maya/server/settings/publishers.py
@@ -634,10 +634,6 @@ class PublishersModel(BaseSettingsModel):
         title="Validate Instance In Context",
         section="Validators"
     )
-    ValidateContainers: BasicValidateModel = SettingsField(
-        default_factory=BasicValidateModel,
-        title="Validate Containers"
-    )
     ValidateFrameRange: ValidateFrameRangeModel = SettingsField(
         default_factory=ValidateFrameRangeModel,
         title="Validate Frame Range"
@@ -1055,11 +1051,6 @@ DEFAULT_PUBLISH_SETTINGS = {
         "enabled": False
     },
     "ValidateInstanceInContext": {
-        "enabled": True,
-        "optional": True,
-        "active": True
-    },
-    "ValidateContainers": {
         "enabled": True,
         "optional": True,
         "active": True

--- a/server_addon/nuke/package.py
+++ b/server_addon/nuke/package.py
@@ -1,3 +1,3 @@
 name = "nuke"
 title = "Nuke"
-version = "0.1.12"
+version = "0.1.13"

--- a/server_addon/nuke/server/settings/publish_plugins.py
+++ b/server_addon/nuke/server/settings/publish_plugins.py
@@ -231,10 +231,6 @@ class PublishPluginsModel(BaseSettingsModel):
         default_factory=OptionalPluginModel,
         section="Validators"
     )
-    ValidateContainers: OptionalPluginModel = SettingsField(
-        title="Validate Containers",
-        default_factory=OptionalPluginModel
-    )
     ValidateKnobs: ValidateKnobsModel = SettingsField(
         title="Validate Knobs",
         default_factory=ValidateKnobsModel
@@ -296,11 +292,6 @@ DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
         ]
     },
     "ValidateCorrectAssetContext": {
-        "enabled": True,
-        "optional": True,
-        "active": True
-    },
-    "ValidateContainers": {
         "enabled": True,
         "optional": True,
         "active": True

--- a/server_addon/photoshop/package.py
+++ b/server_addon/photoshop/package.py
@@ -1,3 +1,3 @@
 name = "photoshop"
 title = "Photoshop"
-version = "0.1.2"
+version = "0.1.3"

--- a/server_addon/photoshop/server/settings/publish_plugins.py
+++ b/server_addon/photoshop/server/settings/publish_plugins.py
@@ -83,14 +83,6 @@ class CollectVersionPlugin(BaseSettingsModel):
     enabled: bool = SettingsField(True, title="Enabled")
 
 
-class ValidateContainersPlugin(BaseSettingsModel):
-    """Check that workfile contains latest version of loaded items"""  # noqa
-    _isGroup = True
-    enabled: bool = True
-    optional: bool = SettingsField(False, title="Optional")
-    active: bool = SettingsField(True, title="Active")
-
-
 class ValidateNamingPlugin(BaseSettingsModel):
     """Validate naming of products and layers"""  # noqa
     invalid_chars: str = SettingsField(
@@ -154,11 +146,6 @@ class PhotoshopPublishPlugins(BaseSettingsModel):
         default_factory=CollectVersionPlugin,
     )
 
-    ValidateContainers: ValidateContainersPlugin = SettingsField(
-        title="Validate Containers",
-        default_factory=ValidateContainersPlugin,
-    )
-
     ValidateNaming: ValidateNamingPlugin = SettingsField(
         title="Validate naming of products and layers",
         default_factory=ValidateNamingPlugin,
@@ -186,11 +173,6 @@ DEFAULT_PUBLISH_SETTINGS = {
     },
     "CollectVersion": {
         "enabled": False
-    },
-    "ValidateContainers": {
-        "enabled": True,
-        "optional": True,
-        "active": True
     },
     "ValidateNaming": {
         "invalid_chars": "[ \\\\/+\\*\\?\\(\\)\\[\\]\\{\\}:,;]",


### PR DESCRIPTION
## Changelog Description
Added profile based settings for Validate Content publish plugin.

## Additional info
The settings will change behavior of the plugin based on host name. The plugin is disabled if host does not support load functionality, or there are no profiles. Removed settings of the plugin from other hosts.

We should do this for the move of hosts. The first encounter happened in https://github.com/ynput/ayon-core/pull/516 .

## Testing notes:
1. Create package of core and all changed host addons (AE, PS, Nuke, Maya, Houdini, Harmony).
2. Launch DCC of one of the host integrations.
3. Validate Content should be there and can be disabled (with default settings).
4. Based on changed settings the plugin should change it's state -> remove all profiles, remove the host from list, add new hosts, change optional state etc.
