### PR TITLE
Maya 2025: Should display scriptsmenu correctly instead of only search bar

### DIFF
--- a/client/ayon_core/vendor/python/scriptsmenu/launchformaya.py
+++ b/client/ayon_core/vendor/python/scriptsmenu/launchformaya.py
@@ -130,7 +130,7 @@ def main(title="Scripts", parent=None, objectName=None):
 
     # Register control + shift callback to add to shelf (maya behavior)
     modifiers = QtCore.Qt.ControlModifier | QtCore.Qt.ShiftModifier
-    if int(cmds.about(version=True)) <= 2025:
+    if int(cmds.about(version=True)) < 2025:
         modifiers = int(modifiers)
 
     menu.register_callback(modifiers, to_shelf)


### PR DESCRIPTION
## Changelog Description

Maya 2025 scripts menu does not show any menu entries.

Reported [here](https://discord.com/channels/517362899170230292/1281462971897221121).

## Additional info

Previous fix https://github.com/ynput/ayon-core/pull/669 may have been wrong?

## Testing notes:
1. Launch Maya 2025
2. Scripts menu should log no errors on startup or menu open. 
3. The menu entries should be visible and work as intended.
