### PR TITLE
Scene Inventory tool: Set version dialog can change version for whole selection

### DIFF
--- a/client/ayon_core/tools/sceneinventory/select_version_dialog.py
+++ b/client/ayon_core/tools/sceneinventory/select_version_dialog.py
@@ -67,8 +67,12 @@ class SelectVersionComboBox(QtWidgets.QComboBox):
         self._combo_view = combo_view
         self._status_delegate = status_delegate
         self._items_by_id = {}
+        self._status_visible = True
 
     def paintEvent(self, event):
+        if not self._status_visible:
+            return super().paintEvent(event)
+
         painter = QtWidgets.QStylePainter(self)
         option = QtWidgets.QStyleOptionComboBox()
         self.initStyleOption(option)
@@ -119,6 +123,12 @@ class SelectVersionComboBox(QtWidgets.QComboBox):
             return
 
         self.setCurrentIndex(index)
+
+    def set_status_visible(self, visible):
+        header = self._combo_view.header()
+        header.setSectionHidden(1, not visible)
+        self._status_visible = visible
+        self.update()
 
     def get_item_by_id(self, item_id):
         return self._items_by_id[item_id]
@@ -195,10 +205,16 @@ class SelectVersionDialog(QtWidgets.QDialog):
     def select_index(self, index):
         self._versions_combobox.set_current_index(index)
 
+    def set_status_visible(self, visible):
+        self._versions_combobox.set_status_visible(visible)
+
     @classmethod
-    def ask_for_version(cls, version_options, index=None, parent=None):
+    def ask_for_version(
+        cls, version_options, index=None, show_statuses=True, parent=None
+    ):
         dialog = cls(parent)
         dialog.set_versions(version_options)
+        dialog.set_status_visible(show_statuses)
         if index is not None:
             dialog.select_index(index)
         dialog.exec_()

--- a/client/ayon_core/tools/sceneinventory/view.py
+++ b/client/ayon_core/tools/sceneinventory/view.py
@@ -683,37 +683,51 @@ class SceneInventoryView(QtWidgets.QTreeView):
             repre_ids
         )
 
+        product_ids = {
+            repre_info.product_id
+            for repre_info in repre_info_by_id.values()
+        }
         active_repre_info = repre_info_by_id[active_repre_id]
-        active_product_id = active_repre_info.product_id
         active_version_id = active_repre_info.version_id
-        filtered_repre_info_by_id = {
-            repre_id: repre_info
-            for repre_id, repre_info in repre_info_by_id.items()
-            if repre_info.product_id == active_product_id
-        }
-        filtered_container_item_ids = {
-            item_id
-            for item_id, container_item in container_items_by_id.items()
-            if container_item.representation_id in filtered_repre_info_by_id
-        }
-        version_items_by_id = self._controller.get_version_items(
-            {active_product_id}
-        )[active_product_id]
+        active_product_id = active_repre_info.product_id
+        version_items_by_product_id = self._controller.get_version_items(
+            product_ids
+        )
+        version_items = list(
+            version_items_by_product_id[active_product_id].values()
+        )
+        versions = {version_item.version for version_item in version_items}
+        product_ids_by_version = collections.defaultdict(set)
+        for version_items_by_id in version_items_by_product_id.values():
+            for version_item in version_items_by_id.values():
+                version = version_item.version
+                _prod_version = version
+                if _prod_version < 0:
+                    _prod_version = -1
+                product_ids_by_version[_prod_version].add(
+                    version_item.product_id
+                )
+                if version in versions:
+                    continue
+                versions.add(version)
+                version_items.append(version_item)
 
         def version_sorter(item):
             hero_value = 0
-            version = item.version
-            if version < 0:
+            i_version = item.version
+            if i_version < 0:
                 hero_value = 1
-                version = abs(version)
-            return version, hero_value
+                i_version = abs(i_version)
+            return i_version, hero_value
 
-        version_items = list(version_items_by_id.values())
         version_items.sort(key=version_sorter, reverse=True)
-        status_items_by_name = {
-            status_item.name: status_item
-            for status_item in self._controller.get_project_status_items()
-        }
+        show_statuses = len(product_ids) == 1
+        status_items_by_name = {}
+        if show_statuses:
+            status_items_by_name = {
+                status_item.name: status_item
+                for status_item in self._controller.get_project_status_items()
+            }
 
         version_options = []
         active_version_idx = 0
@@ -743,17 +757,28 @@ class SceneInventoryView(QtWidgets.QTreeView):
         version_option = SelectVersionDialog.ask_for_version(
             version_options,
             active_version_idx,
+            show_statuses=show_statuses,
             parent=self
         )
         if version_option is None:
             return
 
-        version = version_option.version
+        product_version = version = version_option.version
         if version < 0:
+            product_version = -1
             version = HeroVersionType(version)
 
+        product_ids = product_ids_by_version[product_version]
+
+        filtered_item_ids = set()
+        for container_item in container_items_by_id.values():
+            repre_id = container_item.representation_id
+            repre_info = repre_info_by_id[repre_id]
+            if repre_info.product_id in product_ids:
+                filtered_item_ids.add(container_item.item_id)
+
         self._update_containers_to_version(
-            filtered_container_item_ids, version
+            filtered_item_ids, version
         )
 
     def _show_switch_dialog(self, item_ids):


### PR DESCRIPTION
## Changelog Description
Scene inventory can change version for whole selection, but does not show statuses next to version if are from different products.

## Additional info
Sometimes it might be helpfull to change version for multiple loaded products at the same time. But we're not able to show status in that case, lazy solution is to hide the statuses to avoid confusion.

## Testing notes:
1. It is possible to change version of multiple containers from different products in scene manager tool.
