### PR TITLE
Chore: Faster cli initalization

### DIFF
--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -271,7 +271,7 @@ def _set_addons_environments(addons_manager):
 
 def _add_addons(addons_manager):
     """Modules/Addons can add their cli commands dynamically."""
-    log = Logger.get_logger("CLI-AddModules")
+    log = Logger.get_logger("CLI-AddAddons")
     for addon_obj in addons_manager.addons:
         try:
             addon_obj.cli(addon)

--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -120,7 +120,7 @@ def publish(path, targets, gui):
     """Start CLI publishing.
 
     Publish collects json from path provided as an argument.
-S
+
     """
     Commands.publish(path, targets, gui)
 

--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -83,6 +83,7 @@ main_cli.set_alias("addon", "module")
 
 
 @main_cli.command()
+@click.pass_context
 @click.argument("output_json_path")
 @click.option("--project", help="Project name", default=None)
 @click.option("--asset", help="Folder path", default=None)
@@ -91,7 +92,9 @@ main_cli.set_alias("addon", "module")
 @click.option(
     "--envgroup", help="Environment group (e.g. \"farm\")", default=None
 )
-def extractenvironments(output_json_path, project, asset, task, app, envgroup):
+def extractenvironments(
+    ctx, output_json_path, project, asset, task, app, envgroup
+):
     """Extract environment variables for entered context to a json file.
 
     Entered output filepath will be created if does not exists.

--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -106,23 +106,30 @@ def extractenvironments(output_json_path, project, asset, task, app, envgroup):
         'addon applications extractenvironments ...' instead.
     """
     Commands.extractenvironments(
-        output_json_path, project, asset, task, app, envgroup
+        output_json_path,
+        project,
+        asset,
+        task,
+        app,
+        envgroup,
+        ctx.obj["addons_manager"]
     )
 
 
 @main_cli.command()
+@click.pass_context
 @click.argument("path", required=True)
 @click.option("-t", "--targets", help="Targets", default=None,
               multiple=True)
 @click.option("-g", "--gui", is_flag=True,
               help="Show Publish UI", default=False)
-def publish(path, targets, gui):
+def publish(ctx, path, targets, gui):
     """Start CLI publishing.
 
     Publish collects json from path provided as an argument.
 
     """
-    Commands.publish(path, targets, gui)
+    Commands.publish(path, targets, gui, ctx.obj["addons_manager"])
 
 
 @main_cli.command(context_settings={"ignore_unknown_options": True})
@@ -301,7 +308,10 @@ def main(*args, **kwargs):
     _set_addons_environments(addons_manager)
     _add_addons(addons_manager)
     try:
-        main_cli(obj={}, prog_name="ayon")
+        main_cli(
+            prog_name="ayon",
+            obj={"addons_manager": addons_manager},
+        )
     except Exception:  # noqa
         exc_info = sys.exc_info()
         print("!!! AYON crashed:")

--- a/client/ayon_core/cli_commands.py
+++ b/client/ayon_core/cli_commands.py
@@ -20,7 +20,12 @@ class Commands:
         tray.main()
 
     @staticmethod
-    def publish(path: str, targets: list=None, gui:bool=False) -> None:
+    def publish(
+        path: str,
+        targets: list = None,
+        gui: bool = False,
+        addons_manager=None,
+    ) -> None:
         """Start headless publishing.
 
         Publish use json from passed path argument.
@@ -81,14 +86,15 @@ class Commands:
 
         install_ayon_plugins()
 
-        manager = AddonsManager()
+        if addons_manager is None:
+            addons_manager = AddonsManager()
 
-        publish_paths = manager.collect_plugin_paths()["publish"]
+        publish_paths = addons_manager.collect_plugin_paths()["publish"]
 
         for plugin_path in publish_paths:
             pyblish.api.register_plugin_path(plugin_path)
 
-        applications_addon = manager.get_enabled_addon("applications")
+        applications_addon = addons_manager.get_enabled_addon("applications")
         if applications_addon is not None:
             context = get_global_context()
             env = applications_addon.get_farm_publish_environment_variables(
@@ -137,15 +143,12 @@ class Commands:
 
     @staticmethod
     def extractenvironments(
-        output_json_path, project, asset, task, app, env_group
+        output_json_path, project, asset, task, app, env_group, addons_manager
     ):
         """Produces json file with environment based on project and app.
 
         Called by Deadline plugin to propagate environment into render jobs.
         """
-
-        from ayon_core.addon import AddonsManager
-
         warnings.warn(
             (
                 "Command 'extractenvironments' is deprecated and will be"
@@ -155,7 +158,6 @@ class Commands:
             DeprecationWarning
         )
 
-        addons_manager = AddonsManager()
         applications_addon = addons_manager.get_enabled_addon("applications")
         if applications_addon is None:
             raise RuntimeError(

--- a/client/ayon_core/cli_commands.py
+++ b/client/ayon_core/cli_commands.py
@@ -2,6 +2,7 @@
 """Implementation of AYON commands."""
 import os
 import sys
+import warnings
 from typing import Optional, List
 
 from ayon_core.addon import AddonsManager

--- a/client/ayon_core/cli_commands.py
+++ b/client/ayon_core/cli_commands.py
@@ -20,27 +20,6 @@ class Commands:
         tray.main()
 
     @staticmethod
-    def add_addons(click_func):
-        """Modules/Addons can add their cli commands dynamically."""
-
-        from ayon_core.lib import Logger
-        from ayon_core.addon import AddonsManager
-
-        manager = AddonsManager()
-        log = Logger.get_logger("CLI-AddModules")
-        for addon in manager.addons:
-            try:
-                addon.cli(click_func)
-
-            except Exception:
-                log.warning(
-                    "Failed to add cli command for module \"{}\"".format(
-                        addon.name
-                    ), exc_info=True
-                )
-        return click_func
-
-    @staticmethod
     def publish(path: str, targets: list=None, gui:bool=False) -> None:
         """Start headless publishing.
 

--- a/client/ayon_core/cli_commands.py
+++ b/client/ayon_core/cli_commands.py
@@ -2,7 +2,9 @@
 """Implementation of AYON commands."""
 import os
 import sys
-import warnings
+from typing import Optional, List
+
+from ayon_core.addon import AddonsManager
 
 
 class Commands:
@@ -22,9 +24,9 @@ class Commands:
     @staticmethod
     def publish(
         path: str,
-        targets: list = None,
-        gui: bool = False,
-        addons_manager=None,
+        targets: Optional[List[str]] = None,
+        gui: Optional[bool] = False,
+        addons_manager: Optional[AddonsManager] = None,
     ) -> None:
         """Start headless publishing.
 
@@ -32,8 +34,9 @@ class Commands:
 
         Args:
             path (str): Path to JSON.
-            targets (list of str): List of pyblish targets.
-            gui (bool): Show publish UI.
+            targets (Optional[List[str]]): List of pyblish targets.
+            gui (Optional[bool]): Show publish UI.
+            addons_manager (Optional[AddonsManager]): Addons manager instance.
 
         Raises:
             RuntimeError: When there is no path to process.


### PR DESCRIPTION
## Changelog Description
Create AddonsManager only once for cli processing.

## Additional info
Create only AddonsManager object only single time for whole main cli processing which should make the startup a little bit faster as it does not need to re-fetch all the data.

## Testing notes:
1. All command line commands are working as expected.
2. The most affected commands are `extractenvironments` and `publish` which now do not create addons manager bu expect it as argument. Both are used on farm.