### PR TITLE
Workfile template build: Allow empty representation name

### DIFF
--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1519,9 +1519,10 @@ class PlaceholderLoadMixin(object):
         if "asset" in placeholder.data:
             return []
 
-        representation_name = placeholder.data["representation"]
-        if not representation_name:
-            return []
+        representation_names = None
+        representation_name: str = placeholder.data["representation"]
+        if representation_name:
+            representation_names = [representation_name]
 
         project_name = self.builder.project_name
         current_folder_entity = self.builder.current_folder_entity
@@ -1578,7 +1579,7 @@ class PlaceholderLoadMixin(object):
         )
         return list(get_representations(
             project_name,
-            representation_names={representation_name},
+            representation_names=representation_names,
             version_ids=version_ids
         ))
 


### PR DESCRIPTION
## Changelog Description

Allow placeholder representation name to be set as an empty value to load all representations

## Additional info

Use case described by @fabiaserra [here](https://github.com/ynput/ayon-core/pull/871#issuecomment-2332185180).

## Testing notes:

1. Create load placeholder with empty representation name
2. It should load all representations
