### PR TITLE
UI Icons: Cache key is safely generated

### DIFF
--- a/client/ayon_core/tools/utils/lib.py
+++ b/client/ayon_core/tools/utils/lib.py
@@ -485,7 +485,10 @@ class _IconsCache:
             parts = [icon_type, icon_def["path"]]
 
         elif icon_type in {"awesome-font", "material-symbols"}:
-            parts = [icon_type, icon_def["name"], icon_def["color"]]
+            color = icon_def["color"] or ""
+            if isinstance(color, QtGui.QColor):
+                color = color.name()
+            parts = [icon_type, icon_def["name"] or "", color]
         return "|".join(parts)
 
     @classmethod


### PR DESCRIPTION
## Changelog Description
Cache key expect values to be `None` and `QColor`.

## Additional info
Issue discovered in https://github.com/ynput/ayon-core/pull/764#pullrequestreview-2169128475 causing that `Set version` on multiselection does not work as it request icon and color set as `None` . That already happened few times, always causing crashes of UI, so maybe we should expect broken values and show empty icons rather than crashing tools.

## Testing notes:
1. Set version in scene inventory does work on multiselection of multiple different products.
