### PR TITLE
Loader tool: Hero version is smaller than standard version

### DIFF
--- a/client/ayon_core/tools/loader/abstract.py
+++ b/client/ayon_core/tools/loader/abstract.py
@@ -177,7 +177,7 @@ class VersionItem:
         other_version = abs(other.version)
         # Hero version is greater than non-hero
         if version == other_version:
-            return self.is_hero
+            return not self.is_hero
         return version > other_version
 
     def __lt__(self, other):
@@ -188,7 +188,7 @@ class VersionItem:
         other_version = abs(other.version)
         # Non-hero version is lesser than hero
         if version == other_version:
-            return not self.is_hero
+            return self.is_hero
         return version < other_version
 
     def __ge__(self, other):


### PR DESCRIPTION
## Changelog Description
Change order of hero version in versions combobox so hero version is under standard version.

## Additional info
When hero version is higher then hero version is first option to use for load which is unconventional.

## Testing notes:
1. Loader tool should preselect last standard version even if there is hero version with same value.
