### PR TITLE
Unreal: fixes for custom integration plugin path

### DIFF
--- a/client/ayon_core/hosts/unreal/addon.py
+++ b/client/ayon_core/hosts/unreal/addon.py
@@ -17,7 +17,7 @@ class UnrealAddon(AYONAddon, IHostAddon):
     def add_implementation_envs(self, env, app):
         """Modify environments to contain all required for implementation."""
         # Set AYON_UNREAL_PLUGIN required for Unreal implementation
-        # Imports are in this method for Python 2 compatiblity of an addon
+        # Imports are in this method for Python 2 compatibility of an addon
         from pathlib import Path
 
         from .lib import get_compatible_integration
@@ -39,19 +39,17 @@ class UnrealAddon(AYONAddon, IHostAddon):
             raise ValueError(msg)
 
         ue_version = app.name.replace("-", ".")
+
         unreal_plugin_path = os.path.join(
-            UNREAL_ROOT_DIR, "integration", "UE_{}".format(ue_version), "Ayon"
-        )
+            UNREAL_ROOT_DIR, "integration", f"UE_{ue_version}", "Ayon")
         if not Path(unreal_plugin_path).exists():
-            compatible_versions = get_compatible_integration(
+            if compatible_versions := get_compatible_integration(
                 ue_version, Path(UNREAL_ROOT_DIR) / "integration"
-            )
-            if compatible_versions:
+            ):
                 unreal_plugin_path = compatible_versions[-1] / "Ayon"
                 unreal_plugin_path = unreal_plugin_path.as_posix()
 
-        if not env.get("AYON_UNREAL_PLUGIN") or \
-                env.get("AYON_UNREAL_PLUGIN") != unreal_plugin_path:
+        if not env.get("AYON_UNREAL_PLUGIN"):
             env["AYON_UNREAL_PLUGIN"] = unreal_plugin_path
 
         # Set default environments if are not set via settings

--- a/client/ayon_core/hosts/unreal/ue_workers.py
+++ b/client/ayon_core/hosts/unreal/ue_workers.py
@@ -345,7 +345,7 @@ class UEPluginInstallWorker(UEWorker):
         uat_path: Path = ue_lib.get_path_to_uat(self.engine_path)
         src_plugin_dir = Path(self.env.get("AYON_UNREAL_PLUGIN", ""))
 
-        if not os.path.isdir(src_plugin_dir):
+        if not src_plugin_dir.is_dir():
             msg = "Path to the integration plugin is null!"
             self.failed.emit(msg, 1)
             raise RuntimeError(msg)

--- a/server_addon/unreal/package.py
+++ b/server_addon/unreal/package.py
@@ -1,3 +1,3 @@
 name = "unreal"
 title = "Unreal"
-version = "0.1.1"
+version = "0.1.0"

--- a/server_addon/unreal/package.py
+++ b/server_addon/unreal/package.py
@@ -1,3 +1,3 @@
 name = "unreal"
 title = "Unreal"
-version = "0.1.0"
+version = "0.1.1"


### PR DESCRIPTION
## Changelog Description
Setting `AYON_UNREAL_PLUGIN` will override now inbuilt integration. Also fixing type issue with source plugin path.

## Testing notes:
1. set `AYON_UNREAL_PLUGIN` to your local copy of https://github.com/ynput/ayon-unreal-plugin
2. *OPTIONAL:* delete existing plugin from Unreal Engine
3. run Unreal on AYON project
