### PR TITLE
Review: Integrate reviewables to AYON

### DIFF
--- a/client/ayon_core/lib/__init__.py
+++ b/client/ayon_core/lib/__init__.py
@@ -109,6 +109,7 @@ from .transcoding import (
     convert_ffprobe_fps_value,
     convert_ffprobe_fps_to_float,
     get_rescaled_command_arguments,
+    get_media_mime_type,
 )
 
 from .plugin_tools import (
@@ -209,6 +210,7 @@ __all__ = [
     "convert_ffprobe_fps_value",
     "convert_ffprobe_fps_to_float",
     "get_rescaled_command_arguments",
+    "get_media_mime_type",
 
     "compile_list_of_regexes",
 

--- a/client/ayon_core/lib/transcoding.py
+++ b/client/ayon_core/lib/transcoding.py
@@ -6,6 +6,7 @@ import collections
 import tempfile
 import subprocess
 import platform
+from typing import Optional
 
 import xml.etree.ElementTree
 
@@ -1455,3 +1456,89 @@ def get_oiio_input_and_channel_args(oiio_input_info, alpha_default=None):
         input_arg += ":ch={}".format(input_channels_str)
 
     return input_arg, channels_arg
+
+
+def _get_media_mime_type_from_ftyp(content):
+    if content[8:10] == b"qt":
+        return "video/quicktime"
+
+    if content[8:12] == b"isom":
+        return "video/mp4"
+    if content[8:12] in (b"M4V\x20", b"mp42"):
+        return "video/mp4v"
+    if content[8:13] in (b"3gpis"):
+        return "video/3gpp"
+    # (
+    #     b"avc1", b"iso2", b"isom", b"mmp4", b"mp41", b"mp71",
+    #     b"msnv", b"ndas", b"ndsc", b"ndsh", b"ndsm", b"ndsp", b"ndss",
+    #     b"ndxc", b"ndxh", b"ndxm", b"ndxp", b"ndxs"
+    # )
+    return None
+
+
+def get_media_mime_type(filepath: str) -> Optional[str]:
+    """Determine Mime-Type of a file.
+
+    Args:
+        filepath (str): Path to file.
+
+    Returns:
+        Optional[str]: Mime type or None if is unknown mime type.
+
+    """
+    if not filepath or not os.path.exists(filepath):
+        return None
+
+    with open(filepath, "rb") as stream:
+        content = stream.read()
+
+    content_len = len(content)
+    # Pre-validation (largest definition check)
+    # - hopefully there cannot be media defined in less than 12 bytes
+    if content_len < 12:
+        return None
+
+    # FTYP
+    if content[4:8] == b"ftyp":
+        return _get_media_mime_type_from_ftyp(content)
+
+    # BMP
+    if content[0:2] == b"BM":
+        return "image/bmp"
+
+    # Tiff
+    if content[0:2] in (b"MM", b"II"):
+        return "tiff"
+
+    # PNG
+    if content[0:4] == b"\211PNG":
+        return "image/png"
+
+    # SVG
+    if b'xmlns="http://www.w3.org/2000/svg"' in content:
+        return "image/svg+xml"
+
+    # JPEG, JFIF or Exif
+    if (
+        content[0:4] == b"\xff\xd8\xff\xdb"
+        or content[6:10] in (b"JFIF", b"Exif")
+    ):
+        return "image/jpeg"
+
+    # Webp
+    if content[0:4] == b"RIFF" and content[8:12] == b"WEBP":
+        return "image/webp"
+
+    # Gif
+    if content[0:6] in (b"GIF87a", b"GIF89a"):
+        return "gif"
+
+    # Adobe PhotoShop file (8B > Adobe, PS > PhotoShop)
+    if content[0:4] == b"8BPS":
+        return "image/vnd.adobe.photoshop"
+
+    # Windows ICO > this might be wild guess as multiple files can start
+    #   with this header
+    if content[0:4] == b"\x00\x00\x01\x00":
+        return "image/x-icon"
+    return None

--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -11,6 +11,7 @@ from ayon_api import (
     get_product_by_name,
     get_version_by_name,
     get_representations,
+    RequestTypes,
 )
 from ayon_api.operations import (
     OperationsSession,
@@ -1028,7 +1029,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 query = f"?label={label}"
 
             endpoint = (
-                f"/api/projects/{project_name}"
+                f"/projects/{project_name}"
                 f"/versions/{version_id}/reviewables{query}"
             )
             # Make sure label is unique
@@ -1049,7 +1050,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             ayon_con.upload_file(
                 endpoint,
                 repre_path,
-                headers=headers
+                headers=headers,
+                request_type=RequestTypes.post,
             )
 
     def _validate_path_in_project_roots(self, anatomy, file_path):

--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -992,6 +992,14 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
 
     def _upload_reviewable(self, project_name, version_id, instance):
         ayon_con = get_server_api_connection()
+        major, minor, _, _, _ = ayon_con.get_server_version_tuple()
+        if (major, minor) < (1, 3):
+            self.log.info(
+                "Skipping reviewable upload, supported from server 1.3.x."
+                f" User server version {ayon_con.get_server_version()}"
+            )
+            return
+
         base_headers = ayon_con.get_headers()
 
         uploaded_labels = set()

--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -116,18 +116,19 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
     # the database even if not used by the destination template
     db_representation_context_keys = [
         "project",
-        "asset",
         "hierarchy",
         "folder",
         "task",
         "product",
-        "subset",
-        "family",
         "version",
         "representation",
         "username",
         "user",
-        "output"
+        "output",
+        # OpenPype keys - should be removed
+        "asset",  # folder[name]
+        "subset",  # product[name]
+        "family",  # product[type]
     ]
 
     def process(self, instance):

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -1011,7 +1011,8 @@ DEFAULT_PUBLISH_VALUES = {
                         "ext": "png",
                         "tags": [
                             "ftrackreview",
-                            "kitsureview"
+                            "kitsureview",
+                            "webreview"
                         ],
                         "burnins": [],
                         "ffmpeg_args": {
@@ -1051,7 +1052,8 @@ DEFAULT_PUBLISH_VALUES = {
                         "tags": [
                             "burnin",
                             "ftrackreview",
-                            "kitsureview"
+                            "kitsureview",
+                            "webreview"
                         ],
                         "burnins": [],
                         "ffmpeg_args": {
@@ -1063,7 +1065,10 @@ DEFAULT_PUBLISH_VALUES = {
                             "output": [
                                 "-pix_fmt yuv420p",
                                 "-crf 18",
-                                "-intra"
+                                "-c:a acc",
+                                "-b:a 192k",
+                                "-g 1",
+                                "-movflags faststart"
                             ]
                         },
                         "filter": {


### PR DESCRIPTION
## Changelog Description
Integrate plugin does integrate reviewables to AYON server.

## Additional info
Upload reviewables to AYON server during integration. The method is not yet available in ayon-python-api so it had to be implemented there. Also modified default ExtractReview arguments to more suite needs of server, but previous defaults should work too.

I did have issues with ExtractBurnins, that could be because of my dev environment, please validate if is working for you.

There is one possible issue that should be resolved in future, which is that if there is only review representation without representation to integrate, it is actually not uploaded to server because the version is not integrated (as would not have any representations). This topic needs more thinking and usually happens only in edge cases...

## Testing notes:
1. Make sure you have AYON server 1.3.0 or higher.
2. Create package and upload it to server.
3. Make sure you have added tag `"webreview"` in ExtractReview settings.
4. Start host of your choice.
5. Run publishing with some review.
6. The review should be uploaded to AYON server.