### PR TITLE
Create: Allow context promise for editorial workflow

### DIFF
--- a/client/ayon_core/pipeline/create/structures.py
+++ b/client/ayon_core/pipeline/create/structures.py
@@ -1,6 +1,7 @@
 import copy
 import collections
 from uuid import uuid4
+from typing import Optional
 
 from ayon_core.lib.attribute_definitions import (
     UnknownDef,
@@ -396,6 +397,24 @@ class PublishAttributes:
                 )
 
 
+class InstanceContextInfo:
+    def __init__(
+        self,
+        folder_path: Optional[str],
+        task_name: Optional[str],
+        folder_is_valid: bool,
+        task_is_valid: bool,
+    ):
+        self.folder_path: Optional[str] = folder_path
+        self.task_name: Optional[str] = task_name
+        self.folder_is_valid: bool = folder_is_valid
+        self.task_is_valid: bool = task_is_valid
+
+    @property
+    def is_valid(self) -> bool:
+        return self.folder_is_valid and self.task_is_valid
+
+
 class CreatedInstance:
     """Instance entity with data that will be stored to workfile.
 
@@ -527,9 +546,6 @@ class CreatedInstance:
 
         if not self._data.get("instance_id"):
             self._data["instance_id"] = str(uuid4())
-
-        self._folder_is_valid = self.has_set_folder
-        self._task_is_valid = self.has_set_task
 
     def __str__(self):
         return (
@@ -699,6 +715,17 @@ class CreatedInstance:
     def publish_attributes(self):
         return self._data["publish_attributes"]
 
+    @property
+    def has_promised_context(self) -> bool:
+        """Get context data that are promised to be set by creator.
+
+        Returns:
+            bool: Has context that won't bo validated. Artist can't change
+                value when set to True.
+
+        """
+        return self._data.get("has_promised_context", False)
+
     def data_to_store(self):
         """Collect data that contain json parsable types.
 
@@ -826,46 +853,3 @@ class CreatedInstance:
         obj.publish_attributes.deserialize_attributes(publish_attributes)
 
         return obj
-
-    # Context validation related methods/properties
-    @property
-    def has_set_folder(self):
-        """Folder path is set in data."""
-
-        return "folderPath" in self._data
-
-    @property
-    def has_set_task(self):
-        """Task name is set in data."""
-
-        return "task" in self._data
-
-    @property
-    def has_valid_context(self):
-        """Context data are valid for publishing."""
-
-        return self.has_valid_folder and self.has_valid_task
-
-    @property
-    def has_valid_folder(self):
-        """Folder set in context exists in project."""
-
-        if not self.has_set_folder:
-            return False
-        return self._folder_is_valid
-
-    @property
-    def has_valid_task(self):
-        """Task set in context exists in project."""
-
-        if not self.has_set_task:
-            return False
-        return self._task_is_valid
-
-    def set_folder_invalid(self, invalid):
-        # TODO replace with `set_folder_path`
-        self._folder_is_valid = not invalid
-
-    def set_task_invalid(self, invalid):
-        # TODO replace with `set_task_name`
-        self._task_is_valid = not invalid

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -323,6 +323,12 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         pass
 
     @abstractmethod
+    def get_instances_context_info(
+        self, instance_ids: Optional[Iterable[str]] = None
+    ):
+        pass
+
+    @abstractmethod
     def get_existing_product_names(self, folder_path: str) -> List[str]:
         pass
 

--- a/client/ayon_core/tools/publisher/control.py
+++ b/client/ayon_core/tools/publisher/control.py
@@ -190,6 +190,9 @@ class PublisherController(
     def get_instances_by_id(self, instance_ids=None):
         return self._create_model.get_instances_by_id(instance_ids)
 
+    def get_instances_context_info(self, instance_ids=None):
+        return self._create_model.get_instances_context_info(instance_ids)
+
     def get_convertor_items(self):
         return self._create_model.get_convertor_items()
 

--- a/client/ayon_core/tools/publisher/models/create.py
+++ b/client/ayon_core/tools/publisher/models/create.py
@@ -306,6 +306,14 @@ class CreateModel:
             for instance_id in instance_ids
         }
 
+    def get_instances_context_info(
+        self, instance_ids: Optional[Iterable[str]] = None
+    ):
+        instances = self.get_instances_by_id(instance_ids).values()
+        return self._create_context.get_instances_context_info(
+            instances
+        )
+
     def get_convertor_items(self) -> Dict[str, ConvertorItem]:
         return self._create_context.convertor_items_by_id
 

--- a/client/ayon_core/tools/publisher/widgets/widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/widgets.py
@@ -1206,7 +1206,6 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
 
             except TaskNotSetError:
                 invalid_tasks = True
-                instance.set_task_invalid(True)
                 product_names.add(instance["productName"])
                 continue
 
@@ -1216,11 +1215,9 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
 
             if folder_path is not None:
                 instance["folderPath"] = folder_path
-                instance.set_folder_invalid(False)
 
             if task_name is not None:
                 instance["task"] = task_name or None
-                instance.set_task_invalid(False)
 
             instance["productName"] = new_product_name
 
@@ -1768,9 +1765,16 @@ class ProductAttributesWidget(QtWidgets.QWidget):
         self.bottom_separator = bottom_separator
 
     def _on_instance_context_changed(self):
+        instance_ids = {
+            instance.id
+            for instance in self._current_instances
+        }
+        context_info_by_id = self._controller.get_instances_context_info(
+            instance_ids
+        )
         all_valid = True
-        for instance in self._current_instances:
-            if not instance.has_valid_context:
+        for instance_id, context_info in context_info_by_id.items():
+            if not context_info.is_valid:
                 all_valid = False
                 break
 
@@ -1795,9 +1799,17 @@ class ProductAttributesWidget(QtWidgets.QWidget):
             convertor_identifiers(List[str]): Identifiers of convert items.
         """
 
+        instance_ids = {
+            instance.id
+            for instance in instances
+        }
+        context_info_by_id = self._controller.get_instances_context_info(
+            instance_ids
+        )
+
         all_valid = True
-        for instance in instances:
-            if not instance.has_valid_context:
+        for context_info in context_info_by_id.values():
+            if not context_info.is_valid:
                 all_valid = False
                 break
 

--- a/client/ayon_core/tools/publisher/window.py
+++ b/client/ayon_core/tools/publisher/window.py
@@ -913,12 +913,18 @@ class PublisherWindow(QtWidgets.QDialog):
             self._set_footer_enabled(True)
             return
 
+        active_instances_by_id = {
+            instance.id: instance
+            for instance in self._controller.get_instances()
+            if instance["active"]
+        }
+        context_info_by_id = self._controller.get_instances_context_info(
+            active_instances_by_id.keys()
+        )
         all_valid = None
-        for instance in self._controller.get_instances():
-            if not instance["active"]:
-                continue
-
-            if not instance.has_valid_context:
+        for instance_id, instance in active_instances_by_id.items():
+            context_info = context_info_by_id[instance_id]
+            if not context_info.is_valid:
                 all_valid = False
                 break
 


### PR DESCRIPTION
## Changelog Description
Create logic does allow to fill folder path and task name that are not validated in Publisher UI.

## Additional info
This change required change of context validation on instances. From now `CreatedIntance` does not have information about having valid context or not, it must be validated against `CreateContext`.

Added option to add `"has_promised_context"` to instance data. When set to `True` it does mark the instance as it's context is not validated in Publisher and cannot be modified by artist. Must be prefilled by create plugin, this does allow editorial create plugins to create instances before their target folder and task do exist.

### Note
I'm not sure if `"has_promised_context"` should be stored to instance data as it does not have to be stored to scene. Maybe using transient data would be more sufficient?

## Testing notes:
1. Create package and upload it to server.
2. Choose one of editorial hosts.
3. Modify create plugin that defines instances to set `"has_promised_context"` to `True`.
4. That should allow to set `"folderPath"` and `"task"` even if they do not exist.

Resolves https://github.com/ynput/ayon-core/issues/878