### PR TITLE
Fix: Not removing absolute path in Maya DL submission

### DIFF
--- a/client/ayon_core/pipeline/farm/pyblish_functions.py
+++ b/client/ayon_core/pipeline/farm/pyblish_functions.py
@@ -788,6 +788,11 @@ def _create_instances_for_aov(instance, skeleton, aov_filter, additional_data,
                 colorspace = product.colorspace
                 break
 
+        if isinstance(files, (list, tuple)):
+            files = [os.path.basename(f) for f in files]
+        else:
+            files = os.path.basename(files)
+
         rep = {
             "name": ext,
             "ext": ext,


### PR DESCRIPTION
## Changelog Description
This occured only in Maya (or DCC with AOV), caused pasting whole absolute path to metadata.json which could cause `Given file names contain full paths` (if ValidateExpectedFiles was disabled). 'files' is expecting only file names, not full paths.


## Testing notes:
1. disable `ValidateExpectedFiles`
2. publish from Maya
3. check metadata.json, shouldn't contain absolute paths, but only file names in `files`
