### PR TITLE
Tool UIs: Handle missing folder short name

### DIFF
--- a/client/ayon_core/tools/common_models/projects.py
+++ b/client/ayon_core/tools/common_models/projects.py
@@ -89,7 +89,7 @@ class FolderTypeItem:
     def from_project_item(cls, folder_type_data):
         return cls(
             name=folder_type_data["name"],
-            short=folder_type_data["shortName"],
+            short=folder_type_data.get("shortName", ""),
             icon=folder_type_data["icon"],
         )
 

--- a/client/ayon_core/tools/utils/folders_widget.py
+++ b/client/ayon_core/tools/utils/folders_widget.py
@@ -192,7 +192,11 @@ class FoldersQtModel(QtGui.QStandardItemModel):
             or thread_id != self._current_refresh_thread.id
         ):
             return
-        folder_items, folder_type_items = thread.get_result()
+        if thread.failed:
+            # TODO visualize that refresh failed
+            folder_items, folder_type_items = {}, {}
+        else:
+            folder_items, folder_type_items = thread.get_result()
         self._fill_items(folder_items, folder_type_items)
         self._current_refresh_thread = None
 

--- a/client/ayon_core/tools/utils/lib.py
+++ b/client/ayon_core/tools/utils/lib.py
@@ -2,7 +2,10 @@ import os
 import sys
 import contextlib
 import collections
+import traceback
 from functools import partial
+from typing import Union, Any
+
 
 from qtpy import QtWidgets, QtCore, QtGui
 import qtawesome
@@ -425,25 +428,38 @@ class RefreshThread(QtCore.QThread):
         self._id = thread_id
         self._callback = partial(func, *args, **kwargs)
         self._exception = None
+        self._traceback = None
         self._result = None
         self.finished.connect(self._on_finish_callback)
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._id
 
     @property
-    def failed(self):
+    def failed(self) -> bool:
         return self._exception is not None
 
     def run(self):
         try:
             self._result = self._callback()
         except Exception as exc:
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            err_traceback = "".join(traceback.format_exception(
+                exc_type, exc_value, exc_traceback
+            ))
+            print(err_traceback)
+            self._traceback = err_traceback
             self._exception = exc
 
-    def get_result(self):
+    def get_result(self) -> Any:
         return self._result
+
+    def get_exception(self) -> Union[BaseException, None]:
+        return self._exception
+
+    def get_traceback(self) -> Union[str, None]:
+        return self._traceback
 
     def _on_finish_callback(self):
         """Trigger custom signal with thread id.


### PR DESCRIPTION
## Changelog Description
It looks like `"shortName"` does not have to be filled on project so safe access to the key was added.

## Additional info
Also added base handling of failed thread in folders widget to at least print exception.

## Testing notes:
1. Projects without `"shortName"` in folder type should show folders in UIs.
