### PR TITLE
Tray: Force start tray

### DIFF
--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -59,13 +59,20 @@ def main_cli(ctx):
 
 
 @main_cli.command()
-def tray():
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Force to start tray and close any existing one.")
+def tray(force):
     """Launch AYON tray.
 
     Default action of AYON command is to launch tray widget to control basic
     aspects of AYON. See documentation for more information.
     """
-    Commands.launch_tray()
+
+    from ayon_core.tools.tray import main
+
+    main(force)
 
 
 @main_cli.group(help="Run command line arguments of AYON addons")

--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -43,8 +43,8 @@ class AliasedGroup(click.Group):
               help="Enable debug")
 @click.option("--verbose", expose_value=False,
               help=("Change AYON log level (debug - critical or 0-50)"))
-@click.option("--force", is_flag=True, expose_value=False, hidden=True)
-def main_cli(ctx):
+@click.option("--force", is_flag=True, hidden=True)
+def main_cli(ctx, force):
     """AYON is main command serving as entry point to pipeline system.
 
     It wraps different commands together.
@@ -56,7 +56,7 @@ def main_cli(ctx):
             print(ctx.get_help())
             sys.exit(0)
         else:
-            ctx.invoke(tray)
+            ctx.forward(tray)
 
 
 @main_cli.command()

--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -43,6 +43,7 @@ class AliasedGroup(click.Group):
               help="Enable debug")
 @click.option("--verbose", expose_value=False,
               help=("Change AYON log level (debug - critical or 0-50)"))
+@click.option("--force", is_flag=True, expose_value=False, hidden=True)
 def main_cli(ctx):
     """AYON is main command serving as entry point to pipeline system.
 

--- a/client/ayon_core/cli_commands.py
+++ b/client/ayon_core/cli_commands.py
@@ -14,12 +14,6 @@ class Commands:
     Most of its methods are called by :mod:`cli` module.
     """
     @staticmethod
-    def launch_tray():
-        from ayon_core.tools.tray import main
-
-        main()
-
-    @staticmethod
     def publish(
         path: str,
         targets: Optional[List[str]] = None,

--- a/client/ayon_core/tools/tray/lib.py
+++ b/client/ayon_core/tools/tray/lib.py
@@ -344,12 +344,20 @@ def is_tray_running(
     return state != TrayState.NOT_RUNNING
 
 
-def main():
+def main(force=False):
     from ayon_core.tools.tray.ui import main
 
     Logger.set_process_name("Tray")
 
     state = get_tray_state()
+    if force and state in (TrayState.RUNNING, TrayState.STARTING):
+        file_info = get_tray_file_info() or {}
+        pid = file_info.get("pid")
+        if pid is not None:
+            _kill_tray_process(pid)
+        remove_tray_server_url(force=True)
+        state = TrayState.NOT_RUNNING
+
     if state == TrayState.RUNNING:
         print("Tray is already running.")
         return

--- a/client/ayon_core/tools/tray/lib.py
+++ b/client/ayon_core/tools/tray/lib.py
@@ -7,6 +7,7 @@ import subprocess
 import csv
 import time
 import signal
+import locale
 from typing import Optional, Dict, Tuple, Any
 
 import ayon_api
@@ -50,7 +51,8 @@ def _get_server_and_variant(
 def _windows_pid_is_running(pid: int) -> bool:
     args = ["tasklist.exe", "/fo", "csv", "/fi", f"PID eq {pid}"]
     output = subprocess.check_output(args)
-    csv_content = csv.DictReader(output.decode("utf-8").splitlines())
+    encoding = locale.getpreferredencoding()
+    csv_content = csv.DictReader(output.decode(encoding).splitlines())
     # if "PID" not in csv_content.fieldnames:
     #     return False
     for _ in csv_content:


### PR DESCRIPTION
## Changelog Description
Added option to force start of tray.

## Additional info
Using `--force` will kill existing tray process and start a new one. Can be used when tray is for some reason stuct and artist should be able to continue.

## Testing notes:
1. Create package and upload to server, or use dev path (server part is not needed).
2. Start a tray in one terminal.
3. Start a tray in second terminal > this should tell you that tray is already running.
4. Start a tray in second terminal with `--force` argument > previous tray should stop and new should start.
