### PR TITLE
Delete old versions: Add confirm prompt to avoid accidental delete

### DIFF
--- a/client/ayon_core/plugins/load/delete_old_versions.py
+++ b/client/ayon_core/plugins/load/delete_old_versions.py
@@ -1,7 +1,7 @@
 import collections
 import os
 import uuid
-from typing import Optional, List, Dict, Any
+from typing import List, Dict, Any
 
 import clique
 import ayon_api

--- a/client/ayon_core/plugins/load/delete_old_versions.py
+++ b/client/ayon_core/plugins/load/delete_old_versions.py
@@ -48,7 +48,7 @@ class DeleteOldVersions(load.ProductLoaderPlugin):
         size = 0
 
         for dir_path in dir_paths:
-            # Delete all files and fodlers in dir path
+            # Delete all files and folders in dir path
             for root, dirs, files in os.walk(dir_path, topdown=False):
                 for name in files:
                     file_path = os.path.join(root, name)

--- a/client/ayon_core/plugins/load/delete_old_versions.py
+++ b/client/ayon_core/plugins/load/delete_old_versions.py
@@ -220,10 +220,8 @@ class DeleteOldVersions(load.ProductLoaderPlugin):
         messagebox.setIcon(QtWidgets.QMessageBox.Warning)
         messagebox.setWindowTitle("Delete Old Versions")
         messagebox.setText(text)
-        if informative_text:
-            messagebox.setInformativeText(informative_text)
-        if detailed_text:
-            messagebox.setDetailedText(detailed_text)
+        messagebox.setInformativeText(informative_text)
+        messagebox.setDetailedText(detailed_text)
         messagebox.setStandardButtons(
             QtWidgets.QMessageBox.Yes
             | QtWidgets.QMessageBox.Cancel

--- a/client/ayon_core/plugins/load/delete_old_versions.py
+++ b/client/ayon_core/plugins/load/delete_old_versions.py
@@ -217,9 +217,6 @@ class DeleteOldVersions(load.ProductLoaderPlugin):
         )
 
         messagebox = QtWidgets.QMessageBox()
-        messagebox.setWindowFlags(
-            messagebox.windowFlags() | QtCore.Qt.FramelessWindowHint
-        )
         messagebox.setIcon(QtWidgets.QMessageBox.Warning)
         messagebox.setWindowTitle("Delete Old Versions")
         messagebox.setText(text)


### PR DESCRIPTION
## Changelog Description

Add informative confirm prompt for delete versions to avoid accidental clicks deleting versions and files.

## Additional info

![image](https://github.com/user-attachments/assets/66a7d474-532d-44ae-a8ec-5c20bdfd8564)

With "Show details..." clicked:

![image](https://github.com/user-attachments/assets/95c13349-f082-4331-875c-c4299b755c22)

## Testing notes:

1. Open Loader from Tray
2. Use Delete Old Versions action
3. Deletion should be confirmed (and do nothing when cancelled!)