### PR TITLE
Create logic: Fix parent property in PublishAttributeValues

### DIFF
--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -681,7 +681,7 @@ class PublishAttributeValues(AttributeValues):
 
     @property
     def parent(self):
-        self.publish_attributes.parent
+        return self.publish_attributes.parent
 
 
 class PublishAttributes:


### PR DESCRIPTION
## Changelog Description
Property `parent` actually does return the parent object.

## Testing notes:
1. The property is not used so there is not much to test.
