### PR TITLE
Raise Publisher UI to front when already opened

### DIFF
--- a/client/ayon_core/tools/utils/host_tools.py
+++ b/client/ayon_core/tools/utils/host_tools.py
@@ -252,6 +252,9 @@ class HostToolsHelper:
             if tab:
                 window.set_current_tab(tab)
             window.make_sure_is_visible()
+            window.raise_()
+            window.activateWindow()
+            window.showNormal()
 
     def get_tool_by_name(self, tool_name, parent=None, *args, **kwargs):
         """Show tool by it's name.


### PR DESCRIPTION
## Changelog Description

Make Publisher UI raised to the front when clicking `AYON > Create…` or `AYON > Publish...` in host integrations if it was already opened.

## Additional info

Especially useful for integrations that do not have Qt UI to parent to and the publisher UI sometimes going behind the DCC itself, etc.

## Testing notes:

1. Publisher UI should raise to the front when currently behind another window (or behind the DCC window)
2. Publisher UI should still work across different integrations.
