### PR TITLE
Extract Color Transcode: Fix log message formatting

### DIFF
--- a/client/ayon_core/plugins/publish/extract_color_transcode.py
+++ b/client/ayon_core/plugins/publish/extract_color_transcode.py
@@ -364,7 +364,7 @@ class ExtractOIIOTranscode(publish.Extractor):
 
         if not repre.get("colorspaceData"):
             self.log.debug("Representation '{}' has no colorspace data. "
-                           "Skipped.")
+                           "Skipped.".format(repre["name"]))
             return False
 
         return True


### PR DESCRIPTION
## Changelog Description

Actually format the representation name into the log message

## Additional info

n/a

## Testing notes:

1. Representation name should be logged when no colorspace data