### PR TITLE
Core: Fix folder widget set selected folder path

### DIFF
--- a/client/ayon_core/tools/utils/folders_widget.py
+++ b/client/ayon_core/tools/utils/folders_widget.py
@@ -96,7 +96,7 @@ class FoldersQtModel(QtGui.QStandardItemModel):
             Union[str, None]: Folder id or None if folder is not available.
 
         """
-        for folder_id, item in self._items_by_id.values():
+        for folder_id, item in self._items_by_id.items():
             if item.data(FOLDER_PATH_ROLE) == folder_path:
                 return folder_id
         return None


### PR DESCRIPTION
## Changelog Description

Fix the logic to set selected folder path in Folder Widget

## Additional info

Stack trace:
```python
Traceback (most recent call last):
  File "E:\dev\ayon-core\server_addon\houdini\client\ayon_houdini\api\hda_utils.py", line 519, in _select_folder_path
    dialog.folder_widget.set_selected_folder_path(folder_path)
  File "E:\dev\ayon-core\client\ayon_core\tools\utils\folders_widget.py", line 561, in set_selected_folder_path
    folder_id = self._folders_model.get_item_id_by_path(folder_path)
  File "E:\dev\ayon-core\client\ayon_core\tools\utils\folders_widget.py", line 99, in get_item_id_by_path
    for folder_id, item in self._items_by_id.values():
TypeError: cannot unpack non-iterable PySide2.QtGui.QStandardItem object
```

## Testing notes:

1. Folder Widget should work.
