### PR TITLE
Max: fix scene inventory not shown up

### DIFF
--- a/server_addon/max/client/ayon_max/api/pipeline.py
+++ b/server_addon/max/client/ayon_max/api/pipeline.py
@@ -158,7 +158,7 @@ def parse_container(container):
     data = lib.read(container)
 
     # Backwards compatibility pre-schemas for containers
-    data["schema"] = data.get("schema", "openpype:container-1.0")
+    data["schema"] = data.get("schema", "openpype:container-3.0")
 
     # Append transient data
     data["objectName"] = container.Name

--- a/server_addon/max/client/ayon_max/api/pipeline.py
+++ b/server_addon/max/client/ayon_max/api/pipeline.py
@@ -145,7 +145,27 @@ attributes "OpenPypeContext"
         rt.saveMaxFile(dst_path)
 
 
-def ls() -> list:
+def parse_container(container):
+    """Return the container node's full container data.
+
+    Args:
+        container (str): A container node name.
+
+    Returns:
+        dict: The container schema data for this container node.
+
+    """
+    data = lib.read(container)
+
+    # Backwards compatibility pre-schemas for containers
+    data["schema"] = data.get("schema", "openpype:container-1.0")
+
+    # Append transient data
+    data["objectName"] = container.Name
+    return data
+
+
+def ls():
     """Get all AYON containers."""
     objs = rt.objects
     containers = [
@@ -156,7 +176,7 @@ def ls() -> list:
     ]
 
     for container in sorted(containers, key=attrgetter("name")):
-        yield lib.read(container)
+        yield parse_container(container)
 
 
 def on_new():


### PR DESCRIPTION
## Changelog Description
This PR is to make sure the loaded asset showed up scene inventory.

## Additional info
n/a
## Testing notes:
1. Launch Max
2. Load any asset
3. Go to AYON -> Manage
4. Loaded assets should show up correctly 