### PR TITLE
Fix: download referenced representations when synchronizing workfile via SiteSync addon

### DIFF
--- a/client/ayon_core/plugins/publish/integrate_inputlinks.py
+++ b/client/ayon_core/plugins/publish/integrate_inputlinks.py
@@ -9,7 +9,14 @@ from ayon_api import (
 
 
 class IntegrateInputLinksAYON(pyblish.api.ContextPlugin):
-    """Connecting version level dependency links"""
+    """Connecting version level dependency links
+
+    Handles links:
+        - generative - what gets produced from workfile
+        - reference - what was loaded into workfile
+
+    It expects workfile instance is being published.
+    """
 
     order = pyblish.api.IntegratorOrder + 0.2
     label = "Connect Dependency InputLinks AYON"
@@ -47,6 +54,11 @@ class IntegrateInputLinksAYON(pyblish.api.ContextPlugin):
         self.create_links_on_server(context, new_links_by_type)
 
     def split_instances(self, context):
+        """Separates published instances into workfile and other
+
+        Returns:
+            (tuple(pyblish.plugin.Instance), list(pyblish.plugin.Instance))
+        """
         workfile_instance = None
         other_instances = []
 
@@ -83,6 +95,15 @@ class IntegrateInputLinksAYON(pyblish.api.ContextPlugin):
     def create_workfile_links(
         self, workfile_instance, other_instances, new_links_by_type
     ):
+        """Adds links (generative and reference) for workfile.
+
+        Args:
+            workfile_instance (pyblish.plugin.Instance): published workfile
+            other_instances (list[pyblish.plugin.Instance]): other published
+                instances
+            new_links_by_type (dict[str, list[str]): dictionary collecting new
+                created links by its type
+        """
         if workfile_instance is None:
             self.log.warn("No workfile in this publish session.")
             return

--- a/client/ayon_core/plugins/publish/integrate_inputlinks.py
+++ b/client/ayon_core/plugins/publish/integrate_inputlinks.py
@@ -101,7 +101,7 @@ class IntegrateInputLinksAYON(pyblish.api.ContextPlugin):
             workfile_instance (pyblish.plugin.Instance): published workfile
             other_instances (list[pyblish.plugin.Instance]): other published
                 instances
-            new_links_by_type (dict[str, list[str]): dictionary collecting new
+            new_links_by_type (dict[str, list[str]]): dictionary collecting new
                 created links by its type
         """
         if workfile_instance is None:

--- a/client/ayon_core/plugins/publish/integrate_inputlinks.py
+++ b/client/ayon_core/plugins/publish/integrate_inputlinks.py
@@ -97,7 +97,7 @@ class IntegrateInputLinksAYON(pyblish.api.ContextPlugin):
                 instance.data["versionEntity"]["id"],
             )
 
-        loaded_versions = workfile_instance.context.get("loadedVersions")
+        loaded_versions = workfile_instance.context.data.get("loadedVersions")
         if not loaded_versions:
             return
 

--- a/client/ayon_core/tools/loader/models/sitesync.py
+++ b/client/ayon_core/tools/loader/models/sitesync.py
@@ -588,9 +588,6 @@ class SiteSyncModel:
                     if link["entityType"] != "version":
                         continue
                     entity_id = link["entityId"]
-                    # Skip already found linked version ids
-                    if entity_id in linked_version_ids:
-                        continue
                     linked_version_ids.add(entity_id)
                     versions_to_check.add(entity_id)
 

--- a/client/ayon_core/tools/loader/models/sitesync.py
+++ b/client/ayon_core/tools/loader/models/sitesync.py
@@ -578,7 +578,7 @@ class SiteSyncModel:
                 project_name,
                 versions_to_check,
                 link_types=link_types,
-                link_direction="out")
+                link_direction="in")  # looking for 'in'puts for version
 
             versions_to_check = set()
             for links in versions_links.values():

--- a/client/ayon_core/tools/loader/models/sitesync.py
+++ b/client/ayon_core/tools/loader/models/sitesync.py
@@ -512,18 +512,19 @@ class SiteSyncModel:
             "reference"
         )
         for link_repre_id in links:
-            try:
+            if not self._sitesync_addon.is_representation_on_site(
+                project_name,
+                link_repre_id,
+                site_name
+            ):
                 print("Adding {} to linked representation: {}".format(
                     site_name, link_repre_id))
                 self._sitesync_addon.add_site(
                     project_name,
                     link_repre_id,
                     site_name,
-                    force=False
+                    force=True
                 )
-            except Exception:
-                # do not add/reset working site for references
-                log.debug("Site present", exc_info=True)
 
     def _get_linked_representation_id(
         self,

--- a/client/ayon_core/tools/loader/models/sitesync.py
+++ b/client/ayon_core/tools/loader/models/sitesync.py
@@ -1,6 +1,9 @@
 import collections
 
-from ayon_api import get_representations, get_versions_links
+from ayon_api import (
+    get_representations,
+    get_versions_links,
+)
 
 from ayon_core.lib import Logger, NestedCacheItem
 from ayon_core.addon import AddonsManager


### PR DESCRIPTION
## Changelog Description
When workfile representation is being downloaded with SiteSync addon, it should also download all referenced, eg loaded representations if they are not present on target site.

## Additional information
No need to test it in Maya, links should work in any DCC.

## Testing notes:
1. enable SiteSync addon, set studio-studio in Site Settings
1. publish workfile with something loaded via Loader
2. this should create `reference` link between workfile and loaded representation (could be checked by Node Addon??)
3. switch Site Settings to `local` - `studio` (to actually engage syncing) and set there your root folder for your local site ( restart Tray)
4. go to Loader, find published workfile from step 1 and `Download` it (bottom right corner)
5. it should eventually download both workfile and referenced representation
