### PR TITLE
Extract Burnin: Fix typo in settings label

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -558,7 +558,7 @@ class ExtractBurninProfile(BaseSettingsModel):
     _layout = "expanded"
     product_types: list[str] = SettingsField(
         default_factory=list,
-        title="Produt types"
+        title="Product types"
     )
     hosts: list[str] = SettingsField(
         default_factory=list,


### PR DESCRIPTION
## Changelog Description
Fix typo `Produt types` to `Product types`.