### PR TITLE
Chore: Transcode color spaces plugin does not remove all representations

### DIFF
--- a/client/ayon_core/plugins/publish/extract_color_transcode.py
+++ b/client/ayon_core/plugins/publish/extract_color_transcode.py
@@ -202,10 +202,10 @@ class ExtractOIIOTranscode(publish.Extractor):
                 added_representations = True
 
             if added_representations:
-                self._mark_original_repre_for_deletion(repre, profile,
-                                                       added_review)
+                self._mark_original_repre_for_deletion(
+                    repre, profile, added_review
+                )
 
-        for repre in tuple(instance.data["representations"]):
             tags = repre.get("tags") or []
             if "delete" in tags and "thumbnail" not in tags:
                 instance.data["representations"].remove(repre)


### PR DESCRIPTION
## Changelog Description
Plugin `Transcode color spaces` does remove only representations that were processed by the plugin.

## Testing notes:
1. Not having profiles for specific context in `Transcode color spaces` should not cause that all reviews are skipped
