### PR TITLE
Tweak grammar for "Addon is not available" due to outdated version for moved addon from core

### DIFF
--- a/client/ayon_core/addon/base.py
+++ b/client/ayon_core/addon/base.py
@@ -235,10 +235,10 @@ def _handle_moved_addons(addon_name, milestone_version, log):
         "client",
     )
     if not os.path.exists(addon_dir):
-        log.error((
-            "Addon '{}' is not be available."
-            " Please update applications addon to '{}' or higher."
-        ).format(addon_name, milestone_version))
+        log.error(
+            f"Addon '{addon_name}' is not available. Please update "
+            f"{addon_name} addon to '{milestone_version}' or higher."
+        )
         return None
 
     log.warning((


### PR DESCRIPTION
## Changelog Description

Tweak grammar plus make it more understandable what addon needs updating

## Additional info

Related to discussion where this appeared in the logs on a failed deadline render - but the actual issue was a connection timeout.

## Testing notes:

1. Use this ayon-core version but an older version of `ayon-maya` (e.g `0.1.x`) in your bundle.
2. Launching tray should likely show this error in console.
