### PR TITLE
Loader tool: Safe containers discovery

### DIFF
--- a/client/ayon_core/tools/loader/control.py
+++ b/client/ayon_core/tools/loader/control.py
@@ -348,10 +348,18 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
             return set()
 
         if not self._loaded_products_cache.is_valid:
-            if isinstance(self._host, ILoadHost):
-                containers = self._host.get_containers()
-            else:
-                containers = self._host.ls()
+            try:
+                if isinstance(self._host, ILoadHost):
+                    containers = self._host.get_containers()
+                else:
+                    containers = self._host.ls()
+
+            except BaseException:
+                self.log.error(
+                    "Falied to collect loaded products.", exc_info=True
+                )
+                containers = []
+
             repre_ids = set()
             for container in containers:
                 repre_id = container.get("representation")

--- a/client/ayon_core/tools/loader/control.py
+++ b/client/ayon_core/tools/loader/control.py
@@ -356,7 +356,7 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
 
             except BaseException:
                 self.log.error(
-                    "Falied to collect loaded products.", exc_info=True
+                    "Failed to collect loaded products.", exc_info=True
                 )
                 containers = []
 


### PR DESCRIPTION
## Changelog Description
Wrapped `get_containers` into try except block to avoid broken UI because of broken function implementation.

## Additional info
Added because of bugfix in [PR](https://github.com/ynput/ayon-core/pull/595). This is 3rd ocassion when loader UI was not showing anything to load because of bug in `get_containers`. Scene inventory would not work, but loader can be at least used to load.