### PR TITLE
Publish Maya rig USD contribution directly into USD asset

### DIFF
--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -308,6 +308,8 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
             instance.data.get("productGroup") or "USD Layer"
         )
 
+        instance.data["has_usd_contribution"] = True
+
         # Allow formatting in variant set name and variant name
         data = instance.data.copy()
         data["layer"] = attr_values["contribution_layer"]
@@ -558,6 +560,27 @@ class CollectUSDLayerContributionsHoudiniLook(CollectUSDLayerContributions):
         # Update default for department layer to look
         layer_def = next(d for d in defs if d.key == "contribution_layer")
         layer_def.default = "look"
+
+        return defs
+
+
+class CollectUSDLayerContributionsMayaRig(CollectUSDLayerContributions):
+    """
+    This is solely here to expose the attribute definitions for the
+    Houdini "look" family.
+    """
+    # TODO: Improve how this is built for the rig family
+    hosts = ["maya"]
+    families = ["rig"]
+    label = CollectUSDLayerContributions.label + " (Rig)"
+
+    @classmethod
+    def get_attribute_defs(cls):
+        defs = super().get_attribute_defs()
+
+        # Update default for department layer to look
+        layer_def = next(d for d in defs if d.key == "contribution_layer")
+        layer_def.default = "rig"
 
         return defs
 


### PR DESCRIPTION
…ork to publish the loaded assets as animation instances directly into the shots

## Changelog Description

Publish Maya rig USD contribution directly into USD asset

## Additional info

Requires https://github.com/ynput/ayon-maya/pull/132

## Testing notes:

_TODO_

1. start with this step
2. follow this step
