### PR TITLE
Workfiles tool: Published files can be copied/opened

### DIFF
--- a/client/ayon_core/tools/workfiles/widgets/files_widget_published.py
+++ b/client/ayon_core/tools/workfiles/widgets/files_widget_published.py
@@ -10,7 +10,6 @@ from ayon_core.tools.utils.delegates import PrettyTimeDelegate
 
 from .utils import BaseOverlayFrame
 
-
 REPRE_ID_ROLE = QtCore.Qt.UserRole + 1
 FILEPATH_ROLE = QtCore.Qt.UserRole + 2
 AUTHOR_ROLE = QtCore.Qt.UserRole + 3
@@ -249,7 +248,7 @@ class PublishedFilesModel(QtGui.QStandardItemModel):
 
         # Handle roles for first column
         col = index.column()
-        if col != 1:
+        if col == 0:
             return super().data(index, role)
 
         if role == QtCore.Qt.DecorationRole:


### PR DESCRIPTION
## Changelog Description
Fix work with published workfiles in workfiles tool.

## Additional info
There was a bug in Qt model when receiving data for specific roles.

## Testing notes:
1. Published workfiles can be opened/copy-pasted.
