### PR TITLE
Chore: add the missing 3dsmax addon as part of addon milestone versions

### DIFF
--- a/client/ayon_core/addon/base.py
+++ b/client/ayon_core/addon/base.py
@@ -54,6 +54,7 @@ MOVED_ADDON_MILESTONE_VERSIONS = {
     "celaction": VersionInfo(0, 2, 0),
     "clockify": VersionInfo(0, 2, 0),
     "flame": VersionInfo(0, 2, 0),
+    "max": VersionInfo(0, 2, 0),
     "traypublisher": VersionInfo(0, 2, 0),
     "tvpaint": VersionInfo(0, 2, 0),
     "nuke": VersionInfo(0, 2, 0),


### PR DESCRIPTION
## Changelog Description
Add the 3dsmax addon version into addon milestone version after https://github.com/ynput/ayon-core/pull/563

## Additional info
Paragraphs of text giving context of additional technical information or code examples.

## Testing notes:
1. build 3dsmax addon with core addon
2. install addons
3. Launch 3dmax in AYON
4. Should be working