### PR TITLE
Maya: Publishing fbx in model family

### DIFF
--- a/server_addon/maya/client/ayon_maya/plugins/publish/collect_fbx_model.py
+++ b/server_addon/maya/client/ayon_maya/plugins/publish/collect_fbx_model.py
@@ -9,7 +9,7 @@ class CollectFbxModel(plugin.MayaInstancePlugin,
     """Collect Camera for FBX export."""
 
     order = pyblish.api.CollectorOrder + 0.2
-    label = "Collect Model for FBX export"
+    label = "Collect Fbx Model"
     families = ["model"]
     optional = True
 

--- a/server_addon/maya/client/ayon_maya/plugins/publish/collect_fbx_model.py
+++ b/server_addon/maya/client/ayon_maya/plugins/publish/collect_fbx_model.py
@@ -1,0 +1,29 @@
+import pyblish.api
+from ayon_core.pipeline import OptionalPyblishPluginMixin
+from ayon_maya.api import plugin
+
+
+
+class CollectFbxModel(plugin.MayaInstancePlugin,
+                      OptionalPyblishPluginMixin):
+    """Collect Camera for FBX export."""
+
+    order = pyblish.api.CollectorOrder + 0.2
+    label = "Collect Model for FBX export"
+    families = ["model"]
+    optional = True
+
+    def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
+        if not instance.data.get("families"):
+            instance.data["families"] = []
+
+        if "fbx" not in instance.data["families"]:
+            instance.data["families"].append("fbx")
+
+        for key in {
+            "bakeComplexAnimation", "bakeResampleAnimation",
+            "skins", "constraints", "lights"}:
+                instance.data[key] = False

--- a/server_addon/maya/client/ayon_maya/version.py
+++ b/server_addon/maya/client/ayon_maya/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'maya' version."""
-__version__ = "0.2.7"
+__version__ = "0.2.8"

--- a/server_addon/maya/package.py
+++ b/server_addon/maya/package.py
@@ -1,6 +1,6 @@
 name = "maya"
 title = "Maya"
-version = "0.2.7"
+version = "0.2.8"
 client_dir = "ayon_maya"
 
 ayon_required_addons = {

--- a/server_addon/maya/server/settings/publishers.py
+++ b/server_addon/maya/server/settings/publishers.py
@@ -184,6 +184,11 @@ class CollectFbxCameraModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="CollectFbxCamera")
 
 
+
+class CollectFbxModelModel(BaseSettingsModel):
+    enabled: bool = SettingsField(title="CollectFbxModel")
+
+
 class CollectGLTFModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="CollectGLTF")
 
@@ -625,6 +630,10 @@ class PublishersModel(BaseSettingsModel):
         default_factory=CollectFbxCameraModel,
         title="Collect Camera for FBX export",
     )
+    CollectFbxModel: CollectFbxModelModel = SettingsField(
+        default_factory=CollectFbxModelModel,
+        title="Collect Model for FBX export",
+    )
     CollectGLTF: CollectGLTFModel = SettingsField(
         default_factory=CollectGLTFModel,
         title="Collect Assets for GLB/GLTF export"
@@ -1045,6 +1054,9 @@ DEFAULT_PUBLISH_SETTINGS = {
         "enabled": False
     },
     "CollectFbxCamera": {
+        "enabled": False
+    },
+    "CollectFbxModel": {
         "enabled": False
     },
     "CollectGLTF": {

--- a/server_addon/maya/server/settings/publishers.py
+++ b/server_addon/maya/server/settings/publishers.py
@@ -184,11 +184,6 @@ class CollectFbxCameraModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="CollectFbxCamera")
 
 
-
-class CollectFbxModelModel(BaseSettingsModel):
-    enabled: bool = SettingsField(title="CollectFbxModel")
-
-
 class CollectGLTFModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="CollectGLTF")
 
@@ -630,8 +625,8 @@ class PublishersModel(BaseSettingsModel):
         default_factory=CollectFbxCameraModel,
         title="Collect Camera for FBX export",
     )
-    CollectFbxModel: CollectFbxModelModel = SettingsField(
-        default_factory=CollectFbxModelModel,
+    CollectFbxModel: BasicValidateModel = SettingsField(
+        default_factory=BasicValidateModel,
         title="Collect Model for FBX export",
     )
     CollectGLTF: CollectGLTFModel = SettingsField(
@@ -1057,7 +1052,9 @@ DEFAULT_PUBLISH_SETTINGS = {
         "enabled": False
     },
     "CollectFbxModel": {
-        "enabled": False
+        "enabled": False,
+        "optional": True,
+        "active": True
     },
     "CollectGLTF": {
         "enabled": False


### PR DESCRIPTION
## Changelog Description
This PR is to add support to publish fbx in model product type in Maya

## Additional info
Update maya addon to 0.2.8

## Testing notes:
1. Go to your AYON server, make sure `Collect Model for FBX export` enabled
![image](https://github.com/ynput/ayon-core/assets/64118225/6a1409a5-fb59-495d-b684-d09d91bcb189)

2. Launch Maya
3. Create Model Instance
4. You can choose to turn on/off `Collect Model for FBX Export`
![image](https://github.com/ynput/ayon-core/assets/64118225/9f235d38-102b-4afa-9ce6-377fc16f372d)
5. If you turn on, it will publish fbx with model product type.
