### PR TITLE
Houdini: Publish different HDA products from different folder paths with the same product name

### DIFF
--- a/server_addon/houdini/client/ayon_houdini/plugins/create/create_hda.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/create/create_hda.py
@@ -2,7 +2,11 @@
 """Creator plugin for creating publishable Houdini Digital Assets."""
 import ayon_api
 
-from ayon_core.pipeline import CreatorError
+from ayon_core.pipeline import (
+    CreatorError,
+    get_current_project_name,
+    get_current_folder_path,
+)
 from ayon_houdini.api import plugin
 import hou
 
@@ -56,8 +60,18 @@ class CreateHDA(plugin.HoudiniCreator):
                 raise CreatorError(
                     "cannot create hda from node {}".format(to_hda))
 
+            # Pick a unique type name for HDA product per folder path per project.
+            type_name = (
+                "{project_name}{folder_path}_{node_name}".format(
+                    project_name=get_current_project_name(),
+                    folder_path=get_current_folder_path().replace("/","_"),
+                    node_name=node_name
+                )
+            )
+
             hda_node = to_hda.createDigitalAsset(
-                name=node_name,
+                name=type_name,
+                description=node_name,
                 hda_file_name="$HIP/{}.hda".format(node_name)
             )
             hda_node.layoutChildren()

--- a/server_addon/houdini/client/ayon_houdini/plugins/create/create_hda.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/create/create_hda.py
@@ -4,8 +4,7 @@ import ayon_api
 
 from ayon_core.pipeline import (
     CreatorError,
-    get_current_project_name,
-    get_current_folder_path,
+    get_current_project_name
 )
 from ayon_houdini.api import plugin
 import hou
@@ -64,7 +63,7 @@ class CreateHDA(plugin.HoudiniCreator):
             type_name = (
                 "{project_name}{folder_path}_{node_name}".format(
                     project_name=get_current_project_name(),
-                    folder_path=get_current_folder_path().replace("/","_"),
+                    folder_path=folder_path.replace("/","_"),
                     node_name=node_name
                 )
             )

--- a/server_addon/houdini/client/ayon_houdini/plugins/load/load_hda.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/load/load_hda.py
@@ -35,9 +35,10 @@ class HdaLoader(plugin.HoudiniLoader):
 
         # Get the type name from the HDA definition.
         hda_defs = hou.hda.definitionsInFile(file_path)
-        for hda_def in hda_defs:
-            type_name = hda_def.nodeTypeName()
+        if not hda_defs:
+            raise RuntimeError(f"No HDA definitions found in file: {file_path}")
 
+        type_name = hda_defs[0].nodeTypeName()
         hda_node = obj.createNode(type_name, node_name)
 
         self[:] = [hda_node]

--- a/server_addon/houdini/client/ayon_houdini/plugins/load/load_hda.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/load/load_hda.py
@@ -28,14 +28,17 @@ class HdaLoader(plugin.HoudiniLoader):
         # Get the root node
         obj = hou.node("/obj")
 
-        # Create a unique name
-        counter = 1
         namespace = namespace or context["folder"]["name"]
-        formatted = "{}_{}".format(namespace, name) if namespace else name
-        node_name = "{0}_{1:03d}".format(formatted, counter)
+        node_name = "{}_{}".format(namespace, name) if namespace else name
 
         hou.hda.installFile(file_path)
-        hda_node = obj.createNode(name, node_name)
+
+        # Get the type name from the HDA definition.
+        hda_defs = hou.hda.definitionsInFile(file_path)
+        for hda_def in hda_defs:
+            type_name = hda_def.nodeTypeName()
+
+        hda_node = obj.createNode(type_name, node_name)
 
         self[:] = [hda_node]
 

--- a/server_addon/houdini/client/ayon_houdini/plugins/load/load_hda.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/load/load_hda.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 from ayon_core.pipeline import get_representation_path
+from ayon_core.pipeline.load import LoadError
 from ayon_houdini.api import (
     pipeline,
     plugin
@@ -36,7 +37,7 @@ class HdaLoader(plugin.HoudiniLoader):
         # Get the type name from the HDA definition.
         hda_defs = hou.hda.definitionsInFile(file_path)
         if not hda_defs:
-            raise RuntimeError(f"No HDA definitions found in file: {file_path}")
+            raise LoadError(f"No HDA definitions found in file: {file_path}")
 
         type_name = hda_defs[0].nodeTypeName()
         hda_node = obj.createNode(type_name, node_name)


### PR DESCRIPTION
## Changelog Description
 Fix a bug when publishing different HDA products from different folder paths with the same product name.

![image](https://github.com/ynput/ayon-core/assets/20871534/e04babbb-3bb0-40fc-8d3c-80d9136ae2c7)


## Additional info
About the bug: product name was being used for HDA `type name` and `type label`. 
when publishing HDA from different folder paths with the product name results in having multiple HDAs/Houdini nodes with the 
`type name`. which makes houdini thinks they are the same HDA. 

## Testing notes:
1. Publish HDAs from different folder paths, _maybe different projects too_.
2. Load the published HDAs. 
