### PR TITLE
Houdini: Expose Extract Active View Thumbnail to settings

### DIFF
--- a/server_addon/houdini/client/ayon_houdini/plugins/publish/extract_active_view_thumbnail.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/publish/extract_active_view_thumbnail.py
@@ -1,10 +1,13 @@
 import tempfile
 import pyblish.api
+
+from ayon_core.pipeline import OptionalPyblishPluginMixin
 from ayon_houdini.api import lib, plugin
 from ayon_houdini.api.pipeline import IS_HEADLESS
 
 
-class ExtractActiveViewThumbnail(plugin.HoudiniExtractorPlugin):
+class ExtractActiveViewThumbnail(plugin.HoudiniExtractorPlugin,
+                                 OptionalPyblishPluginMixin):
     """Set instance thumbnail to a screengrab of current active viewport.
 
     This makes it so that if an instance does not have a thumbnail set yet that
@@ -17,6 +20,9 @@ class ExtractActiveViewThumbnail(plugin.HoudiniExtractorPlugin):
     families = ["workfile"]
 
     def process(self, instance):
+        if not self.is_active(instance):
+            return
+
         if IS_HEADLESS:
             self.log.debug(
                 "Skip extraction of active view thumbnail, due to being in"

--- a/server_addon/houdini/client/ayon_houdini/plugins/publish/extract_active_view_thumbnail.py
+++ b/server_addon/houdini/client/ayon_houdini/plugins/publish/extract_active_view_thumbnail.py
@@ -20,7 +20,7 @@ class ExtractActiveViewThumbnail(plugin.HoudiniExtractorPlugin,
     families = ["workfile"]
 
     def process(self, instance):
-        if not self.is_active(instance):
+        if not self.is_active(instance.data):
             return
 
         if IS_HEADLESS:

--- a/server_addon/houdini/server/settings/publish.py
+++ b/server_addon/houdini/server/settings/publish.py
@@ -57,7 +57,7 @@ class ValidateWorkfilePathsModel(BaseSettingsModel):
     )
 
 
-class BasicValidateModel(BaseSettingsModel):
+class BasicEnabledStatesModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="Enabled")
     optional: bool = SettingsField(title="Optional")
     active: bool = SettingsField(title="Active")
@@ -77,25 +77,29 @@ class PublishPluginsModel(BaseSettingsModel):
         default_factory=CollectLocalRenderInstancesModel,
         title="Collect Local Render Instances."
     )
-    ValidateInstanceInContextHoudini: BasicValidateModel = SettingsField(
-        default_factory=BasicValidateModel,
+    ValidateInstanceInContextHoudini: BasicEnabledStatesModel = SettingsField(
+        default_factory=BasicEnabledStatesModel,
         title="Validate Instance is in same Context.",
         section="Validators")
-    ValidateMeshIsStatic: BasicValidateModel = SettingsField(
-        default_factory=BasicValidateModel,
+    ValidateMeshIsStatic: BasicEnabledStatesModel = SettingsField(
+        default_factory=BasicEnabledStatesModel,
         title="Validate Mesh is Static.")
-    ValidateReviewColorspace: BasicValidateModel = SettingsField(
-        default_factory=BasicValidateModel,
+    ValidateReviewColorspace: BasicEnabledStatesModel = SettingsField(
+        default_factory=BasicEnabledStatesModel,
         title="Validate Review Colorspace.")
-    ValidateSubsetName: BasicValidateModel = SettingsField(
-        default_factory=BasicValidateModel,
+    ValidateSubsetName: BasicEnabledStatesModel = SettingsField(
+        default_factory=BasicEnabledStatesModel,
         title="Validate Subset Name.")
-    ValidateUnrealStaticMeshName: BasicValidateModel = SettingsField(
-        default_factory=BasicValidateModel,
+    ValidateUnrealStaticMeshName: BasicEnabledStatesModel = SettingsField(
+        default_factory=BasicEnabledStatesModel,
         title="Validate Unreal Static Mesh Name.")
     ValidateWorkfilePaths: ValidateWorkfilePathsModel = SettingsField(
         default_factory=ValidateWorkfilePathsModel,
         title="Validate workfile paths settings.")
+    ExtractActiveViewThumbnail: BasicEnabledStatesModel = SettingsField(
+        default_factory=BasicEnabledStatesModel,
+        title="Extract Active View Thumbnail"
+    )
 
 
 DEFAULT_HOUDINI_PUBLISH_SETTINGS = {
@@ -152,5 +156,10 @@ DEFAULT_HOUDINI_PUBLISH_SETTINGS = {
             "$HIP",
             "$JOB"
         ]
+    },
+    "ExtractActiveViewThumbnail": {
+        "enabled": True,
+        "optional": False,
+        "active": True
     }
 }

--- a/server_addon/houdini/server/settings/publish.py
+++ b/server_addon/houdini/server/settings/publish.py
@@ -99,7 +99,8 @@ class PublishPluginsModel(BaseSettingsModel):
         title="Validate workfile paths settings")
     ExtractActiveViewThumbnail: BasicEnabledStatesModel = SettingsField(
         default_factory=BasicEnabledStatesModel,
-        title="Extract Active View Thumbnail"
+        title="Extract Active View Thumbnail",
+        section="Extractors"
     )
 
 


### PR DESCRIPTION
## Changelog Description

Exposes the Extractor that takes a quick screenshot of the active view to settings to allow disabling/enabling it.

## Additional info

Unfortunately we've been having some crashes with Houdini on this logic on a very heavy scene with heavy VDBs - unsure why and it's been inconsistent unfortunately, making it hard to debug and detect whether there's a way to report a bug to sidefx and have them fix Houdini.

This change now allows us to disable it for that project.

## Testing notes:

1. Tweak the settings
2. The Extract Active View Thumbnail should behave accordingly
