### PR TITLE
Custom template name profiles for uasset/umap publish in Unreal

### DIFF
--- a/server/settings/tools.py
+++ b/server/settings/tools.py
@@ -588,6 +588,18 @@ DEFAULT_TOOLS_VALUES = {
                 "task_types": [],
                 "task_names": [],
                 "template_name": "tycache"
+            },
+            {
+                "product_types": [
+                    "uasset",
+                    "umap"
+                ],
+                "hosts": [
+                    "unreal"
+                ],
+                "task_types": [],
+                "task_names": [],
+                "template_name": "unrealuasset"
             }
         ],
         "hero_template_name_profiles": [


### PR DESCRIPTION
## Changelog Description
Add supports for custom template name profiles for uasset/umap publish in Unreal. This would keep original filename and resolve the issue of corrupting the uasset file by changing name during publishing.
The related template name ticket in ayon_backend: 
Resolve https://github.com/ynput/ayon-unreal/issues/65
Resolve https://github.com/ynput/ayon-unreal/issues/64

## Additional info
n/a

## Testing notes:
1. Build and install this addon along with the update from the backend ticket
2. Publish uasset/umap in unreal.
