### PR TITLE
Push to Project: Fix task lowering

### DIFF
--- a/client/ayon_core/tools/push_to_project/models/integrate.py
+++ b/client/ayon_core/tools/push_to_project/models/integrate.py
@@ -723,7 +723,6 @@ class ProjectPushItemProcess:
         dst_project_name = self._item.dst_project_name
         dst_folder_id = self._item.dst_folder_id
         dst_task_name = self._item.dst_task_name
-        dst_task_name_low = dst_task_name.lower()
         new_folder_name = self._item.new_folder_name
         if not dst_folder_id and not new_folder_name:
             self._status.set_failed(
@@ -765,7 +764,7 @@ class ProjectPushItemProcess:
                 dst_project_name, folder_ids=[folder_entity["id"]]
             )
         }
-        task_info = folder_tasks.get(dst_task_name_low)
+        task_info = folder_tasks.get(dst_task_name.lower())
         if not task_info:
             self._status.set_failed(
                 f"Could find task with name \"{dst_task_name}\""


### PR DESCRIPTION
## Changelog Description
Lower task name when is used, and not when it can be `None`.

## Additional information
Quick fix without knowing full context -> missing test notes @MustafaJafar fill if you can.
