### PR TITLE
Loader: Change placeholder text to "Version status filter..."

### DIFF
--- a/client/ayon_core/tools/loader/ui/statuses_combo.py
+++ b/client/ayon_core/tools/loader/ui/statuses_combo.py
@@ -294,7 +294,7 @@ class StatusesCombobox(CustomPaintMultiselectComboBox):
             model=model,
             parent=parent
         )
-        self.set_placeholder_text("Statuses...")
+        self.set_placeholder_text("Version status filter...")
         self._model = model
         self._last_project_name = None
         self._fully_disabled_filter = False


### PR DESCRIPTION
## Changelog Description

Change placeholder text from "Statuses..." to "Version status filter..." to align more with the filter fields to left of it.

Before:

![before](https://github.com/user-attachments/assets/19875033-c293-4bf6-8a83-6e9bb16003bc)

After:

![image](https://github.com/user-attachments/assets/cfb139cf-c9d3-4051-aabd-01564d257a64)

## Additional info

For context - there's also a "Folder name filter..." a bit further left.

![image](https://github.com/user-attachments/assets/88b42e5d-ec7d-431f-a602-c078a9120c69)


## Testing notes:

1. Loader should display the new "Version status filter..." placeholder text
