### PR TITLE
Fix delivering UDIMs using {udim} in delivery template

### DIFF
--- a/client/ayon_core/lib/path_tools.py
+++ b/client/ayon_core/lib/path_tools.py
@@ -81,7 +81,10 @@ def collect_frames(files):
         dict: {'/folder/product_v001.0001.png': '0001', ....}
     """
 
-    patterns = [clique.PATTERNS["frames"]]
+    # clique.PATTERNS["frames"] supports only `.1001.exr` not `_1001.exr` so
+    # we use a customized pattern.
+    pattern = "[_.](?P<index>(?P<padding>0*)\\d+)\\.\\D+\\d?$"
+    patterns = [pattern]
     collections, remainder = clique.assemble(
         files, minimum_items=1, patterns=patterns)
 


### PR DESCRIPTION
## Changelog Description

Support the `{udim}` key in delivery template to deliver UDIM sequences.

## Additional info

Fixes #905 

## Testing notes:

1. Publish a UDIM sequence from e.g. Substance Painter
2. Run "Deliver Versions" action to deliver the UDIMs

Use e.g. delivery template:
```json
{
  "name": "udims",
  "directory": "{root[work]}/{project[name]}/io_test/{yy}{mm}{dd}",
  "file": "{project[code]}{asset}{subset}{@version}<{output}><.{@frame}><_{udim}>.{ext}"
}
```
![image](https://github.com/user-attachments/assets/7635a70e-5766-4c2e-87cc-ac083a1d8347)

