### PR TITLE
Workfile template builder: Allow custom `resolve_template_path`

### DIFF
--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -872,11 +872,7 @@ class AbstractTemplateBuilder(ABC):
             "code": anatomy.project_code,
         }
 
-        result = StringTemplate.format_template(path, fill_data)
-        if result.solved:
-            path = result.normalized()
-
-        path = self.resolve_template_path(path)
+        path = self.resolve_template_path(path, fill_data)
 
         if path and os.path.exists(path):
             self.log.info("Found template at: '{}'".format(path))
@@ -916,21 +912,25 @@ class AbstractTemplateBuilder(ABC):
             "create_first_version": create_first_version
         }
 
-    def resolve_template_path(self, path: str) -> str:
+    def resolve_template_path(self, path, fill_data) -> str:
         """Resolve the template path.
 
         By default, this does nothing except returning the path directly.
-        But, this allows additional resolving over the template path inside
-        a custom AYON integration. Like, in Houdini using
-        `hou.text.expandString`
+
+        This can be overridden in host integrations to perform additional
+        resolving over the template. Like, `hou.text.expandString` in Houdini.
 
         Arguments:
             path (str): The input path.
+            fill_data (dict[str, str]): Data to use for template formatting.
 
         Returns:
             str: The resolved path.
 
         """
+        result = StringTemplate.format_template(path, fill_data)
+        if result.solved:
+            path = result.normalized()
         return path
 
     def emit_event(self, topic, data=None, source=None) -> Event:

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -859,7 +859,7 @@ class AbstractTemplateBuilder(ABC):
                 "Settings\\Profiles"
             ).format(host_name.title()))
 
-        # Try fill path with environments and anatomy roots
+        # Try to fill path with environments and anatomy roots
         anatomy = Anatomy(project_name)
         fill_data = {
             key: value

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -876,6 +876,8 @@ class AbstractTemplateBuilder(ABC):
         if result.solved:
             path = result.normalized()
 
+        path = self.resolve_template_path(path)
+
         if path and os.path.exists(path):
             self.log.info("Found template at: '{}'".format(path))
             return {
@@ -913,6 +915,23 @@ class AbstractTemplateBuilder(ABC):
             "keep_placeholder": keep_placeholder,
             "create_first_version": create_first_version
         }
+
+    def resolve_template_path(self, path: str) -> str:
+        """Resolve the template path.
+
+        By default, this does nothing except returning the path directly.
+        But, this allows additional resolving over the template path inside
+        a custom AYON integration. Like, in Houdini using
+        `hou.text.expandString`
+
+        Arguments:
+            path (str): The input path.
+
+        Returns:
+            str: The resolved path.
+
+        """
+        return path
 
     def emit_event(self, topic, data=None, source=None) -> Event:
         return self._event_system.emit(topic, data, source)


### PR DESCRIPTION
## Changelog Description

Allow custom `resolve_template_path` to be implemented by AYON addon integrations

## Additional info

Related to Houdini workfile templates that allows extra path resolving using `hou.text.expandString`

## Testing notes:

1. Test together with https://github.com/ynput/ayon-houdini/pull/74

