### PR TITLE
Colorspace: Fix Anatomy object initialization

### DIFF
--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -920,7 +920,7 @@ def get_imageio_config_preset(
     project_entity = None
     if anatomy is None:
         project_entity = ayon_api.get_project(project_name)
-        anatomy = Anatomy(project_name, project_entity)
+        anatomy = Anatomy(project_name, project_entity=project_entity)
 
     if env is None:
         env = dict(os.environ.items())


### PR DESCRIPTION
## Changelog Description
Use kwargs to pass project entity to Anatomy initialization.

## Additional info
Project entity was passed in as site name instead of project entity.

## Testing notes:
- Make sure you have core with new imageio color settings (or create package from this PR and upload to server to be sure).
1. Enable colormanagement in core addon.
2. Launch host of your choice (should have ability to run python scripts)
3. Run this
```python
from ayon_core.pipeline.colorspace import get_current_context_imageio_config_preset

get_current_context_imageio_config_preset()
```
It should not crash.