### PR TITLE
Motion Builder: application settings for motion builder

### DIFF
--- a/server_addon/applications/package.py
+++ b/server_addon/applications/package.py
@@ -1,6 +1,6 @@
 name = "applications"
 title = "Applications"
-version = "0.2.2"
+version = "0.2.3"
 
 ayon_server_version = ">=1.0.7"
 ayon_launcher_version = ">=1.0.2"

--- a/server_addon/applications/server/applications.json
+++ b/server_addon/applications/server/applications.json
@@ -1293,6 +1293,28 @@
                 }
             ]
         },
+        "motionbuilder": {
+            "enabled": true,
+            "label": "Motion Builder",
+            "icon": "{}/app_icons/motionbuilder.png",
+            "host_name": "motionbuilder",
+            "environment": "{}",
+            "variants": [
+                {
+                    "name": "2025",
+                    "label": "2025",
+                    "use_python_2": false,
+                    "executables": {
+                        "windows": [
+                            "C:\\Program Files\\Autodesk\\MotionBuilder 2025\\bin\\x64\\motionbuilder.exe"
+                        ],
+                        "darwin": [],
+                        "linux": []
+                    },
+                    "environment": "{}"
+                }
+            ]
+        },
         "additional_apps": []
     }
 }

--- a/server_addon/applications/server/settings.py
+++ b/server_addon/applications/server/settings.py
@@ -192,6 +192,8 @@ class ApplicationsSettings(BaseSettingsModel):
         default_factory=AppGroupWithPython, title="Zbrush")
     equalizer: AppGroup = SettingsField(
         default_factory=AppGroupWithPython, title="3DEqualizer")
+    motionbuilder: AppGroup = SettingsField(
+        default_factory=AppGroupWithPython, title="Motion Builder")
     additional_apps: list[AdditionalAppGroup] = SettingsField(
         default_factory=list, title="Additional Applications")
 


### PR DESCRIPTION
## Changelog Description
Application Settings which include motion builder executable into AYON launcher

## Additional info
n/a

## Testing notes:
1. Build the applications addon by `python ./server_addon/create_ayon_addons.py --addon applications
2. Install the addon and set your Anatomy Applications to include motion builder
3. You can find the motion builder in your launcher
![image](https://github.com/ynput/ayon-core/assets/64118225/d9f675d1-6964-40b6-b3f7-c80d18c7b60a)
