### PR TITLE
Settings: Minor cosmetic tweaks

### DIFF
--- a/server_addon/deadline/server/settings/publish_plugins.py
+++ b/server_addon/deadline/server/settings/publish_plugins.py
@@ -153,8 +153,8 @@ class FusionSubmitDeadlineModel(BaseSettingsModel):
     )
     group: str = SettingsField("", title="Group Name")
     plugin: str = SettingsField("Fusion",
-                        enum_resolver=fusion_deadline_plugin_enum,
-                        title="Deadline Plugin")
+                                enum_resolver=fusion_deadline_plugin_enum,
+                                title="Deadline Plugin")
 
 
 class NukeSubmitDeadlineModel(BaseSettingsModel):
@@ -376,7 +376,7 @@ class PublishPluginsModel(BaseSettingsModel):
     ProcessSubmittedCacheJobOnFarm: ProcessCacheJobFarmModel = SettingsField(
         default_factory=ProcessCacheJobFarmModel,
         title="Process submitted cache Job on farm",
-            section="Publish Jobs")
+        section="Publish Jobs")
     ProcessSubmittedJobOnFarm: ProcessSubmittedJobOnFarmModel = SettingsField(
         default_factory=ProcessSubmittedJobOnFarmModel,
         title="Process submitted job on farm")

--- a/server_addon/deadline/server/settings/publish_plugins.py
+++ b/server_addon/deadline/server/settings/publish_plugins.py
@@ -375,11 +375,11 @@ class PublishPluginsModel(BaseSettingsModel):
         title="Nuke Submit to deadline")
     ProcessSubmittedCacheJobOnFarm: ProcessCacheJobFarmModel = SettingsField(
         default_factory=ProcessCacheJobFarmModel,
-        title="Process submitted cache Job on farm.",
+        title="Process submitted cache Job on farm",
             section="Publish Jobs")
     ProcessSubmittedJobOnFarm: ProcessSubmittedJobOnFarmModel = SettingsField(
         default_factory=ProcessSubmittedJobOnFarmModel,
-        title="Process submitted job on farm.")
+        title="Process submitted job on farm")
 
 
 DEFAULT_DEADLINE_PLUGINS_SETTINGS = {

--- a/server_addon/houdini/server/settings/publish.py
+++ b/server_addon/houdini/server/settings/publish.py
@@ -66,36 +66,36 @@ class BasicValidateModel(BaseSettingsModel):
 class PublishPluginsModel(BaseSettingsModel):
     CollectAssetHandles: CollectAssetHandlesModel = SettingsField(
         default_factory=CollectAssetHandlesModel,
-        title="Collect Asset Handles.",
+        title="Collect Asset Handles",
         section="Collectors"
     )
     CollectChunkSize: CollectChunkSizeModel = SettingsField(
         default_factory=CollectChunkSizeModel,
-        title="Collect Chunk Size."
+        title="Collect Chunk Size"
     )
     CollectLocalRenderInstances: CollectLocalRenderInstancesModel = SettingsField(
         default_factory=CollectLocalRenderInstancesModel,
-        title="Collect Local Render Instances."
+        title="Collect Local Render Instances"
     )
     ValidateInstanceInContextHoudini: BasicValidateModel = SettingsField(
         default_factory=BasicValidateModel,
-        title="Validate Instance is in same Context.",
+        title="Validate Instance is in same Context",
         section="Validators")
     ValidateMeshIsStatic: BasicValidateModel = SettingsField(
         default_factory=BasicValidateModel,
-        title="Validate Mesh is Static.")
+        title="Validate Mesh is Static")
     ValidateReviewColorspace: BasicValidateModel = SettingsField(
         default_factory=BasicValidateModel,
-        title="Validate Review Colorspace.")
+        title="Validate Review Colorspace")
     ValidateSubsetName: BasicValidateModel = SettingsField(
         default_factory=BasicValidateModel,
-        title="Validate Subset Name.")
+        title="Validate Subset Name")
     ValidateUnrealStaticMeshName: BasicValidateModel = SettingsField(
         default_factory=BasicValidateModel,
-        title="Validate Unreal Static Mesh Name.")
+        title="Validate Unreal Static Mesh Name")
     ValidateWorkfilePaths: ValidateWorkfilePathsModel = SettingsField(
         default_factory=ValidateWorkfilePathsModel,
-        title="Validate workfile paths settings.")
+        title="Validate workfile paths settings")
 
 
 DEFAULT_HOUDINI_PUBLISH_SETTINGS = {

--- a/server_addon/houdini/server/settings/publish.py
+++ b/server_addon/houdini/server/settings/publish.py
@@ -31,6 +31,7 @@ class AOVFilterSubmodel(BaseSettingsModel):
         title="AOV regex"
     )
 
+
 class CollectLocalRenderInstancesModel(BaseSettingsModel):
 
     use_deadline_aov_filter: bool = SettingsField(
@@ -109,7 +110,7 @@ DEFAULT_HOUDINI_PUBLISH_SETTINGS = {
     },
     "CollectLocalRenderInstances": {
         "use_deadline_aov_filter": False,
-        "aov_filter" : {
+        "aov_filter": {
             "host_name": "houdini",
             "value": [
                 ".*([Bb]eauty).*"


### PR DESCRIPTION
## Changelog Description

Remove dot `.` from title at end of plug-in names in settings

## Additional info

Removes the dots at the end of plug-in labels seen at the bottom here.

![image](https://github.com/ynput/ayon-core/assets/2439881/ac7376bd-06ff-4013-9edf-6d958bd5846f)

+ some PEP8 cosmetics

## Testing notes:

1. Check the changes - nothing should change in code behavior.
