### PR TITLE
Publisher: Added default iterator on publisher initialization

### DIFF
--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -829,7 +829,7 @@ class PublishModel:
         )
 
         # Plugin iterator
-        self._main_thread_iter: Iterable[partial] = []
+        self._main_thread_iter: Iterable[partial] = self._default_iterator()
 
     def reset(self):
         create_context = self._controller.get_create_context()
@@ -900,10 +900,9 @@ class PublishModel:
         #   only in specific cases (e.g. when it happens for a first time)
 
         if (
-            self._main_thread_iter is None
             # There are validation errors and validation is passed
             # - can't do any progree
-            or (
+            (
                 self._publish_has_validated
                 and self._publish_has_validation_errors
             )
@@ -1069,6 +1068,18 @@ class PublishModel:
                 "publish.publish_error.changed",
                 {"value": value}
             )
+
+    def _default_iterator(self):
+        """Iterator used on initialization.
+
+        Should be replaced by real iterator when 'reset' is called.
+
+        Yields:
+            partial: Function that will be called in main thread.
+
+        """
+        while True:
+            yield partial(self.stop_publish)
 
     def _start_publish(self):
         """Start or continue in publishing."""


### PR DESCRIPTION
## Changelog Description
Fix possible issue with running main iterator before reset.

## Additional info
The issue happens in flame randomly, we could not replicate the issue, so we don't know the "real" reason and it is possible that this won't fix it, but it definetelly won't hurt.

The logic actually changed in https://github.com/ynput/ayon-core/pull/689 , before that PR `_main_thread_iter` was set to `None` in `__init__` which was validated afterwards, looks like that might be the cause, but I don't know how.

### Traceback
Traceback (most recent call last):
  File "../ayon-core/client/ayon_core/tools/publisher/control_qt.py", line 52, in _execute
    item.process()
  File "../ayon-core/client/ayon_core/tools/publisher/control_qt.py", line 20, in process
    self.callback(*self.args, **self.kwargs)
  File "../ayon-core/client/ayon_core/tools/publisher/control_qt.py", line 95, in _next_publish_item_process
    func = self._publish_model.get_next_process_func()
  File "../ayon-core/client/ayon_core/tools/publisher/models/publish.py", line 918, in get_next_process_func
    item = next(self._main_thread_iter)
StopIteration

## Testing notes:
1. Flame does not complain about empty iterator.

