### PR TITLE
Allow `.tif` and `.tiff` extensions for review

### DIFF
--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -95,7 +95,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
     ]
 
     # Supported extensions
-    image_exts = ["exr", "jpg", "jpeg", "png", "dpx", "tga"]
+    image_exts = ["exr", "jpg", "jpeg", "png", "dpx", "tga", "tiff", "tif"]
     video_exts = ["mov", "mp4"]
     supported_exts = image_exts + video_exts
 


### PR DESCRIPTION
## Changelog Description

Allow `.tif` and `.tiff` extensions as supported extensions for extract review.

## Additional info

Avoids the case where `tif` outputs are skipped for review generation due to their extension with log message:
> INFO: Representation has unsupported extension "tif"

Is there a reason this [doesn't use the transcoding list of extensions](https://github.com/ynput/ayon-core/blob/432ead8178e7f75229c67924e411f2ac6d3055e3/client/ayon_core/lib/transcoding.py#L47-L67)?
```python
from ayon_core.lib.transcoding import (
    IMAGE_EXTENSIONS,
    VIDEO_EXTENSIONS,
)
```

## Testing notes:

1. Publish a `.tiff` or `.tif` sequence with `review` enabled - it should generate the reviewable.