### PR TITLE
Houdini: Support collect frames for files with dot in filename (and other special characters)

### DIFF
--- a/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_frames.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_frames.py
@@ -48,16 +48,18 @@ class CollectFrames(plugin.HoudiniInstancePlugin):
         match = re.match(pattern, file_name)
 
         if match and start_frame is not None:
-            self.log.debug("Collecting file sequence %s [%s-%s]",
-                           file_name, start_frame, end_frame)
             # Check if frames are bigger than 1 (file collection)
             # override the result
             if end_frame - start_frame > 0:
                 result = self.create_file_list(
                     match, int(start_frame), int(end_frame)
                 )
+
+        if isinstance(result, list):
+            self.log.debug("Collect frames: file sequence '%s' [%s-%s]",
+                           file_name, start_frame, end_frame)
         else:
-            self.log.debug("Collecting single file %s", file_name)
+            self.log.debug("Collect frames: single file '%s'", file_name)
 
         # todo: `frames` currently conflicts with "explicit frames" for a
         #       for a custom frame list. So this should be refactored.

--- a/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_frames.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_frames.py
@@ -48,13 +48,16 @@ class CollectFrames(plugin.HoudiniInstancePlugin):
         match = re.match(pattern, file_name)
 
         if match and start_frame is not None:
-
+            self.log.debug("Collecting file sequence %s [%s-%s]",
+                           file_name, start_frame, end_frame)
             # Check if frames are bigger than 1 (file collection)
             # override the result
             if end_frame - start_frame > 0:
                 result = self.create_file_list(
                     match, int(start_frame), int(end_frame)
                 )
+        else:
+            self.log.debug("Collecting single file %s", file_name)
 
         # todo: `frames` currently conflicts with "explicit frames" for a
         #       for a custom frame list. So this should be refactored.

--- a/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_frames.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/publish/collect_frames.py
@@ -41,11 +41,10 @@ class CollectFrames(plugin.HoudiniInstancePlugin):
         file_name = os.path.basename(output)
         result = file_name
 
-        # Get the filename pattern match from the output
-        # path, so we can compute all frames that would
-        # come out from rendering the ROP node if there
-        # is a frame pattern in the name
-        pattern = r"\w+\.(\d+)" + re.escape(ext)
+        # Get the filename pattern match from the output path, so we can 
+        # compute all frames that would come out from rendering the ROP node
+        # if there is a frame pattern in the name
+        pattern = r".*\.(\d+)" + re.escape(ext) + "$"
         match = re.match(pattern, file_name)
 
         if match and start_frame is not None:

--- a/server_addon/houdini/client/ayon_houdini/version.py
+++ b/server_addon/houdini/client/ayon_houdini/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'houdini' version."""
-__version__ = "0.3.7"
+__version__ = "0.3.8"

--- a/server_addon/houdini/package.py
+++ b/server_addon/houdini/package.py
@@ -1,6 +1,6 @@
 name = "houdini"
 title = "Houdini"
-version = "0.3.7"
+version = "0.3.8"
 
 client_dir = "ayon_houdini"
 


### PR DESCRIPTION
## Changelog Description

Fixes detection of output sequences where the filename had an extra dot in it, like e.g. `$HIP/vdbcache.fixed.1001.vdb`.

## Additional info

The previous regex match of `\w` in the filename disallowed matching `.` or other special characters - it now allows any character before the expected end.

Also adds some small debug logs to make debugging easier in the future.

## Testing notes:

1. A publish should work with a `vdbcache` publish with e.g. output path set to `$HIP/vdbcache.fixed.1001.vdb`