### PR TITLE
Loader tool: Fix filtering

### DIFF
--- a/client/ayon_core/tools/loader/ui/products_model.py
+++ b/client/ayon_core/tools/loader/ui/products_model.py
@@ -127,7 +127,6 @@ class ProductsModel(QtGui.QStandardItemModel):
 
         self._last_project_name = None
         self._last_folder_ids = []
-        self._last_status_names = None
         self._last_project_statuses = {}
         self._last_status_icons_by_name = {}
 
@@ -168,8 +167,7 @@ class ProductsModel(QtGui.QStandardItemModel):
         # Ignore change if groups are not available
         self.refresh(
             self._last_project_name,
-            self._last_folder_ids,
-            self._last_status_names
+            self._last_folder_ids
         )
 
     def flags(self, index):
@@ -459,12 +457,11 @@ class ProductsModel(QtGui.QStandardItemModel):
     def get_last_project_name(self):
         return self._last_project_name
 
-    def refresh(self, project_name, folder_ids, status_names):
+    def refresh(self, project_name, folder_ids):
         self._clear()
 
         self._last_project_name = project_name
         self._last_folder_ids = folder_ids
-        self._last_status_names = status_names
         status_items = self._controller.get_project_status_items(project_name)
         self._last_project_statuses = {
             status_item.name: status_item
@@ -492,17 +489,9 @@ class ProductsModel(QtGui.QStandardItemModel):
         }
         last_version_by_product_id = {}
         for product_item in product_items:
-            all_versions = list(product_item.version_items.values())
-            all_versions.sort()
-            versions = [
-                version_item
-                for version_item in all_versions
-                if status_names is None or version_item.status in status_names
-            ]
-            if versions:
-                last_version = versions[-1]
-            else:
-                last_version = all_versions[-1]
+            versions = list(product_item.version_items.values())
+            versions.sort()
+            last_version = versions[-1]
             last_version_by_product_id[product_item.product_id] = (
                 last_version
             )

--- a/client/ayon_core/tools/loader/ui/products_model.py
+++ b/client/ayon_core/tools/loader/ui/products_model.py
@@ -127,6 +127,7 @@ class ProductsModel(QtGui.QStandardItemModel):
 
         self._last_project_name = None
         self._last_folder_ids = []
+        self._last_status_names = None
         self._last_project_statuses = {}
         self._last_status_icons_by_name = {}
 
@@ -165,7 +166,11 @@ class ProductsModel(QtGui.QStandardItemModel):
             return
         self._grouping_enabled = enable_grouping
         # Ignore change if groups are not available
-        self.refresh(self._last_project_name, self._last_folder_ids)
+        self.refresh(
+            self._last_project_name,
+            self._last_folder_ids,
+            self._last_status_names
+        )
 
     def flags(self, index):
         # Make the version column editable
@@ -459,6 +464,7 @@ class ProductsModel(QtGui.QStandardItemModel):
 
         self._last_project_name = project_name
         self._last_folder_ids = folder_ids
+        self._last_status_names = status_names
         status_items = self._controller.get_project_status_items(project_name)
         self._last_project_statuses = {
             status_item.name: status_item

--- a/client/ayon_core/tools/loader/ui/products_model.py
+++ b/client/ayon_core/tools/loader/ui/products_model.py
@@ -156,9 +156,8 @@ class ProductsModel(QtGui.QStandardItemModel):
         if product_item is None:
             return
 
-        self.setData(
-            product_item.index(), version_id, VERSION_NAME_EDIT_ROLE
-        )
+        index = self.indexFromItem(product_item)
+        self.setData(index, version_id, VERSION_NAME_EDIT_ROLE)
 
     def set_enable_grouping(self, enable_grouping):
         if enable_grouping is self._grouping_enabled:

--- a/client/ayon_core/tools/loader/ui/products_model.py
+++ b/client/ayon_core/tools/loader/ui/products_model.py
@@ -132,7 +132,7 @@ class ProductsModel(QtGui.QStandardItemModel):
 
     def get_product_item_indexes(self):
         return [
-            item.index()
+            self.indexFromItem(item)
             for item in self._items_by_id.values()
         ]
 

--- a/client/ayon_core/tools/loader/ui/products_model.py
+++ b/client/ayon_core/tools/loader/ui/products_model.py
@@ -538,10 +538,11 @@ class ProductsModel(QtGui.QStandardItemModel):
             for product_name, product_items in groups.items():
                 group_product_types |= {p.product_type for p in product_items}
                 for product_item in product_items:
-                    group_product_types |= {
+                    group_status_names |= {
                         version_item.status
                         for version_item in product_item.version_items.values()
                     }
+                    group_product_types.add(product_item.product_type)
 
                 if len(product_items) == 1:
                     top_items.append(product_items[0])
@@ -584,13 +585,15 @@ class ProductsModel(QtGui.QStandardItemModel):
                 product_name, product_items = path_info
                 (merged_color_hex, merged_color_qt) = self._get_next_color()
                 merged_color = qtawesome.icon(
-                    "fa.circle", color=merged_color_qt)
+                    "fa.circle", color=merged_color_qt
+                )
                 merged_item = self._get_merged_model_item(
                     product_name, len(product_items), merged_color_hex)
                 merged_item.setData(merged_color, QtCore.Qt.DecorationRole)
                 new_items.append(merged_item)
 
                 merged_product_types = set()
+                merged_status_names = set()
                 new_merged_items = []
                 for product_item in product_items:
                     item = self._get_product_model_item(
@@ -603,9 +606,21 @@ class ProductsModel(QtGui.QStandardItemModel):
                     )
                     new_merged_items.append(item)
                     merged_product_types.add(product_item.product_type)
+                    merged_status_names |= {
+                        version_item.status
+                        for version_item in (
+                            product_item.version_items.values()
+                        )
+                    }
 
                 merged_item.setData(
-                    "|".join(merged_product_types), PRODUCT_TYPE_ROLE)
+                    "|".join(merged_product_types),
+                    PRODUCT_TYPE_ROLE
+                )
+                merged_item.setData(
+                    "|".join(merged_status_names),
+                    STATUS_NAME_FILTER_ROLE
+                )
                 if new_merged_items:
                     merged_item.appendRows(new_merged_items)
 

--- a/client/ayon_core/tools/loader/ui/products_widget.py
+++ b/client/ayon_core/tools/loader/ui/products_widget.py
@@ -321,8 +321,7 @@ class ProductsWidget(QtWidgets.QWidget):
     def _refresh_model(self):
         self._products_model.refresh(
             self._selected_project_name,
-            self._selected_folder_ids,
-            self._products_proxy_model.get_statuses_filter()
+            self._selected_folder_ids
         )
 
     def _on_context_menu(self, point):

--- a/client/ayon_core/tools/loader/ui/products_widget.py
+++ b/client/ayon_core/tools/loader/ui/products_widget.py
@@ -186,12 +186,12 @@ class ProductsWidget(QtWidgets.QWidget):
         products_proxy_model.rowsInserted.connect(self._on_rows_inserted)
         products_proxy_model.rowsMoved.connect(self._on_rows_moved)
         products_model.refreshed.connect(self._on_refresh)
+        products_model.version_changed.connect(self._on_version_change)
         products_view.customContextMenuRequested.connect(
             self._on_context_menu)
         products_view_sel_model = products_view.selectionModel()
         products_view_sel_model.selectionChanged.connect(
             self._on_selection_change)
-        products_model.version_changed.connect(self._on_version_change)
         version_delegate.version_changed.connect(
             self._on_version_delegate_change
         )

--- a/client/ayon_core/tools/loader/ui/products_widget.py
+++ b/client/ayon_core/tools/loader/ui/products_widget.py
@@ -188,7 +188,8 @@ class ProductsWidget(QtWidgets.QWidget):
         products_model.refreshed.connect(self._on_refresh)
         products_view.customContextMenuRequested.connect(
             self._on_context_menu)
-        products_view.selectionModel().selectionChanged.connect(
+        products_view_sel_model = products_view.selectionModel()
+        products_view_sel_model.selectionChanged.connect(
             self._on_selection_change)
         products_model.version_changed.connect(self._on_version_change)
         version_delegate.version_changed.connect(


### PR DESCRIPTION
## Changelog Description
Loader tool can enable/disable grouping of products and filtering by product types and status names should work.

## Additional info
~~This was broken with new statuses filter which required to pass status names on model refresh, which was mid-solution that is not necessary at the end. So changed the logic of Products model refresh back to previous integration to not require status names on refresh.~~
PR changed during it's lifetime as was discovered that the whole filtering was not working. Product type filtering was completelly broken and statuses filtering did break UI for multiselection of folders. Also products under group item did not propagate version change from combobox in specific cases.

## Testing notes:
- First of all grouping can be enabled/disabled.
- To validate we didn't break the source of the previous implementation:

1. Open loader tool.
2. Add some status filters (that will change version to lower version than latest).
3. Refresh or enable/disable grouping.
4. The version should stay at same version number and should show correct status and rest of version related information.

Resolves https://github.com/ynput/ayon-core/issues/782