### PR TITLE
Chore: Remove 'HOST_WORKFILE_EXTENSIONS'

### DIFF
--- a/client/ayon_core/pipeline/__init__.py
+++ b/client/ayon_core/pipeline/__init__.py
@@ -3,7 +3,6 @@ from .constants import (
     AVALON_INSTANCE_ID,
     AYON_CONTAINER_ID,
     AYON_INSTANCE_ID,
-    HOST_WORKFILE_EXTENSIONS,
 )
 
 from .anatomy import Anatomy
@@ -114,7 +113,6 @@ __all__ = (
     "AVALON_INSTANCE_ID",
     "AYON_CONTAINER_ID",
     "AYON_INSTANCE_ID",
-    "HOST_WORKFILE_EXTENSIONS",
 
     # --- Anatomy ---
     "Anatomy",

--- a/client/ayon_core/pipeline/constants.py
+++ b/client/ayon_core/pipeline/constants.py
@@ -4,21 +4,3 @@ AYON_INSTANCE_ID = "ayon.create.instance"
 # Backwards compatibility
 AVALON_CONTAINER_ID = "pyblish.avalon.container"
 AVALON_INSTANCE_ID = "pyblish.avalon.instance"
-
-# TODO get extensions from host implementations
-HOST_WORKFILE_EXTENSIONS = {
-    "blender": [".blend"],
-    "celaction": [".scn"],
-    "cinema4d": [".c4d"],
-    "tvpaint": [".tvpp"],
-    "fusion": [".comp"],
-    "harmony": [".zip"],
-    "houdini": [".hip", ".hiplc", ".hipnc"],
-    "maya": [".ma", ".mb"],
-    "nuke": [".nk"],
-    "hiero": [".hrox"],
-    "photoshop": [".psd", ".psb"],
-    "premiere": [".prproj"],
-    "resolve": [".drp"],
-    "aftereffects": [".aep"]
-}


### PR DESCRIPTION
## Changelog Description
Constant `HOST_WORKFILE_EXTENSIONS` is deprecated and unused for a long time. It is time to remove it.

## Additional info
Workfile extensions are defined by host addons by implementing `get_workfile_extensions`.

## Testing notes:
1. Validate `HOST_WORKFILE_EXTENSIONS` is not really used.
2. Validate changes.
