### PR TITLE
Maya: Fix the scriptmenu error found during launch maya 2025

### DIFF
--- a/client/ayon_core/vendor/python/scriptsmenu/launchformaya.py
+++ b/client/ayon_core/vendor/python/scriptsmenu/launchformaya.py
@@ -130,7 +130,10 @@ def main(title="Scripts", parent=None, objectName=None):
 
     # Register control + shift callback to add to shelf (maya behavior)
     modifiers = QtCore.Qt.ControlModifier | QtCore.Qt.ShiftModifier
-    menu.register_callback(int(modifiers), to_shelf)
+    if int(cmds.about(version=True)) <= 2025:
+        modifiers = int(modifiers)
+
+    menu.register_callback(modifiers, to_shelf)
 
     menu.register_callback(0, register_repeat_last)
 


### PR DESCRIPTION
## Changelog Description
This PR is to fix the bug found during the launch of Maya 2025.
```
 Error: TypeError: file C:\Users\murph\AppData\Local\Ynput\AYON\addons\core_0.4.0\ayon_core\vendor\python\scriptsmenu\launchformaya.py line 133: int() argument must be a string, a bytes-like object or a real number, not 'KeyboardModifier'
```
## Additional info
n/a

## Testing notes:
1. Launch Maya with different versions
2. Check Script Editor
3. the scriptmenu related error should be gone