### PR TITLE
Workfiles tool: Context selection is properly propagated to workarea

### DIFF
--- a/client/ayon_core/tools/workfiles/abstract.py
+++ b/client/ayon_core/tools/workfiles/abstract.py
@@ -834,12 +834,13 @@ class AbstractWorkfilesFrontend(AbstractWorkfilesCommon):
         pass
 
     @abstractmethod
-    def get_workarea_file_items(self, folder_id, task_id):
+    def get_workarea_file_items(self, folder_id, task_name, sender=None):
         """Get workarea file items.
 
         Args:
             folder_id (str): Folder id.
-            task_id (str): Task id.
+            task_name (str): Task name.
+            sender (Optional[str]): Who requested workarea file items.
 
         Returns:
             list[FileItem]: List of workarea file items.
@@ -905,12 +906,12 @@ class AbstractWorkfilesFrontend(AbstractWorkfilesCommon):
         pass
 
     @abstractmethod
-    def get_workfile_info(self, folder_id, task_id, filepath):
+    def get_workfile_info(self, folder_id, task_name, filepath):
         """Workfile info from database.
 
         Args:
             folder_id (str): Folder id.
-            task_id (str): Task id.
+            task_name (str): Task id.
             filepath (str): Workfile path.
 
         Returns:
@@ -921,7 +922,7 @@ class AbstractWorkfilesFrontend(AbstractWorkfilesCommon):
         pass
 
     @abstractmethod
-    def save_workfile_info(self, folder_id, task_id, filepath, note):
+    def save_workfile_info(self, folder_id, task_name, filepath, note):
         """Save workfile info to database.
 
         At this moment the only information which can be saved about
@@ -932,7 +933,7 @@ class AbstractWorkfilesFrontend(AbstractWorkfilesCommon):
 
         Args:
             folder_id (str): Folder id.
-            task_id (str): Task id.
+            task_name (str): Task id.
             filepath (str): Workfile path.
             note (Union[str, None]): Note.
         """

--- a/client/ayon_core/tools/workfiles/control.py
+++ b/client/ayon_core/tools/workfiles/control.py
@@ -410,9 +410,11 @@ class BaseWorkfileController(
         return self._workfiles_model.get_workarea_dir_by_context(
             folder_id, task_id)
 
-    def get_workarea_file_items(self, folder_id, task_id):
+    def get_workarea_file_items(self, folder_id, task_name, sender=None):
+        task_id = self._get_task_id(folder_id, task_name)
         return self._workfiles_model.get_workarea_file_items(
-            folder_id, task_id)
+            folder_id, task_id, task_name
+        )
 
     def get_workarea_save_as_data(self, folder_id, task_id):
         return self._workfiles_model.get_workarea_save_as_data(
@@ -447,12 +449,14 @@ class BaseWorkfileController(
         return self._workfiles_model.get_published_file_items(
             folder_id, task_name)
 
-    def get_workfile_info(self, folder_id, task_id, filepath):
+    def get_workfile_info(self, folder_id, task_name, filepath):
+        task_id = self._get_task_id(folder_id, task_name)
         return self._workfiles_model.get_workfile_info(
             folder_id, task_id, filepath
         )
 
-    def save_workfile_info(self, folder_id, task_id, filepath, note):
+    def save_workfile_info(self, folder_id, task_name, filepath, note):
+        task_id = self._get_task_id(folder_id, task_name)
         self._workfiles_model.save_workfile_info(
             folder_id, task_id, filepath, note
         )
@@ -626,6 +630,17 @@ class BaseWorkfileController(
 
     def _emit_event(self, topic, data=None):
         self.emit_event(topic, data, "controller")
+
+    def _get_task_id(self, folder_id, task_name, sender=None):
+        task_item = self._hierarchy_model.get_task_item_by_name(
+            self.get_current_project_name(),
+            folder_id,
+            task_name,
+            sender
+        )
+        if not task_item:
+            return None
+        return task_item.id
 
     # Expected selection
     # - expected selection is used to restore selection after refresh

--- a/client/ayon_core/tools/workfiles/control.py
+++ b/client/ayon_core/tools/workfiles/control.py
@@ -737,7 +737,7 @@ class BaseWorkfileController(
             self._host_save_workfile(dst_filepath)
 
         # Make sure workfile info exists
-        self.save_workfile_info(folder_id, task_id, dst_filepath, None)
+        self.save_workfile_info(folder_id, task_name, dst_filepath, None)
 
         # Create extra folders
         create_workdir_extra_folders(

--- a/client/ayon_core/tools/workfiles/models/workfiles.py
+++ b/client/ayon_core/tools/workfiles/models/workfiles.py
@@ -173,7 +173,7 @@ class WorkareaModel:
         folder_mapping[task_id] = workdir
         return workdir
 
-    def get_file_items(self, folder_id, task_id):
+    def get_file_items(self, folder_id, task_id, task_name):
         items = []
         if not folder_id or not task_id:
             return items
@@ -192,7 +192,7 @@ class WorkareaModel:
                 continue
 
             workfile_info = self._controller.get_workfile_info(
-                folder_id, task_id, filepath
+                folder_id, task_name, filepath
             )
             modified = os.path.getmtime(filepath)
             items.append(FileItem(
@@ -770,19 +770,21 @@ class WorkfilesModel:
         return self._workarea_model.get_workarea_dir_by_context(
             folder_id, task_id)
 
-    def get_workarea_file_items(self, folder_id, task_id):
+    def get_workarea_file_items(self, folder_id, task_id, task_name):
         """Workfile items for passed context from workarea.
 
         Args:
             folder_id (Union[str, None]): Folder id.
             task_id (Union[str, None]): Task id.
+            task_name (Union[str, None]): Task name.
 
         Returns:
             list[FileItem]: List of file items matching workarea of passed
                 context.
         """
-
-        return self._workarea_model.get_file_items(folder_id, task_id)
+        return self._workarea_model.get_file_items(
+            folder_id, task_id, task_name
+        )
 
     def get_workarea_save_as_data(self, folder_id, task_id):
         return self._workarea_model.get_workarea_save_as_data(

--- a/client/ayon_core/tools/workfiles/models/workfiles.py
+++ b/client/ayon_core/tools/workfiles/models/workfiles.py
@@ -1,6 +1,7 @@
 import os
 import re
 import copy
+import uuid
 
 import arrow
 import ayon_api
@@ -587,6 +588,7 @@ class WorkfileEntitiesModel:
 
         username = self._get_current_username()
         workfile_info = {
+            "id": uuid.uuid4().hex,
             "path": rootless_path,
             "taskId": task_id,
             "attrib": {

--- a/client/ayon_core/tools/workfiles/widgets/files_widget_workarea.py
+++ b/client/ayon_core/tools/workfiles/widgets/files_widget_workarea.py
@@ -66,7 +66,7 @@ class WorkAreaFilesModel(QtGui.QStandardItemModel):
         self._empty_item_used = False
         self._published_mode = False
         self._selected_folder_id = None
-        self._selected_task_id = None
+        self._selected_task_name = None
 
         self._add_missing_context_item()
 
@@ -153,7 +153,7 @@ class WorkAreaFilesModel(QtGui.QStandardItemModel):
 
     def _on_task_changed(self, event):
         self._selected_folder_id = event["folder_id"]
-        self._selected_task_id = event["task_id"]
+        self._selected_task_name = event["task_name"]
         if not self._published_mode:
             self._fill_items()
 
@@ -179,13 +179,13 @@ class WorkAreaFilesModel(QtGui.QStandardItemModel):
 
     def _fill_items_impl(self):
         folder_id = self._selected_folder_id
-        task_id = self._selected_task_id
-        if not folder_id or not task_id:
+        task_name = self._selected_task_name
+        if not folder_id or not task_name:
             self._add_missing_context_item()
             return
 
         file_items = self._controller.get_workarea_file_items(
-            folder_id, task_id
+            folder_id, task_name
         )
         root_item = self.invisibleRootItem()
         if not file_items:

--- a/client/ayon_core/tools/workfiles/widgets/side_panel.py
+++ b/client/ayon_core/tools/workfiles/widgets/side_panel.py
@@ -75,7 +75,7 @@ class SidePanelWidget(QtWidgets.QWidget):
         self._btn_note_save = btn_note_save
 
         self._folder_id = None
-        self._task_id = None
+        self._task_name = None
         self._filepath = None
         self._orig_note = ""
         self._controller = controller
@@ -93,10 +93,10 @@ class SidePanelWidget(QtWidgets.QWidget):
 
     def _on_selection_change(self, event):
         folder_id = event["folder_id"]
-        task_id = event["task_id"]
+        task_name = event["task_name"]
         filepath = event["path"]
 
-        self._set_context(folder_id, task_id, filepath)
+        self._set_context(folder_id, task_name, filepath)
 
     def _on_note_change(self):
         text = self._note_input.toPlainText()
@@ -106,19 +106,19 @@ class SidePanelWidget(QtWidgets.QWidget):
         note = self._note_input.toPlainText()
         self._controller.save_workfile_info(
             self._folder_id,
-            self._task_id,
+            self._task_name,
             self._filepath,
             note
         )
         self._orig_note = note
         self._btn_note_save.setEnabled(False)
 
-    def _set_context(self, folder_id, task_id, filepath):
+    def _set_context(self, folder_id, task_name, filepath):
         workfile_info = None
         # Check if folder, task and file are selected
-        if bool(folder_id) and bool(task_id) and bool(filepath):
+        if bool(folder_id) and bool(task_name) and bool(filepath):
             workfile_info = self._controller.get_workfile_info(
-                folder_id, task_id, filepath
+                folder_id, task_name, filepath
             )
         enabled = workfile_info is not None
 
@@ -127,7 +127,7 @@ class SidePanelWidget(QtWidgets.QWidget):
         self._btn_note_save.setEnabled(enabled)
 
         self._folder_id = folder_id
-        self._task_id = task_id
+        self._task_name = task_name
         self._filepath = filepath
 
         # Disable inputs and remove texts if any required arguments are


### PR DESCRIPTION
## Changelog Description
Selection of context in workfiles tools does correctly resolve workfile entity from AYON and new workfile can save note.

## Additional info
When context is changed from a folder 1 to folder 1 and they have the same tasks then there is a chance that workfile entity is not loaded for correct task. And when new workfile is created, it was not possible to change note because we didn't have access to workfile entity id.

## Testing notes:
### New workfile
1. Create new workfile using workfiles tools.
2. Set note on the workfile and hit save.
3. It should save the note.

### Context change
1. Make sure you have 2 folders with same tasks.
2. Open last workfile on one of the tasks on folder 1.
3. Open workfiles tool.
4. Set some note on the workfile (this is how we find out it works).
5. Change folder to folder 2 (The task should stay selected).
6. Change folder to folder 1 (The task should stay selected).
7. The last workfile should stay selected and the same note from step 4 should be visible in side panel.