### PR TITLE
Houdini: Disable integration for the original render instance when publishing locally

### DIFF
--- a/client/ayon_core/hosts/houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/collect_local_render_instances.py
@@ -132,6 +132,6 @@ class CollectLocalRenderInstances(pyblish.api.InstancePlugin):
                 ]
             })
 
-        # Remove original render instance
-        # I can't remove it here as I still need it to trigger the render.
-        # context.remove(instance)
+        # Skip integrating original render instance.
+        # We are not removing it because it's used to trigger the render.
+        instance.data["integrate"] = False

--- a/client/ayon_core/hosts/houdini/plugins/publish/extract_render.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/extract_render.py
@@ -74,4 +74,4 @@ class ExtractRender(publish.Extractor):
                                    missing_frames))
 
         # Remove original render instance
-        instance.context.remove(instance)
+        instance.data["integrate"] = False

--- a/client/ayon_core/hosts/houdini/plugins/publish/extract_render.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/extract_render.py
@@ -72,3 +72,6 @@ class ExtractRender(publish.Extractor):
             raise RuntimeError("Failed to complete render extraction. "
                                "Missing output files: {}".format(
                                    missing_frames))
+
+        # Remove original render instance
+        instance.context.remove(instance)

--- a/client/ayon_core/hosts/houdini/plugins/publish/extract_render.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/extract_render.py
@@ -73,5 +73,5 @@ class ExtractRender(publish.Extractor):
                                "Missing output files: {}".format(
                                    missing_frames))
 
-        # Remove original render instance
+        # Skip integrating original render instance
         instance.data["integrate"] = False

--- a/client/ayon_core/hosts/houdini/plugins/publish/extract_render.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/extract_render.py
@@ -72,6 +72,3 @@ class ExtractRender(publish.Extractor):
             raise RuntimeError("Failed to complete render extraction. "
                                "Missing output files: {}".format(
                                    missing_frames))
-
-        # Skip integrating original render instance
-        instance.data["integrate"] = False


### PR DESCRIPTION
## Changelog Description
Disable integration for original render instance when publishing locally

## Testing notes:
1. Launch Houdini
2. Publish Render locally and on farm.
