### PR TITLE
Report exception info when CLI command failed to be added.

### DIFF
--- a/client/ayon_core/cli_commands.py
+++ b/client/ayon_core/cli_commands.py
@@ -36,7 +36,7 @@ class Commands:
                 log.warning(
                     "Failed to add cli command for module \"{}\"".format(
                         addon.name
-                    )
+                    ), exc_info=True
                 )
         return click_func
 


### PR DESCRIPTION
## Changelog Description

Report exception info when CLI command failed to be added from an addon.

## Additional info

Before:
```
*** WRN: >>> { CLI-AddModules }: [  FAILED to add cli command for module "launch_scripts"  ]
```
After:
```
*** WRN: >>> { CLI-AddModules }: [  FAILED to add cli command for module "launch_scripts"  ]
==============================
'Group' object has no attribute 'name'
==============================
Traceback (most recent call last):
  File "E:\dev\ayon-core\client\ayon_core\cli_commands.py", line 33, in add_addons
    addon.cli(click_func)
  File "E:\dev/ayon-launch-scripts/client\ayon_launch_scripts\addon.py", line 24, in cli
    click_group.add_command(cli_main)
  File "C:\Users\User\AppData\Local\Ynput\AYON\dependency_packages\ayon_2403061937_windows.zip\dependencies\click\core.py", line 1839, in add_command
    name = name or cmd.name
AttributeERROR: 'Group' object has no attribute 'name'
```

## Testing notes:

1. Create a failing CLI for an addon
2. Error should be clear with stack trace. 