### PR TITLE
Burnins: Remove deprecated ffmpeg argument

### DIFF
--- a/client/ayon_core/lib/transcoding.py
+++ b/client/ayon_core/lib/transcoding.py
@@ -978,7 +978,7 @@ def _ffmpeg_h264_codec_args(stream_data, source_ffmpeg_cmd):
     if pix_fmt:
         output.extend(["-pix_fmt", pix_fmt])
 
-    output.extend(["-intra", "-g", "1"])
+    output.extend(["-g", "1"])
     return output
 
 


### PR DESCRIPTION
## Changelog Description
Removed deprecated `-intra` command from ffmpeg burnins commands.

## Testing notes:
1. Burnins are created and playable.
