### PR TITLE
Launcher tool: Fix view update

### DIFF
--- a/client/ayon_core/tools/launcher/ui/actions_widget.py
+++ b/client/ayon_core/tools/launcher/ui/actions_widget.py
@@ -359,7 +359,8 @@ class ActionsWidget(QtWidgets.QWidget):
     def _on_model_refresh(self):
         self._proxy_model.sort(0)
         # Force repaint all items
-        self._view.update()
+        viewport = self._view.viewport()
+        viewport.update()
 
     def _on_animation(self):
         time_now = time.time()


### PR DESCRIPTION
## Changelog Description
Call update on viewport instead on view.

## Additional info
Method `update` on view does update single index which should be passed in, but it is not. The bug was discovered with PySide6.

### Traceback
```
Traceback (most recent call last):
  File ".\client\ayon_core\tools\launcher\ui\actions_widget.py", line 362, in _on_model_refresh
    self._view.update()
  TypeError: QListView.update() takes exactly one argument (0 given)
```

## Testing notes:

You would have to use macOs or force using PySide6 in AYON launcher (for other platforms).
1. Start ayon launcher with console.
2. In tray open `Launcher` tool.
3. Select project and change context few times.
4. The traceback should not be raised.

- With PySide2 launcher tool works as expected too.