### PR TITLE
Integrator: Log the filepath if invalidated for being fullpath for clearer log

### DIFF
--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -509,8 +509,11 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         if not is_sequence_representation:
             files = [files]
 
-        if any(os.path.isabs(fname) for fname in files):
-            raise KnownPublishError("Given file names contain full paths")
+        for fname in files:
+            if os.path.isabs(fname):
+                raise KnownPublishError(
+                    f"Representation file names contains full paths: {fname}"
+                )
 
         if not is_sequence_representation:
             return


### PR DESCRIPTION
## Changelog Description

Integrator: Log the filepath if invalidated for being fullpath for clearer log

## Additional info

This makes it easier to debug logs failing due to somehow 'finding' a full path in the data.

## Testing notes:

1. Publish something that for whatever reason sets a fullpath for `instance.data["representations"][0]["files"]` or alike.