### PR TITLE
Chore: Editorial dos not use asset naming

### DIFF
--- a/client/ayon_core/plugins/publish/collect_anatomy_instance_data.py
+++ b/client/ayon_core/plugins/publish/collect_anatomy_instance_data.py
@@ -391,7 +391,11 @@ class CollectAnatomyInstanceData(pyblish.api.ContextPlugin):
             anatomy_data.update(folder_data)
             return
 
-        if instance.data.get("newAssetPublishing"):
+        if (
+            instance.data.get("newHierarchyIntegration")
+            # Backwards compatible
+            or instance.data.get("newAssetPublishing")
+        ):
             hierarchy = instance.data["hierarchy"]
             anatomy_data["hierarchy"] = hierarchy
 
@@ -409,7 +413,7 @@ class CollectAnatomyInstanceData(pyblish.api.ContextPlugin):
                     "path": instance.data["folderPath"],
                     # TODO get folder type from hierarchy
                     #   Using 'Shot' is current default behavior of editorial
-                    #   (or 'newAssetPublishing') publishing.
+                    #   (or 'newHierarchyIntegration') publishing.
                     "type": "Shot",
                 },
             })
@@ -432,15 +436,22 @@ class CollectAnatomyInstanceData(pyblish.api.ContextPlugin):
         if task_data:
             # Fill task data
             # - if we're in editorial, make sure the task type is filled
-            if (
-                not instance.data.get("newAssetPublishing")
-                or task_data["type"]
-            ):
+            new_hierarchy = (
+                instance.data.get("newHierarchyIntegration")
+                # Backwards compatible
+                or instance.data.get("newAssetPublishing")
+            )
+            if not new_hierarchy or task_data["type"]:
                 anatomy_data["task"] = task_data
                 return
 
         # New hierarchy is not created, so we can only skip rest of the logic
-        if not instance.data.get("newAssetPublishing"):
+        new_hierarchy = (
+            instance.data.get("newHierarchyIntegration")
+            # Backwards compatible
+            or instance.data.get("newAssetPublishing")
+        )
+        if not new_hierarchy:
             return
 
         # Try to find task data based on hierarchy context and folder path

--- a/client/ayon_core/plugins/publish/validate_asset_docs.py
+++ b/client/ayon_core/plugins/publish/validate_asset_docs.py
@@ -24,7 +24,11 @@ class ValidateFolderEntities(pyblish.api.InstancePlugin):
         if instance.data.get("folderEntity"):
             self.log.debug("Instance has set fodler entity in its data.")
 
-        elif instance.data.get("newAssetPublishing"):
+        elif (
+            instance.data.get("newHierarchyIntegration")
+            # Backwards compatible
+            or instance.data.get("newAssetPublishing")
+        ):
             # skip if it is editorial
             self.log.debug("Editorial instance has no need to check...")
 

--- a/server_addon/flame/client/ayon_flame/plugins/publish/collect_timeline_instances.py
+++ b/server_addon/flame/client/ayon_flame/plugins/publish/collect_timeline_instances.py
@@ -152,7 +152,9 @@ class CollectTimelineInstances(pyblish.api.ContextPlugin):
                     task["name"]: {"type": task["type"]}
                     for task in self.add_tasks},
                 "representations": [],
-                "newAssetPublishing": True
+                "newHierarchyIntegration": True,
+                # Backwards compatible
+                "newAssetPublishing": True,
             })
             self.log.debug("__ inst_data: {}".format(pformat(inst_data)))
 

--- a/server_addon/flame/client/ayon_flame/version.py
+++ b/server_addon/flame/client/ayon_flame/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'flame' version."""
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/server_addon/flame/package.py
+++ b/server_addon/flame/package.py
@@ -1,6 +1,6 @@
 name = "flame"
 title = "Flame"
-version = "0.2.0"
+version = "0.2.1"
 
 client_dir = "ayon_flame"
 

--- a/server_addon/hiero/client/ayon_hiero/plugins/publish/precollect_instances.py
+++ b/server_addon/hiero/client/ayon_hiero/plugins/publish/precollect_instances.py
@@ -140,7 +140,9 @@ class PrecollectInstances(pyblish.api.ContextPlugin):
 
                 # add all additional tags
                 "tags": phiero.get_track_item_tags(track_item),
-                "newAssetPublishing": True
+                "newHierarchyIntegration": True,
+                # Backwards compatible
+                "newAssetPublishing": True,
             })
 
             # otio clip data

--- a/server_addon/hiero/client/ayon_hiero/version.py
+++ b/server_addon/hiero/client/ayon_hiero/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'hiero' version."""
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/server_addon/hiero/package.py
+++ b/server_addon/hiero/package.py
@@ -1,6 +1,6 @@
 name = "hiero"
 title = "Hiero"
-version = "0.2.0"
+version = "0.2.1"
 client_dir = "ayon_hiero"
 
 ayon_required_addons = {

--- a/server_addon/resolve/client/ayon_resolve/plugins/publish/precollect_instances.py
+++ b/server_addon/resolve/client/ayon_resolve/plugins/publish/precollect_instances.py
@@ -101,6 +101,8 @@ class PrecollectInstances(pyblish.api.ContextPlugin):
                 "fps": context.data["fps"],
                 "handleStart": handle_start,
                 "handleEnd": handle_end,
+                "newHierarchyIntegration": True,
+                # Backwards compatible
                 "newAssetPublishing": True,
                 "families": ["clip"],
                 "productType": product_type,

--- a/server_addon/traypublisher/client/ayon_traypublisher/plugins/create/create_editorial.py
+++ b/server_addon/traypublisher/client/ayon_traypublisher/plugins/create/create_editorial.py
@@ -676,6 +676,8 @@ or updating already created. Publishing will create OTIO file.
             "shotName": shot_name,
             "variant": variant_name,
             "task": None,
+            "newHierarchyIntegration": True,
+            # Backwards compatible
             "newAssetPublishing": True,
             "trackStartFrame": track_start_frame,
             "timelineOffset": timeline_offset,

--- a/server_addon/traypublisher/client/ayon_traypublisher/plugins/publish/collect_sequence_frame_data.py
+++ b/server_addon/traypublisher/client/ayon_traypublisher/plugins/publish/collect_sequence_frame_data.py
@@ -28,8 +28,12 @@ class CollectSequenceFrameData(
             return
 
         # editorial would fail since they might not be in database yet
-        new_folder_publishing = instance.data.get("newAssetPublishing")
-        if new_folder_publishing:
+        new_hierarchy = (
+            instance.data.get("newHierarchyIntegration")
+            # Backwards compatible
+            or instance.data.get("newAssetPublishing")
+        )
+        if new_hierarchy:
             self.log.debug("Instance is creating new folders. Skipping.")
             return
 

--- a/server_addon/traypublisher/client/ayon_traypublisher/plugins/publish/validate_frame_ranges.py
+++ b/server_addon/traypublisher/client/ayon_traypublisher/plugins/publish/validate_frame_ranges.py
@@ -33,8 +33,12 @@ class ValidateFrameRange(OptionalPyblishPluginMixin,
             return
 
         # editorial would fail since they might not be in database yet
-        new_folder_publishing = instance.data.get("newAssetPublishing")
-        if new_folder_publishing:
+        new_hierarchy = (
+            instance.data.get("newHierarchyIntegration")
+            # Backwards compatible
+            or instance.data.get("newAssetPublishing")
+        )
+        if new_hierarchy:
             self.log.debug("Instance is creating new folder. Skipping.")
             return
 

--- a/server_addon/traypublisher/package.py
+++ b/server_addon/traypublisher/package.py
@@ -1,6 +1,6 @@
 name = "traypublisher"
 title = "TrayPublisher"
-version = "0.2.1"
+version = "0.2.2"
 
 client_dir = "ayon_traypublisher"
 


### PR DESCRIPTION
## Changelog Description
Use key `'newHierarchyIntegration"` instead of `"newAssetPublishing"`.

## Additional info
The value stored under the key defines that a new folder and tasks may be created. In that case folder entity and task entity may not be available.

## Testing notes:
1. All editorial integrations should work.
