### PR TITLE
Workfile Template Builder: Allow Create Placeholder to define the 'active' state

### DIFF
--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -2043,7 +2043,8 @@ class CreateContext:
         variant,
         folder_entity=None,
         task_entity=None,
-        pre_create_data=None
+        pre_create_data=None,
+        active=True
     ):
         """Trigger create of plugins with standartized arguments.
 
@@ -2061,6 +2062,8 @@ class CreateContext:
                 of creation (possible context of created instance/s).
             task_entity (Dict[str, Any]): Task entity.
             pre_create_data (Dict[str, Any]): Pre-create attribute values.
+            active (Optional[bool]): Whether the created instance defaults
+                to be active or not. Defaults to True.
 
         Returns:
             Any: Output of triggered creator's 'create' method.
@@ -2124,7 +2127,8 @@ class CreateContext:
             "folderPath": folder_entity["path"],
             "task": task_entity["name"] if task_entity else None,
             "productType": creator.product_type,
-            "variant": variant
+            "variant": variant,
+            "active": bool(active)
         }
         return creator.create(
             product_name,

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -2130,7 +2130,12 @@ class CreateContext:
             "variant": variant
         }
         if active is not None:
-            instance_data["active"] = bool(active)
+            if not isinstance(active, bool):
+                self.log.warning(
+                    "CreateContext.create 'active' argument is not a bool. "
+                    f"Converting {active} {type(active)} to bool.")
+                active = bool(active)
+            instance_data["active"] = active
 
         return creator.create(
             product_name,

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -2044,7 +2044,7 @@ class CreateContext:
         folder_entity=None,
         task_entity=None,
         pre_create_data=None,
-        active=True
+        active=None
     ):
         """Trigger create of plugins with standartized arguments.
 
@@ -2063,7 +2063,7 @@ class CreateContext:
             task_entity (Dict[str, Any]): Task entity.
             pre_create_data (Dict[str, Any]): Pre-create attribute values.
             active (Optional[bool]): Whether the created instance defaults
-                to be active or not. Defaults to True.
+                to be active or not.
 
         Returns:
             Any: Output of triggered creator's 'create' method.
@@ -2127,9 +2127,11 @@ class CreateContext:
             "folderPath": folder_entity["path"],
             "task": task_entity["name"] if task_entity else None,
             "productType": creator.product_type,
-            "variant": variant,
-            "active": bool(active)
+            "variant": variant
         }
+        if active is not None:
+            instance_data["active"] = bool(active)
+
         return creator.create(
             product_name,
             instance_data,

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1797,6 +1797,16 @@ class PlaceholderCreateMixin(object):
                     "\ncompiling of product name."
                 )
             ),
+            attribute_definitions.BoolDef(
+                "active",
+                label="Active",
+                default=options.get("active", True),
+                tooltip=(
+                    "Active"
+                    "\nDefines whether the created instance will default to "
+                    "active or not."
+                )
+            ),
             attribute_definitions.UISeparatorDef(),
             attribute_definitions.NumberDef(
                 "order",
@@ -1826,6 +1836,7 @@ class PlaceholderCreateMixin(object):
         legacy_create = self.builder.use_legacy_creators
         creator_name = placeholder.data["creator"]
         create_variant = placeholder.data["create_variant"]
+        active = placeholder.data.get("active", True)
 
         creator_plugin = self.builder.get_creators_by_name()[creator_name]
 
@@ -1873,7 +1884,8 @@ class PlaceholderCreateMixin(object):
                     create_variant,
                     folder_entity,
                     task_entity,
-                    pre_create_data=pre_create_data
+                    pre_create_data=pre_create_data,
+                    active=active
                 )
 
         except:  # noqa: E722

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1836,7 +1836,7 @@ class PlaceholderCreateMixin(object):
         legacy_create = self.builder.use_legacy_creators
         creator_name = placeholder.data["creator"]
         create_variant = placeholder.data["create_variant"]
-        active = placeholder.data.get("active", True)
+        active = placeholder.data.get("active")
 
         creator_plugin = self.builder.get_creators_by_name()[creator_name]
 


### PR DESCRIPTION
## Changelog Description

Workfile Template Builder: Allow Create Placeholder to define the 'active' state of the created instance.

## Additional info

Example in Houdini using https://github.com/ynput/ayon-houdini/pull/36

![image](https://github.com/user-attachments/assets/7b68ec17-2e2e-4bcb-b4ef-21f34cfb9f51)

The template:

![image](https://github.com/user-attachments/assets/8c80c32d-a666-4cb2-a319-748efb60bd82)

After template build:

![image](https://github.com/user-attachments/assets/9920bea2-2c99-4233-9f13-df5eeee46fc6)

## Testing notes:

> would be nice to test in Nuke and Maya if it does not break anything.
>    Use old template where are placeholders without active.
>    Use new template and try if it creates activated/deactivated instances based on the placeholder data.

1. Test whether this works when creating create placeholders in other hosts, like:
    - [ ] Nuke 
    - [x] Houdini (requires https://github.com/ynput/ayon-houdini/pull/36
 and bugfix https://github.com/ynput/ayon-houdini/pull/41 )
    - [ ] Maya (does not have "Create" placeholders - but may be good to test whether it still works)
    - [ ] (not sure which other hosts support Create Placeholders?)
2. Existing create placeholders in an existing template should still work and default to active.