### PR TITLE
Fix NTSC framerates floating issue comparison.

### DIFF
--- a/client/ayon_core/pipeline/editorial.py
+++ b/client/ayon_core/pipeline/editorial.py
@@ -292,13 +292,23 @@ def get_media_range_with_retimes(otio_clip, handle_start, handle_end):
     # Note that 24fps is slower than 25fps hence extended duration
     # to preserve media range
 
-    # Compute new source range based on available rate
-    conformed_src_in = source_range.start_time.rescaled_to(available_range_rate)
-    conformed_src_duration = source_range.duration.rescaled_to(available_range_rate)
-    conformed_source_range = otio.opentime.TimeRange(
-        start_time=conformed_src_in,
-        duration=conformed_src_duration
-    )
+    # Compute new source range based on available rate.
+    # NSTC compatibility might introduce floating rates, when these are
+    # not exactly the same (23.976 vs 23.976024627685547)
+    # this will cause precision issue in computation.
+    # Round to 2 decimals for comparison.
+    rounded_av_rate = round(available_range_rate, 2)
+    rounded_src_rate = round(source_range.start_time.rate, 2)
+    if rounded_av_rate != rounded_src_rate:
+        conformed_src_in = source_range.start_time.rescaled_to(available_range_rate)
+        conformed_src_duration = source_range.duration.rescaled_to(available_range_rate)
+        conformed_source_range = otio.opentime.TimeRange(
+            start_time=conformed_src_in,
+            duration=conformed_src_duration
+        )
+
+    else:
+        conformed_source_range = source_range
 
     # modifiers
     time_scalar = 1.

--- a/client/ayon_core/pipeline/editorial.py
+++ b/client/ayon_core/pipeline/editorial.py
@@ -293,10 +293,13 @@ def get_media_range_with_retimes(otio_clip, handle_start, handle_end):
     # to preserve media range
 
     # Compute new source range based on available rate.
+
+    # Backward-compatibility for Hiero OTIO exporter.
     # NTSC compatibility might introduce floating rates, when these are
     # not exactly the same (23.976 vs 23.976024627685547)
     # this will cause precision issue in computation.
-    # Round to 2 decimals for comparison.
+    # Currently round to 2 decimals for comparison,
+    # but this should always rescale after that.
     rounded_av_rate = round(available_range_rate, 2)
     rounded_src_rate = round(source_range.start_time.rate, 2)
     if rounded_av_rate != rounded_src_rate:

--- a/client/ayon_core/pipeline/editorial.py
+++ b/client/ayon_core/pipeline/editorial.py
@@ -293,7 +293,7 @@ def get_media_range_with_retimes(otio_clip, handle_start, handle_end):
     # to preserve media range
 
     # Compute new source range based on available rate.
-    # NSTC compatibility might introduce floating rates, when these are
+    # NTSC compatibility might introduce floating rates, when these are
     # not exactly the same (23.976 vs 23.976024627685547)
     # this will cause precision issue in computation.
     # Round to 2 decimals for comparison.

--- a/tests/client/ayon_core/pipeline/editorial/resources/img_seq_23.976_metadata.json
+++ b/tests/client/ayon_core/pipeline/editorial/resources/img_seq_23.976_metadata.json
@@ -1,0 +1,255 @@
+{
+    "OTIO_SCHEMA": "Clip.2",
+    "metadata": {
+        "active": true,
+        "applieswhole": 1,
+        "asset": "sh020",
+        "audio": true,
+        "families": [
+            "clip"
+        ],
+        "family": "plate",
+        "handleEnd": 8,
+        "handleStart": 0,
+        "heroTrack": true,
+        "hierarchy": "shots/sq001",
+        "hierarchyData": {
+            "episode": "ep01",
+            "folder": "shots",
+            "sequence": "sq001",
+            "shot": "sh020",
+            "track": "reference"
+        },
+        "hiero_source_type": "TrackItem",
+        "id": "pyblish.avalon.instance",
+        "label": "openpypeData",
+        "note": "OpenPype data container",
+        "parents": [
+            {
+                "entity_name": "shots",
+                "entity_type": "folder"
+            },
+            {
+                "entity_name": "sq001",
+                "entity_type": "sequence"
+            }
+        ],
+        "publish": true,
+        "reviewTrack": null,
+        "sourceResolution": false,
+        "subset": "plateP01",
+        "variant": "Main",
+        "workfileFrameStart": 1001
+    },
+    "name": "sh020",
+    "source_range": {
+        "OTIO_SCHEMA": "TimeRange.1",
+        "duration": {
+            "OTIO_SCHEMA": "RationalTime.1",
+            "rate": 23.976024627685547,
+            "value": 51.0
+        },
+        "start_time": {
+            "OTIO_SCHEMA": "RationalTime.1",
+            "rate": 23.976024627685547,
+            "value": 0.0
+        }
+    },
+    "effects": [],
+    "markers": [
+        {
+            "OTIO_SCHEMA": "Marker.2",
+            "metadata": {
+                "active": true,
+                "applieswhole": 1,
+                "asset": "sh020",
+                "audio": true,
+                "families": [
+                    "clip"
+                ],
+                "family": "plate",
+                "handleEnd": 8,
+                "handleStart": 0,
+                "heroTrack": true,
+                "hierarchy": "shots/sq001",
+                "hierarchyData": {
+                    "episode": "ep01",
+                    "folder": "shots",
+                    "sequence": "sq001",
+                    "shot": "sh020",
+                    "track": "reference"
+                },
+                "hiero_source_type": "TrackItem",
+                "id": "pyblish.avalon.instance",
+                "label": "openpypeData",
+                "note": "OpenPype data container",
+                "parents": [
+                    {
+                        "entity_name": "shots",
+                        "entity_type": "folder"
+                    },
+                    {
+                        "entity_name": "sq001",
+                        "entity_type": "sequence"
+                    }
+                ],
+                "publish": true,
+                "reviewTrack": null,
+                "sourceResolution": false,
+                "subset": "plateP01",
+                "variant": "Main",
+                "workfileFrameStart": 1001
+            },
+            "name": "openpypeData",
+            "color": "RED",
+            "marked_range": {
+                "OTIO_SCHEMA": "TimeRange.1",
+                "duration": {
+                    "OTIO_SCHEMA": "RationalTime.1",
+                    "rate": 23.976024627685547,
+                    "value": 0.0
+                },
+                "start_time": {
+                    "OTIO_SCHEMA": "RationalTime.1",
+                    "rate": 23.976024627685547,
+                    "value": 0.0
+                }
+            }
+        },
+        {
+            "OTIO_SCHEMA": "Marker.2",
+            "metadata": {
+                "applieswhole": 1,
+                "family": "task",
+                "hiero_source_type": "TrackItem",
+                "label": "comp",
+                "note": "Compositing",
+                "type": "Compositing"
+            },
+            "name": "comp",
+            "color": "RED",
+            "marked_range": {
+                "OTIO_SCHEMA": "TimeRange.1",
+                "duration": {
+                    "OTIO_SCHEMA": "RationalTime.1",
+                    "rate": 23.976024627685547,
+                    "value": 0.0
+                },
+                "start_time": {
+                    "OTIO_SCHEMA": "RationalTime.1",
+                    "rate": 23.976024627685547,
+                    "value": 0.0
+                }
+            }
+        }
+    ],
+    "enabled": true,
+    "media_references": {
+        "DEFAULT_MEDIA": {
+            "OTIO_SCHEMA": "ImageSequenceReference.1",
+            "metadata": {
+                "clip.properties.blendfunc": "0",
+                "clip.properties.colourspacename": "default",
+                "clip.properties.domainroot": "",
+                "clip.properties.enabled": "1",
+                "clip.properties.expanded": "1",
+                "clip.properties.opacity": "1",
+                "clip.properties.valuesource": "",
+                "foundry.source.audio": "",
+                "foundry.source.bitmapsize": "0",
+                "foundry.source.bitsperchannel": "0",
+                "foundry.source.channelformat": "integer",
+                "foundry.source.colourtransform": "ACES - ACES2065-1",
+                "foundry.source.duration": "59",
+                "foundry.source.filename": "MER_sq001_sh020_P01.%04d.exr 997-1055",
+                "foundry.source.filesize": "",
+                "foundry.source.fragments": "59",
+                "foundry.source.framerate": "23.98",
+                "foundry.source.fullpath": "",
+                "foundry.source.height": "1080",
+                "foundry.source.layers": "colour",
+                "foundry.source.path": "C:/projects/AY01_VFX_demo/resources/plates/MER_sq001_sh020_P01/MER_sq001_sh020_P01.%04d.exr 997-1055",
+                "foundry.source.pixelAspect": "1",
+                "foundry.source.pixelAspectRatio": "",
+                "foundry.source.pixelformat": "RGBA (Float16)  Open Color IO space: 11",
+                "foundry.source.reelID": "",
+                "foundry.source.resolution": "",
+                "foundry.source.samplerate": "Invalid",
+                "foundry.source.shortfilename": "MER_sq001_sh020_P01.%04d.exr 997-1055",
+                "foundry.source.shot": "",
+                "foundry.source.shotDate": "",
+                "foundry.source.startTC": "",
+                "foundry.source.starttime": "997",
+                "foundry.source.timecode": "172800",
+                "foundry.source.umid": "1bf7437a-b446-440c-07c5-7cae7acf4f5e",
+                "foundry.source.umidOriginator": "foundry.source.umid",
+                "foundry.source.width": "1920",
+                "foundry.timeline.autodiskcachemode": "Manual",
+                "foundry.timeline.colorSpace": "ACES - ACES2065-1",
+                "foundry.timeline.duration": "59",
+                "foundry.timeline.framerate": "23.98",
+                "foundry.timeline.outputformat": "",
+                "foundry.timeline.poster": "0",
+                "foundry.timeline.posterLayer": "colour",
+                "foundry.timeline.readParams": "AAAAAQAAAAAAAAAFAAAACmNvbG9yc3BhY2UAAAAFaW50MzIAAAAMAAAAC2VkZ2VfcGl4ZWxzAAAABWludDMyAAAAAAAAABFpZ25vcmVfcGFydF9uYW1lcwAAAARib29sAAAAAAhub3ByZWZpeAAAAARib29sAAAAAB5vZmZzZXRfbmVnYXRpdmVfZGlzcGxheV93aW5kb3cAAAAEYm9vbAE=",
+                "foundry.timeline.samplerate": "Invalid",
+                "isSequence": true,
+                "media.exr.channels": "B:{1 0 1 1},G:{1 0 1 1},R:{1 0 1 1}",
+                "media.exr.compression": "8",
+                "media.exr.compressionName": "DWAA",
+                "media.exr.dataWindow": "0,0,1919,1079",
+                "media.exr.displayWindow": "0,0,1919,1079",
+                "media.exr.dwaCompressionLevel": "90",
+                "media.exr.lineOrder": "0",
+                "media.exr.pixelAspectRatio": "1",
+                "media.exr.screenWindowCenter": "0,0",
+                "media.exr.screenWindowWidth": "1",
+                "media.exr.type": "scanlineimage",
+                "media.exr.version": "1",
+                "media.input.bitsperchannel": "16-bit half float",
+                "media.input.ctime": "2022-04-21 11:56:03",
+                "media.input.filename": "C:/projects/AY01_VFX_demo/resources/plates/MER_sq001_sh020_P01/MER_sq001_sh020_P01.0997.exr",
+                "media.input.filereader": "exr",
+                "media.input.filesize": "1235182",
+                "media.input.frame": "1",
+                "media.input.frame_rate": "23.976",
+                "media.input.height": "1080",
+                "media.input.mtime": "2022-03-06 10:14:41",
+                "media.input.timecode": "02:00:00:00",
+                "media.input.width": "1920",
+                "media.nuke.full_layer_names": "0",
+                "media.nuke.node_hash": "ffffffffffffffff",
+                "media.nuke.version": "12.2v3",
+                "openpype.source.colourtransform": "ACES - ACES2065-1",
+                "openpype.source.height": 1080,
+                "openpype.source.pixelAspect": 1.0,
+                "openpype.source.width": 1920,
+                "padding": 4
+            },
+            "name": "",
+            "available_range": {
+                "OTIO_SCHEMA": "TimeRange.1",
+                "duration": {
+                    "OTIO_SCHEMA": "RationalTime.1",
+                    "rate": 23.976,
+                    "value": 59.0
+                },
+                "start_time": {
+                    "OTIO_SCHEMA": "RationalTime.1",
+                    "rate": 23.976,
+                    "value": 997.0
+                }
+            },
+            "available_image_bounds": null,
+            "target_url_base": "C:/projects/AY01_VFX_demo/resources/plates/MER_sq001_sh020_P01\\",
+            "name_prefix": "MER_sq001_sh020_P01.",
+            "name_suffix": ".exr",
+            "start_frame": 997,
+            "frame_step": 1,
+            "rate": 23.976,
+            "frame_zero_padding": 4,
+            "missing_frame_policy": "error"
+        }
+    },
+    "active_media_reference_key": "DEFAULT_MEDIA"
+}

--- a/tests/client/ayon_core/pipeline/editorial/test_media_range_with_retimes.py
+++ b/tests/client/ayon_core/pipeline/editorial/test_media_range_with_retimes.py
@@ -166,3 +166,24 @@ def test_img_sequence_relative_source_range():
         "legacy_img_sequence.json",
         expected_data
     )
+
+def test_img_sequence_conform_to_23_976fps():
+    """
+    Img sequence clip
+    available files = 997-1047 23.976fps
+    source_range =  997-1055 23.976024627685547fps
+    """
+    expected_data = {
+        'mediaIn': 997,
+        'mediaOut': 1047,
+        'handleStart': 0,
+        'handleEnd': 8,
+        'speed': 1.0
+    }
+
+    _check_expected_retimed_values(
+        "img_seq_23.976_metadata.json",
+        expected_data,
+        handle_start=0,
+        handle_end=8,
+    )


### PR DESCRIPTION
## Changelog Description

Fixes issue reported by @jakubjezek001 on Discord when source_range and available_range rates are technically the same rate but not exactly the same value in the OTIO exported file.

### Testing
1. Run the unit tests
run `.\tools\manage.ps1 run pytest .\tests\client\ayon_core\pipeline\editorial\` (windows)
run `.\tools\manage.sh run pytest .\tests\client\ayon_core\pipeline\editorial\` (linux)