### PR TITLE
Tray: Make starting tray check faster

### DIFF
--- a/client/ayon_core/tools/tray/lib.py
+++ b/client/ayon_core/tools/tray/lib.py
@@ -278,7 +278,12 @@ def remove_tray_server_url(force: Optional[bool] = False):
     except BaseException:
         data = {}
 
-    if force or not data or data.get("pid") == os.getpid():
+    if (
+        force
+        or not data
+        or data.get("pid") == os.getpid()
+        or not _is_process_running(data.get("pid"))
+    ):
         os.remove(filepath)
 
 

--- a/client/ayon_core/tools/tray/lib.py
+++ b/client/ayon_core/tools/tray/lib.py
@@ -124,6 +124,7 @@ def _wait_for_starting_tray(
 
         pid = data.get("pid")
         if pid and not _is_process_running(pid):
+            remove_tray_server_url()
             return None
 
         if time.time() - started_at > timeout:

--- a/client/ayon_core/tools/tray/lib.py
+++ b/client/ayon_core/tools/tray/lib.py
@@ -122,6 +122,10 @@ def _wait_for_starting_tray(
         if data.get("started") is True:
             return data
 
+        pid = data.get("pid")
+        if pid and not _is_process_running(pid):
+            return None
+
         if time.time() - started_at > timeout:
             return None
         time.sleep(0.1)


### PR DESCRIPTION
## Changelog Description
Check if the PID defined in tray info file is alive to make validation of starting tray faster.

## Additional info
It happened to me that if tray is brute-force shutdown it does not cleanup the file, so next tray startup takes 10 seconds. Added check if the PID is still alive before any other check.

## Testing notes:
Not sure how to exactly replicate the issue. I've started tray in terminal and killed the terminal tab when splash showed up. With that done, the next startup takes at about 10 seconds. With this PR it should be faster.
