### PR TITLE
Update dialog: Change label to `Restart & Update`

### DIFF
--- a/client/ayon_core/tools/tray/dialogs.py
+++ b/client/ayon_core/tools/tray/dialogs.py
@@ -83,7 +83,7 @@ class UpdateDialog(QtWidgets.QDialog):
         top_layout.addWidget(label_widget, 1)
 
         ignore_btn = QtWidgets.QPushButton("Ignore", self)
-        restart_btn = QtWidgets.QPushButton("Restart && Change", self)
+        restart_btn = QtWidgets.QPushButton("Restart && Update", self)
         restart_btn.setObjectName("TrayRestartButton")
 
         btns_layout = QtWidgets.QHBoxLayout()


### PR DESCRIPTION
## Changelog Description

Changes label from "Restart & Change" to "Restart & Update"

## Additional info

Before:
![image](https://github.com/ynput/ayon-core/assets/2439881/143b9646-18da-45fe-aebc-9400c35e0596)

@m-u-r-p-h-y likes the new labels. [It's true](https://discord.com/channels/517362899170230292/517382145552154634/1260155668934164500).

## Testing notes:

1. Wait for "update" notice from launched ayon console (not dev mode)
2. Green restart button should display  "Restart & Update"