### PR TITLE
Fix attribute_definitions.py typos

### DIFF
--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -16,7 +16,7 @@ _attr_defs_by_type = {}
 def register_attr_def_class(cls):
     """Register attribute definition.
 
-    Currently are registered definitions used to deserialize data to objects.
+    Currently registered definitions are used to deserialize data to objects.
 
     Attrs:
         cls (AbstractAttrDef): Non-abstract class to be registered with unique

--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -60,7 +60,7 @@ def get_default_values(attribute_definitions):
             for which default values should be collected.
 
     Returns:
-        Dict[str, Any]: Default values for passet attribute definitions.
+        Dict[str, Any]: Default values for passed attribute definitions.
     """
 
     output = {}
@@ -75,13 +75,13 @@ def get_default_values(attribute_definitions):
 
 
 class AbstractAttrDefMeta(ABCMeta):
-    """Metaclass to validate existence of 'key' attribute.
+    """Metaclass to validate the existence of 'key' attribute.
 
-    Each object of `AbstractAttrDef` mus have defined 'key' attribute.
+    Each object of `AbstractAttrDef` must have defined 'key' attribute.
     """
 
-    def __call__(self, *args, **kwargs):
-        obj = super(AbstractAttrDefMeta, self).__call__(*args, **kwargs)
+    def __call__(cls, *args, **kwargs):
+        obj = super(AbstractAttrDefMeta, cls).__call__(*args, **kwargs)
         init_class = getattr(obj, "__init__class__", None)
         if init_class is not AbstractAttrDef:
             raise TypeError("{} super was not called in __init__.".format(
@@ -162,7 +162,8 @@ class AbstractAttrDef(metaclass=AbstractAttrDefMeta):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def type(self):
         """Attribute definition type also used as identifier of class.
 
@@ -215,10 +216,11 @@ class AbstractAttrDef(metaclass=AbstractAttrDefMeta):
 
 
 # -----------------------------------------
-# UI attribute definitoins won't hold value
+# UI attribute definitions won't hold value
 # -----------------------------------------
 
 class UIDef(AbstractAttrDef):
+    type = "ui-def"
     is_value_def = False
 
     def __init__(self, key=None, default=None, *args, **kwargs):
@@ -245,7 +247,7 @@ class UILabelDef(UIDef):
 
 
 # ---------------------------------------
-# Attribute defintioins should hold value
+# Attribute definitions should hold value
 # ---------------------------------------
 
 class UnknownDef(AbstractAttrDef):
@@ -311,7 +313,7 @@ class NumberDef(AbstractAttrDef):
     ):
         minimum = 0 if minimum is None else minimum
         maximum = 999999 if maximum is None else maximum
-        # Swap min/max when are passed in opposited order
+        # Swap min/max when are passed in opposite order
         if minimum > maximum:
             maximum, minimum = minimum, maximum
 
@@ -364,10 +366,10 @@ class NumberDef(AbstractAttrDef):
 class TextDef(AbstractAttrDef):
     """Text definition.
 
-    Text can have multiline option so endline characters are allowed regex
+    Text can have multiline option so end-line characters are allowed regex
     validation can be applied placeholder for UI purposes and default value.
 
-    Regex validation is not part of attribute implemntentation.
+    Regex validation is not part of attribute implementation.
 
     Args:
         multiline(bool): Text has single or multiline support.
@@ -949,7 +951,8 @@ def deserialize_attr_def(attr_def_data):
     """Deserialize attribute definition from data.
 
     Args:
-        attr_def (Dict[str, Any]): Attribute definition data to deserialize.
+        attr_def_data (Dict[str, Any]): Attribute definition data to
+            deserialize.
     """
 
     attr_type = attr_def_data.pop("type")

--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -4,7 +4,7 @@ import collections
 import uuid
 import json
 import copy
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 
 import clique
 


### PR DESCRIPTION
## Changelog Description

Some typos.

It does add an attribute `type = "ui-def"` somewhere - I wasn't sure that was reasonable in the original PR.

Ported from https://github.com/ynput/OpenPype/pull/6346

## Additional info

Check code changes

## Testing notes:

1. Check code changes