### PR TITLE
Allow representation switch on update if representation does not exist

### DIFF
--- a/client/ayon_core/pipeline/load/plugins.py
+++ b/client/ayon_core/pipeline/load/plugins.py
@@ -242,6 +242,26 @@ class LoaderPlugin(list):
         if hasattr(self, "_fname"):
             return self._fname
 
+    def update_allowed_representation_switches(self):
+        """Return a mapping from source representation names to ordered
+        destination representation names to which switching is allowed if
+        the source representation name does not exist for the new version.
+
+        For example, to allow an automated switch on update from representation
+        `ma` to `mb` or `abc` if the new version does not have a `ma`
+        representation you can return:
+            {"ma": ["mb", "abc"]}
+
+        The order of the names in the returned values is important, because
+        if `ma` is missing and both of the replacement representations are
+        present than the first one will be chosen.
+
+        Returns:
+            Dict[str, List[str]]: Mapping from representation names to allowed
+                alias representation names switching to is allowed on update.
+        """
+        return {}
+
 
 class ProductLoaderPlugin(LoaderPlugin):
     """Load product into host application

--- a/client/ayon_core/pipeline/load/utils.py
+++ b/client/ayon_core/pipeline/load/utils.py
@@ -505,21 +505,6 @@ def update_container(container, version=-1):
         project_name, product_entity["folderId"]
     )
 
-    repre_name = current_representation["name"]
-    new_representation = ayon_api.get_representation_by_name(
-        project_name, repre_name, new_version["id"]
-    )
-    if new_representation is None:
-        raise ValueError(
-            "Representation '{}' wasn't found on requested version".format(
-                repre_name
-            )
-        )
-
-    path = get_representation_path(new_representation)
-    if not path or not os.path.exists(path):
-        raise ValueError("Path {} doesn't exist".format(path))
-
     # Run update on the Loader for this container
     Loader = _get_container_loader(container)
     if not Loader:
@@ -527,6 +512,40 @@ def update_container(container, version=-1):
             "Can't update container because loader '{}' was not found."
             .format(container.get("loader"))
         )
+
+    repre_name = current_representation["name"]
+    new_representation = ayon_api.get_representation_by_name(
+        project_name, repre_name, new_version["id"]
+    )
+    if new_representation is None:
+        # The representation name is not found in the new version.
+        # Allow updating to a 'matching' representation if the loader
+        # has defined compatible update conversions
+        mapping = Loader.update_allowed_representation_switches()
+        switch_repre_names = mapping.get(repre_name)
+        if switch_repre_names:
+            representations = ayon_api.get_representations(
+                project_name,
+                representation_names=switch_repre_names,
+                version_ids=[new_version["id"]])
+            representations_by_name = {
+                repre["name"]: repre for repre in representations
+            }
+            for name in switch_repre_names:
+                if name in representations_by_name:
+                    new_representation = representations_by_name[name]
+                    break
+
+        if new_representation is None:
+            raise ValueError(
+                "Representation '{}' wasn't found on requested version".format(
+                    repre_name
+                )
+            )
+
+    path = get_representation_path(new_representation)
+    if not path or not os.path.exists(path):
+        raise ValueError("Path {} doesn't exist".format(path))
     project_entity = ayon_api.get_project(project_name)
     context = {
         "project": project_entity,


### PR DESCRIPTION
## Changelog Description

Allow representation switch on update if representation does not exist (e.g. `ma` -> `mb` representation)

## Additional info

Fixes https://github.com/ynput/ayon-maya/issues/111

## Testing notes:

1. start with this step
2. follow this step
