### PR TITLE
Photoshop: Add missing settings category

### DIFF
--- a/server_addon/photoshop/client/ayon_photoshop/plugins/publish/collect_color_coded_instances.py
+++ b/server_addon/photoshop/client/ayon_photoshop/plugins/publish/collect_color_coded_instances.py
@@ -33,6 +33,7 @@ class CollectColorCodedInstances(pyblish.api.ContextPlugin):
     order = pyblish.api.CollectorOrder
     hosts = ["photoshop"]
     targets = ["automated"]
+    settings_category = "photoshop"
 
     # configurable by Settings
     color_code_mapping = []

--- a/server_addon/photoshop/client/ayon_photoshop/plugins/publish/collect_review.py
+++ b/server_addon/photoshop/client/ayon_photoshop/plugins/publish/collect_review.py
@@ -16,6 +16,7 @@ class CollectReview(pyblish.api.ContextPlugin):
     label = "Collect Review"
     hosts = ["photoshop"]
     order = pyblish.api.CollectorOrder + 0.1
+    settings_category = "photoshop"
 
     def process(self, context):
         for instance in context:

--- a/server_addon/photoshop/client/ayon_photoshop/plugins/publish/collect_version.py
+++ b/server_addon/photoshop/client/ayon_photoshop/plugins/publish/collect_version.py
@@ -22,6 +22,7 @@ class CollectVersion(pyblish.api.InstancePlugin):
 
     hosts = ["photoshop"]
     families = ["image", "review", "workfile"]
+    settings_category = "photoshop"
 
     def process(self, instance):
         workfile_version = instance.context.data["version"]

--- a/server_addon/photoshop/client/ayon_photoshop/plugins/publish/extract_image.py
+++ b/server_addon/photoshop/client/ayon_photoshop/plugins/publish/extract_image.py
@@ -22,6 +22,7 @@ class ExtractImage(pyblish.api.ContextPlugin):
 
     families = ["image", "background"]
     formats = ["png", "jpg"]
+    settings_category = "photoshop"
 
     def process(self, context):
         stub = photoshop.stub()

--- a/server_addon/photoshop/client/ayon_photoshop/plugins/publish/extract_review.py
+++ b/server_addon/photoshop/client/ayon_photoshop/plugins/publish/extract_review.py
@@ -29,6 +29,7 @@ class ExtractReview(publish.Extractor):
     label = "Extract Review"
     hosts = ["photoshop"]
     families = ["review"]
+    settings_category = "photoshop"
 
     # Extract Options
     jpg_options = None

--- a/server_addon/photoshop/client/ayon_photoshop/plugins/publish/validate_naming.py
+++ b/server_addon/photoshop/client/ayon_photoshop/plugins/publish/validate_naming.py
@@ -16,6 +16,7 @@ class ValidateNamingRepair(pyblish.api.Action):
     label = "Repair"
     icon = "wrench"
     on = "failed"
+    settings_category = "photoshop"
 
     def process(self, context, plugin):
 

--- a/server_addon/photoshop/client/ayon_photoshop/version.py
+++ b/server_addon/photoshop/client/ayon_photoshop/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'photoshop' version."""
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/server_addon/photoshop/package.py
+++ b/server_addon/photoshop/package.py
@@ -1,6 +1,6 @@
 name = "photoshop"
 title = "Photoshop"
-version = "0.2.0"
+version = "0.2.1"
 
 client_dir = "ayon_photoshop"
 


### PR DESCRIPTION
## Changelog Description
Add missing `settings_category` attribute to publish plugins.

## Testing notes:
1. Plugin settings are applied correctly.
