### PR TITLE
Add cinema4d to OCIO prelaunch hook

### DIFF
--- a/client/ayon_core/hooks/pre_ocio_hook.py
+++ b/client/ayon_core/hooks/pre_ocio_hook.py
@@ -19,7 +19,8 @@ class OCIOEnvHook(PreLaunchHook):
         "nuke",
         "hiero",
         "resolve",
-        "openrv"
+        "openrv",
+        "cinema4d"
     }
     launch_types = set()
 

--- a/client/ayon_core/pipeline/constants.py
+++ b/client/ayon_core/pipeline/constants.py
@@ -9,6 +9,7 @@ AVALON_INSTANCE_ID = "pyblish.avalon.instance"
 HOST_WORKFILE_EXTENSIONS = {
     "blender": [".blend"],
     "celaction": [".scn"],
+    "cinema4d": [".c4d"],
     "tvpaint": [".tvpp"],
     "fusion": [".comp"],
     "harmony": [".zip"],

--- a/client/ayon_core/plugins/publish/validate_file_saved.py
+++ b/client/ayon_core/plugins/publish/validate_file_saved.py
@@ -36,7 +36,8 @@ class ValidateCurrentSaveFile(pyblish.api.ContextPlugin):
 
     label = "Validate File Saved"
     order = pyblish.api.ValidatorOrder - 0.1
-    hosts = ["fusion", "houdini", "max", "maya", "nuke", "substancepainter"]
+    hosts = ["fusion", "houdini", "max", "maya", "nuke", "substancepainter",
+             "cinema4d"]
     actions = [SaveByVersionUpAction, ShowWorkfilesAction]
 
     def process(self, context):


### PR DESCRIPTION
## Changelog Description

Set up the OCIO env vars on launch of Cinema4D application with `ayon-cinema4d` integration.

## Additional info

Related to https://github.com/ynput/ayon-applications/pull/36

## Testing notes:

1. OCIO env var should be set on launching Cinema4D