### PR TITLE
Launcher: Make sure actions in Launcher are sorted

### DIFF
--- a/client/ayon_core/tools/launcher/models/actions.py
+++ b/client/ayon_core/tools/launcher/models/actions.py
@@ -332,7 +332,7 @@ class ActionsModel:
         selection = self._prepare_selection(project_name, folder_id, task_id)
         output = []
         action_items = self._get_action_items(project_name)
-        for identifier, action in self._get_action_objects().items():
+        for identifier, action in sorted(self._get_action_objects().items()):
             if not action.is_compatible(selection):
                 continue
 

--- a/client/ayon_core/tools/launcher/models/actions.py
+++ b/client/ayon_core/tools/launcher/models/actions.py
@@ -332,7 +332,7 @@ class ActionsModel:
         selection = self._prepare_selection(project_name, folder_id, task_id)
         output = []
         action_items = self._get_action_items(project_name)
-        for identifier, action in sorted(self._get_action_objects().items()):
+        for identifier, action in self._get_action_objects().items():
             if not action.is_compatible(selection):
                 continue
 

--- a/client/ayon_core/tools/launcher/ui/actions_widget.py
+++ b/client/ayon_core/tools/launcher/ui/actions_widget.py
@@ -290,6 +290,34 @@ class ActionDelegate(QtWidgets.QStyledItemDelegate):
         painter.drawPixmap(extender_x, extender_y, pix)
 
 
+class ActionsProxyModel(QtCore.QSortFilterProxyModel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.setSortCaseSensitivity(QtCore.Qt.CaseInsensitive)
+
+    def lessThan(self, left, right):
+        # Sort by action order and then by label
+        left_value = left.data(ACTION_SORT_ROLE)
+        right_value = right.data(ACTION_SORT_ROLE)
+
+        # Values are same -> use super sorting
+        if left_value == right_value:
+            # Default behavior is using DisplayRole
+            return super().lessThan(left, right)
+
+        # Validate 'None' values
+        if right_value is None:
+            return True
+        if left_value is None:
+            return False
+        # Sort values and handle incompatible types
+        try:
+            return left_value < right_value
+        except TypeError:
+            return True
+
+
 class ActionsWidget(QtWidgets.QWidget):
     def __init__(self, controller, parent):
         super(ActionsWidget, self).__init__(parent)
@@ -316,10 +344,7 @@ class ActionsWidget(QtWidgets.QWidget):
 
         model = ActionsQtModel(controller)
 
-        proxy_model = QtCore.QSortFilterProxyModel()
-        proxy_model.setSortCaseSensitivity(QtCore.Qt.CaseInsensitive)
-        proxy_model.setSortRole(ACTION_SORT_ROLE)
-
+        proxy_model = ActionsProxyModel()
         proxy_model.setSourceModel(model)
         view.setModel(proxy_model)
 


### PR DESCRIPTION
## Changelog Description
Sort action items by identifier so their order doesn't keep changing on every launch.

## Testing notes:
1. Open Launcher
2. Actions should be sorted
