### PR TITLE
Use proper aac argument for ExtractReview

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -1066,7 +1066,7 @@ DEFAULT_PUBLISH_VALUES = {
                             "output": [
                                 "-pix_fmt yuv420p",
                                 "-crf 18",
-                                "-c:a acc",
+                                "-c:a aac",
                                 "-b:a 192k",
                                 "-g 1",
                                 "-movflags faststart"


### PR DESCRIPTION
## Changelog Description
Original `acc` doesnt work for audio

## Additional info
Solves error `Unknown encoder 'acc'` in ExtractReview

## Testing notes:
1. publish something which will have review with attached audio file (from Hiero, maybe AE)
2. ExtractReview shouldnt fail
