### PR TITLE
improved OIIO subimages handling

### DIFF
--- a/client/ayon_core/lib/transcoding.py
+++ b/client/ayon_core/lib/transcoding.py
@@ -1152,9 +1152,7 @@ def convert_colorspace(
         input_arg, input_path,
         # Tell oiiotool which channels should be put to top stack
         #   (and output)
-        "--ch", channels_arg,
-        # Use first subimage
-        "--subimage", "0"
+        "--ch", channels_arg
     ])
 
     if all([target_colorspace, view, display]):
@@ -1168,12 +1166,12 @@ def convert_colorspace(
         oiio_cmd.extend(additional_command_args)
 
     if target_colorspace:
-        oiio_cmd.extend(["--colorconvert",
+        oiio_cmd.extend(["--colorconvert:subimages=0",
                          source_colorspace,
                          target_colorspace])
     if view and display:
         oiio_cmd.extend(["--iscolorspace", source_colorspace])
-        oiio_cmd.extend(["--ociodisplay", display, view])
+        oiio_cmd.extend(["--ociodisplay:subimages=0", display, view])
 
     oiio_cmd.extend(["-o", output_path])
 


### PR DESCRIPTION
## Changelog Description
Ayon's OIIOtool handling currently removes all subimages (all AOVs that aren't RGBA). This PR does the following: 

- takes out the argument that restricts to 1 subimage
- modifies the colour conversion arguments to only occur on the first subimage (rgba). 
 
The results of the OIIOtool will be unchanged, unless the input files have >1 subimages and the OIIOtool argument "-a" is added (should this be documented somewhere?). Then, extra channels will pass through the transcode, and can have reformats etc applied if desired.

## Additional info
To have subimages identified, inputs must be a proper multipart EXR. In Nuke, this can be done by setting "interleave" to "channels" in the write node (very easy to define in the Ayon Nuke addon). Don't forget to set your channels to "all"!

## Testing notes:
1. Configure an Extract OIIO Transcode profile for a multipart exr (see additional info for more)
2. Add "-a" into the profile's OIIOtool arguments
3. Check that your extra AOVs have survived the transcode process