### PR TITLE
adding deprecation flag on OCIO config override settings

### DIFF
--- a/server_addon/aftereffects/server/settings/imageio.py
+++ b/server_addon/aftereffects/server/settings/imageio.py
@@ -4,13 +4,28 @@ from ayon_server.settings.validators import ensure_unique_names
 
 
 class ImageIOConfigModel(BaseSettingsModel):
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
+
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 

--- a/server_addon/blender/server/settings/imageio.py
+++ b/server_addon/blender/server/settings/imageio.py
@@ -4,13 +4,28 @@ from ayon_server.settings.validators import ensure_unique_names
 
 
 class ImageIOConfigModel(BaseSettingsModel):
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
+
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 

--- a/server_addon/celaction/server/imageio.py
+++ b/server_addon/celaction/server/imageio.py
@@ -4,13 +4,28 @@ from ayon_server.settings.validators import ensure_unique_names
 
 
 class ImageIOConfigModel(BaseSettingsModel):
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
+
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 

--- a/server_addon/flame/server/settings/imageio.py
+++ b/server_addon/flame/server/settings/imageio.py
@@ -40,13 +40,28 @@ class ImageIORemappingModel(BaseSettingsModel):
 
 
 class ImageIOConfigModel(BaseSettingsModel):
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
+
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 

--- a/server_addon/fusion/server/imageio.py
+++ b/server_addon/fusion/server/imageio.py
@@ -4,13 +4,28 @@ from ayon_server.settings.validators import ensure_unique_names
 
 
 class ImageIOConfigModel(BaseSettingsModel):
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
+
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 

--- a/server_addon/harmony/server/settings/imageio.py
+++ b/server_addon/harmony/server/settings/imageio.py
@@ -4,13 +4,28 @@ from ayon_server.settings.validators import ensure_unique_names
 
 
 class ImageIOConfigModel(BaseSettingsModel):
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
+
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 

--- a/server_addon/hiero/server/settings/imageio.py
+++ b/server_addon/hiero/server/settings/imageio.py
@@ -87,13 +87,28 @@ class RegexInputsModel(BaseSettingsModel):
 
 
 class ImageIOConfigModel(BaseSettingsModel):
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
+
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 

--- a/server_addon/houdini/server/settings/imageio.py
+++ b/server_addon/houdini/server/settings/imageio.py
@@ -4,13 +4,28 @@ from ayon_server.settings.validators import ensure_unique_names
 
 
 class ImageIOConfigModel(BaseSettingsModel):
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
+
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 

--- a/server_addon/max/server/settings/imageio.py
+++ b/server_addon/max/server/settings/imageio.py
@@ -4,13 +4,28 @@ from ayon_server.settings.validators import ensure_unique_names
 
 
 class ImageIOConfigModel(BaseSettingsModel):
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
+
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 

--- a/server_addon/maya/server/settings/imageio.py
+++ b/server_addon/maya/server/settings/imageio.py
@@ -12,13 +12,28 @@ from ayon_server.settings import (
 
 
 class ImageIOConfigModel(BaseSettingsModel):
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
+
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 

--- a/server_addon/nuke/server/settings/imageio.py
+++ b/server_addon/nuke/server/settings/imageio.py
@@ -177,15 +177,28 @@ class MonitorProcessModel(BaseSettingsModel):
 
 
 class ImageIOConfigModel(BaseSettingsModel):
-    _isGroup: bool = True
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
 
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 

--- a/server_addon/photoshop/server/settings/imageio.py
+++ b/server_addon/photoshop/server/settings/imageio.py
@@ -4,13 +4,28 @@ from ayon_server.settings.validators import ensure_unique_names
 
 
 class ImageIOConfigModel(BaseSettingsModel):
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
+
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 

--- a/server_addon/resolve/server/imageio.py
+++ b/server_addon/resolve/server/imageio.py
@@ -4,13 +4,28 @@ from ayon_server.settings.validators import ensure_unique_names
 
 
 class ImageIOConfigModel(BaseSettingsModel):
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
+
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 

--- a/server_addon/substancepainter/server/settings/imageio.py
+++ b/server_addon/substancepainter/server/settings/imageio.py
@@ -4,13 +4,28 @@ from ayon_server.settings.validators import ensure_unique_names
 
 
 class ImageIOConfigModel(BaseSettingsModel):
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
+
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 

--- a/server_addon/traypublisher/server/settings/imageio.py
+++ b/server_addon/traypublisher/server/settings/imageio.py
@@ -4,13 +4,27 @@ from ayon_server.settings.validators import ensure_unique_names
 
 
 class ImageIOConfigModel(BaseSettingsModel):
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 

--- a/server_addon/tvpaint/server/settings/imageio.py
+++ b/server_addon/tvpaint/server/settings/imageio.py
@@ -4,13 +4,28 @@ from ayon_server.settings.validators import ensure_unique_names
 
 
 class ImageIOConfigModel(BaseSettingsModel):
+    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
+    path in the Core addon profiles here
+    (ayon+settings://core/imageio/ocio_config_profiles).
+    """
+
     override_global_config: bool = SettingsField(
         False,
-        title="Override global OCIO config"
+        title="Override global OCIO config",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
     filepath: list[str] = SettingsField(
         default_factory=list,
-        title="Config path"
+        title="Config path",
+        description=(
+            "DEPRECATED functionality. Please set the OCIO config path in the "
+            "Core addon profiles here (ayon+settings://core/imageio/"
+            "ocio_config_profiles)."
+        ),
     )
 
 


### PR DESCRIPTION
## Changelog Description
Deprecating OCIO config overrides at individual addon.


## Testing notes:
1. all should work as it is
