### PR TITLE
Chore: Fix creation of applications and maya packages

### DIFF
--- a/server_addon/applications/package.py
+++ b/server_addon/applications/package.py
@@ -2,6 +2,8 @@ name = "applications"
 title = "Applications"
 version = "0.2.2"
 
+client_dir = "ayon_applications"
+
 ayon_server_version = ">=1.0.7"
 ayon_launcher_version = ">=1.0.2"
 ayon_required_addons = {

--- a/server_addon/maya/package.py
+++ b/server_addon/maya/package.py
@@ -2,6 +2,8 @@ name = "maya"
 title = "Maya"
 version = "0.2.1"
 
+client_dir = "ayon_maya"
+
 ayon_required_addons = {
     "core": ">0.3.2",
 }


### PR DESCRIPTION
## Changelog Description
Define `client_dir` in the addons so their client code is created.

## Testing notes:
1. Created packages of the addons contain `client.zip` in private.
