### PR TITLE
Tray: Logout closes tray

### DIFF
--- a/client/ayon_core/tools/tray/lib.py
+++ b/client/ayon_core/tools/tray/lib.py
@@ -10,8 +10,8 @@ import signal
 import locale
 from typing import Optional, Dict, Tuple, Any
 
-import ayon_api
 import requests
+from ayon_api.utils import get_default_settings_variant
 
 from ayon_core.lib import (
     Logger,
@@ -39,7 +39,7 @@ def _get_default_server_url() -> str:
 
 def _get_default_variant() -> str:
     """Get default settings variant."""
-    return ayon_api.get_default_settings_variant()
+    return get_default_settings_variant()
 
 
 def _get_server_and_variant(


### PR DESCRIPTION
## Changelog Description
Logout does not keep tray running.

## Additional info
The issue was that `get_default_settings_variant` from `ayon_api` is actually using global connection, which can't log in if we just logged out.

## Testing notes:
1. Create package, upload to AYON server and use in bundle.
2. Start AYON tray with console (so you can see if it is closed).
3. Click on tray icon > Login.
4. In opened dialog click on Logour and confirm with Ok.
5. You should be logged out and tray should fully close.
