### PR TITLE
Loader: Fix deprecated import

### DIFF
--- a/client/ayon_core/tools/loader/control.py
+++ b/client/ayon_core/tools/loader/control.py
@@ -3,14 +3,13 @@ import uuid
 
 import ayon_api
 
+from ayon_core.lib import NestedCacheItem, CacheItem
 from ayon_core.lib.events import QueuedEventSystem
 from ayon_core.pipeline import Anatomy, get_current_context
 from ayon_core.host import ILoadHost
 from ayon_core.tools.common_models import (
     ProjectsModel,
     HierarchyModel,
-    NestedCacheItem,
-    CacheItem,
     ThumbnailsModel,
 )
 


### PR DESCRIPTION
## Changelog Description
Use import from new location of `NestedCacheItem` and `CacheItem`.

## Testing notes:
1. Loader tool still works.
