### PR TITLE
Log message: Avoid double quotes around paths

### DIFF
--- a/client/ayon_core/plugins/publish/collect_anatomy_instance_data.py
+++ b/client/ayon_core/plugins/publish/collect_anatomy_instance_data.py
@@ -217,9 +217,8 @@ class CollectAnatomyInstanceData(pyblish.api.ContextPlugin):
             joined_paths = ", ".join(
                 ["\"{}\"".format(path) for path in not_found_task_paths]
             )
-            self.log.warning((
-                "Not found task entities with paths \"{}\"."
-            ).format(joined_paths))
+            self.log.warning(
+                f"Not found task entities with paths {joined_paths}.")
 
     def fill_latest_versions(self, context, project_name):
         """Try to find latest version for each instance's product name.


### PR DESCRIPTION
## Changelog Description
Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation.

Before: 
![image](https://github.com/user-attachments/assets/bd23f12e-7d3a-4535-8429-3a2f3729fb5c)

After:
![image](https://github.com/user-attachments/assets/ceb26903-e2af-47ae-afae-73cb3d612d9c)


## Additional info

Yay, pretty. 🎉 

## Testing notes:

1. Publish e.g. editorial or something that doesn't have the task paths (yet?) (in my case Resolve PR for new publisher)
