### PR TITLE
Scene Inventory tool: All outdated containers use red color of version

### DIFF
--- a/client/ayon_core/tools/sceneinventory/model.py
+++ b/client/ayon_core/tools/sceneinventory/model.py
@@ -217,10 +217,7 @@ class InventoryModel(QtGui.QStandardItemModel):
                 version_item = version_items[repre_info.version_id]
                 version_label = format_version(version_item.version)
                 is_hero = version_item.version < 0
-                is_latest = version_item.is_latest
-                # TODO maybe use different colors for last approved and last
-                #    version? Or don't care about color at all?
-                if not is_latest and not version_item.is_last_approved:
+                if not version_item.is_latest:
                     version_color = self.OUTDATED_COLOR
                 status_name = version_item.status
 


### PR DESCRIPTION
## Changelog Description
All containers that are not from last version have marked version with red color.

## Additional info
Adding last approved versions logic to scene inventory stopped to mark last approved versions with red color, which is causing confusions.

## Testing notes:
1. Create version 1 of a product and change status to approved.
2. Create version 2 on the same product and use other than approved status.
3. Load version 1 into a scene.
4. Open scene inventory tool.
5. The container in view should have red colored version label.

Related to issue https://github.com/ynput/ayon-core/issues/789 , does notresolve the issue fully.