### PR TITLE
Deadline: run deadline collectors on preprender

### DIFF
--- a/client/ayon_core/modules/deadline/plugins/publish/collect_deadline_server_from_instance.py
+++ b/client/ayon_core/modules/deadline/plugins/publish/collect_deadline_server_from_instance.py
@@ -17,6 +17,7 @@ class CollectDeadlineServerFromInstance(pyblish.api.InstancePlugin):
     label = "Deadline Webservice from the Instance"
     targets = ["local"]
     families = ["render",
+                "prerender",
                 "rendering",
                 "render.farm",
                 "renderFarm",

--- a/client/ayon_core/modules/deadline/plugins/publish/collect_pools.py
+++ b/client/ayon_core/modules/deadline/plugins/publish/collect_pools.py
@@ -35,6 +35,7 @@ class CollectDeadlinePools(pyblish.api.InstancePlugin,
              "houdini"]
 
     families = ["render",
+                "prerender",
                 "rendering",
                 "render.farm",
                 "renderFarm",

--- a/client/ayon_core/modules/deadline/plugins/publish/collect_user_credentials.py
+++ b/client/ayon_core/modules/deadline/plugins/publish/collect_user_credentials.py
@@ -34,6 +34,7 @@ class CollectDeadlineUserCredentials(pyblish.api.InstancePlugin):
              "houdini"]
 
     families = ["render",
+                "prerender",
                 "rendering",
                 "render.farm",
                 "renderFarm",


### PR DESCRIPTION
## Changelog Description
Prerender instances (in Nuke) would be skipped and submit to DL would fail


## Testing notes:
1. create `prerender` instance in Nuke that should be rendered on DL
2. publish it to DL, it shouldnt fail on submit job plugin
