### PR TITLE
Chore: Burnin script shell execution

### DIFF
--- a/client/ayon_core/scripts/otio_burnin.py
+++ b/client/ayon_core/scripts/otio_burnin.py
@@ -14,9 +14,10 @@ from ayon_core.lib import (
     convert_ffprobe_fps_value,
 )
 
+FFMPEG_EXE_COMMAND = subprocess.list2cmdline(get_ffmpeg_tool_args("ffmpeg"))
 FFMPEG = (
     '{}%(input_args)s -i "%(input)s" %(filters)s %(args)s%(output)s'
-).format(subprocess.list2cmdline(get_ffmpeg_tool_args("ffmpeg")))
+).format(FFMPEG_EXE_COMMAND)
 
 DRAWTEXT = (
     "drawtext@'%(label)s'=fontfile='%(font)s':text=\\'%(text)s\\':"
@@ -482,10 +483,19 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
         )
         print("Launching command: {}".format(command))
 
+        use_shell = True
+        try:
+            test_proc = subprocess.Popen(
+                f"{FFMPEG_EXE_COMMAND} --help", shell=True
+            )
+            test_proc.wait()
+        except BaseException:
+            use_shell = False
+
         kwargs = {
             "stdout": subprocess.PIPE,
             "stderr": subprocess.PIPE,
-            "shell": True,
+            "shell": use_shell,
         }
         proc = subprocess.Popen(command, **kwargs)
 


### PR DESCRIPTION
## Changelog Description
Try to auto-fix usage of `shell=True` in burnin script.

## Additional info
In some cases the shell set to `True` might cause that the subprocess don't have access to the executable. Ideal case would be to not use `shell=True` at all, that would require more modifications. To avoid it we can run "testing" ffmpeg command and change it to `False` if it crashes.
