### PR TITLE
Houdini: support opening workfile on launch

### DIFF
--- a/server_addon/houdini/client/ayon_houdini/api/lib.py
+++ b/server_addon/houdini/client/ayon_houdini/api/lib.py
@@ -8,7 +8,6 @@ import json
 from contextlib import contextmanager
 
 import six
-from qtpy import QtCore, QtWidgets
 import ayon_api
 
 from ayon_core.lib import StringTemplate
@@ -24,11 +23,7 @@ from ayon_core.pipeline import (
 from ayon_core.pipeline.create import CreateContext
 from ayon_core.pipeline.template_data import get_template_data
 from ayon_core.pipeline.context_tools import get_current_folder_entity
-from ayon_core.tools.utils import (
-    PopupUpdateKeys,
-    SimplePopup,
-    host_tools
-)
+from ayon_core.tools.utils import PopupUpdateKeys, SimplePopup
 from ayon_core.tools.utils.host_tools import get_tool_by_name
 
 import hou
@@ -1198,46 +1193,3 @@ def prompt_reset_context():
         update_content_on_context_change()
 
     dialog.deleteLater()
-
-
-def wait_startup_launch_workfiles_app():
-    """Show workfiles tool on Houdini launch.
-
-    Trigger to show workfiles tool on application launch. Can be executed only
-    once all other calls are ignored.
-
-    Workfiles tool show is deferred after application initialization using
-    QTimer.
-
-    Basically, it should wait till the app finish starting up.
-    """
-
-    # Show workfiles tool using timer
-    # - this will be probably triggered during initialization in that case
-    #   the application is not be able to show uis so it must be
-    #   deferred using timer
-    # - timer should be processed when initialization ends
-    #       When applications starts to process events.
-    timer = QtCore.QTimer()
-    timer.timeout.connect(lambda: _launch_workfile_app(timer))
-    timer.setInterval(100)
-    timer.start()
-
-
-def _launch_workfile_app(timer):
-    # Safeguard to not show window when application is still starting up
-    #   or is already closing down.
-    closing_down = QtWidgets.QApplication.closingDown()
-    starting_up = QtWidgets.QApplication.startingUp()
-
-    # Stop the timer if application finished start up of is closing down
-    if closing_down or not starting_up:
-        timer.stop()
-
-    # Skip if application is starting up or closing down
-    if starting_up or closing_down:
-        return
-
-    # Make sure on top is enabled on first show so the window is not hidden
-    #   under main nuke window
-    host_tools.show_workfiles(parent=hou.qt.mainWindow(), on_top=True)

--- a/server_addon/houdini/client/ayon_houdini/api/pipeline.py
+++ b/server_addon/houdini/client/ayon_houdini/api/pipeline.py
@@ -25,13 +25,6 @@ from ayon_core.lib import (
     emit_event,
 )
 
-def show_workfiles_tool():
-    # Make sure on top is enabled on first show so the
-    # window is not hidden under main nuke window
-    print("showing workfiles tool..")
-    from ayon_core.tools.utils import host_tools
-    host_tools.show_workfiles(parent=hou.qt.mainWindow(),
-                                on_top=True)
 
 log = logging.getLogger("ayon_houdini")
 

--- a/server_addon/houdini/client/ayon_houdini/api/pipeline.py
+++ b/server_addon/houdini/client/ayon_houdini/api/pipeline.py
@@ -85,10 +85,9 @@ class HoudiniHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             # initialization during start up delays Houdini UI by minutes
             # making it extremely slow to launch.
             hdefereval.executeDeferred(shelves.generate_shelves)
-
-        if not IS_HEADLESS:
-            import hdefereval # noqa, hdefereval is only available in ui mode
             hdefereval.executeDeferred(creator_node_shelves.install)
+            if os.environ.get("AYON_WORKFILE_TOOL_ON_START"):
+                hdefereval.executeDeferred(lib.wait_startup_launch_workfiles_app)
 
     def workfile_has_unsaved_changes(self):
         return hou.hipFile.hasUnsavedChanges()

--- a/server_addon/houdini/client/ayon_houdini/api/pipeline.py
+++ b/server_addon/houdini/client/ayon_houdini/api/pipeline.py
@@ -6,7 +6,7 @@ import logging
 import hou  # noqa
 
 from ayon_core.host import HostBase, IWorkfileHost, ILoadHost, IPublishHost
-
+from ayon_core.tools.utils import host_tools
 import pyblish.api
 
 from ayon_core.pipeline import (
@@ -25,6 +25,13 @@ from ayon_core.lib import (
     emit_event,
 )
 
+def show_workfiles_tool():
+    # Make sure on top is enabled on first show so the
+    # window is not hidden under main nuke window
+    print("showing workfiles tool..")
+    from ayon_core.tools.utils import host_tools
+    host_tools.show_workfiles(parent=hou.qt.mainWindow(),
+                                on_top=True)
 
 log = logging.getLogger("ayon_houdini")
 
@@ -87,7 +94,7 @@ class HoudiniHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             hdefereval.executeDeferred(shelves.generate_shelves)
             hdefereval.executeDeferred(creator_node_shelves.install)
             if os.environ.get("AYON_WORKFILE_TOOL_ON_START"):
-                hdefereval.executeDeferred(lib.wait_startup_launch_workfiles_app)
+                hdefereval.executeDeferred(lambda: host_tools.show_workfiles(parent=hou.qt.mainWindow()))
 
     def workfile_has_unsaved_changes(self):
         return hou.hipFile.hasUnsavedChanges()

--- a/server_addon/houdini/client/ayon_houdini/api/pipeline.py
+++ b/server_addon/houdini/client/ayon_houdini/api/pipeline.py
@@ -23,6 +23,7 @@ from ayon_houdini.api import lib, shelves, creator_node_shelves
 from ayon_core.lib import (
     register_event_callback,
     emit_event,
+    env_value_to_bool,
 )
 
 
@@ -86,7 +87,7 @@ class HoudiniHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             # making it extremely slow to launch.
             hdefereval.executeDeferred(shelves.generate_shelves)
             hdefereval.executeDeferred(creator_node_shelves.install)
-            if os.environ.get("AYON_WORKFILE_TOOL_ON_START"):
+            if env_value_to_bool("AYON_WORKFILE_TOOL_ON_START"):
                 hdefereval.executeDeferred(lambda: host_tools.show_workfiles(parent=hou.qt.mainWindow()))
 
     def workfile_has_unsaved_changes(self):


### PR DESCRIPTION
## Changelog Description
Support opening workfile on launching Houdini.
Also, it removes  the redundant if statement. 

## Additional Info
For future reference 
This doesn't work 
```python
if os.environ.get("AYON_WORKFILE_TOOL_ON_START"):
    hdefereval.executeDeferred(host_tools.show_workfiles(parent=hou.qt.mainWindow()))
```
but, this works!  :'D 
```python
if os.environ.get("AYON_WORKFILE_TOOL_ON_START"):
    hdefereval.executeDeferred(lambda: host_tools.show_workfiles(parent=hou.qt.mainWindow()))
```

## Testing notes:
1. Enable `ayon+settings://core/tools/Workfiles/open_workfile_tool_on_startup`
![image](https://github.com/ynput/ayon-core/assets/20871534/f543d278-3af7-4a3b-b411-89bf4c9efabe)
2. Launch Houdini
