### PR TITLE
Use product name templates for render products on local Houdini render

### DIFF
--- a/client/ayon_core/hosts/houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/collect_local_render_instances.py
@@ -74,10 +74,18 @@ class CollectLocalRenderInstances(pyblish.api.InstancePlugin):
         )
 
         for aov_name, aov_filepaths in expectedFiles.items():
-            product_name = product_group
-
-            if aov_name:
-                product_name = "{}_{}".format(product_name, aov_name)
+            product_name = get_product_name(
+                context.data["projectName"],
+                context.data["taskEntity"]["name"],
+                context.data["taskEntity"]["taskType"],
+                context.data["hostName"],
+                product_type,
+                instance.data["productName"],
+                dynamic_data={
+                    "renderlayer": instance.data["renderlayer"],
+                    "aov": aov_name
+                }
+            )
 
             # Create instance for each AOV
             aov_instance = context.create_instance(product_name)

--- a/client/ayon_core/hosts/houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/collect_local_render_instances.py
@@ -64,6 +64,8 @@ class CollectLocalRenderInstances(pyblish.api.InstancePlugin):
         expectedFiles = next(iter(instance.data["expectedFiles"]), {})
 
         product_type = "render"  # is always render
+        # TODO: Match the value of product_group with the value of
+        #        group_name in farm pyblish functions.
         product_group = get_product_name(
             context.data["projectName"],
             context.data["taskEntity"]["name"],

--- a/client/ayon_core/hosts/houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_core/hosts/houdini/plugins/publish/collect_local_render_instances.py
@@ -127,6 +127,8 @@ class CollectLocalRenderInstances(pyblish.api.InstancePlugin):
                 "productGroup": product_group,
                 "families": ["render.local.hou", "review"],
                 "instance_node": instance.data["instance_node"],
+                "renderlayer": instance.data["renderlayer"],
+                "aov": aov_name,
                 "representations": [
                     {
                         "stagingDir": staging_dir,


### PR DESCRIPTION
## Changelog Description
This PR extends #447 and make it work with local Houdini render

## Testing notes:
1. Update these settings on ayon server: _you can take reference from my screenshots below._
  - `ayon+settings://core/tools/creator/product_name_profiles`
  - `ayon+anatomy://{my-project}/templates/publish/1` _render template._
2. Launch Houdini 
3. Publish Render locally. Here's what to expect:
  - you should find the names of the created runtime instances follow your the template profile
  - you should find the location of the published render follow your render template (we add support for two more keys `renderlayer` and `aov`)
  
  
## Additional Info
Here are some snippets of my settings. 
**Render template:** 
![image](https://github.com/ynput/ayon-core/assets/20871534/b17d76bf-5c1a-466b-90cb-d860691a8490)
**product_name_profiles:**
![image](https://github.com/ynput/ayon-core/assets/20871534/4a58644f-d2fb-41ff-89cd-e7983098119f)
