### PR TITLE
USD Contribution Workflow: Show/hide attributes per instance based on status of other toggles

### DIFF
--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -458,7 +458,22 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
         return new_instance
 
     @classmethod
-    def get_attribute_defs(cls):
+    def get_attr_defs_for_instance(cls, create_context, instance):
+        # Filtering of instance, if needed, can be customized
+        if not cls.instance_matches_plugin_families(instance):
+            return []
+
+        # Attributes logic
+        disabled = False
+        publish_attributes = instance["publish_attributes"].get(
+            cls.__name__, {})
+
+        enabled = publish_attributes.get("contribution_enabled", True)
+        variant_enabled = enabled and publish_attributes.get(
+            "contribution_apply_as_variant", True)
+
+        disabled = not enabled
+        variant_disabled = not variant_enabled
 
         return [
             UISeparatorDef("usd_container_settings1"),
@@ -484,7 +499,8 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                         "the contribution itself will be added to the "
                         "department layer."
                     ),
-                    default="usdAsset"),
+                    default="usdAsset",
+                    hidden=disabled),
             EnumDef("contribution_target_product_init",
                     label="Initialize as",
                     tooltip=(
@@ -495,7 +511,8 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                         "setting will do nothing."
                     ),
                     items=["asset", "shot"],
-                    default="asset"),
+                    default="asset",
+                    hidden=disabled),
 
             # Asset layer, e.g. model.usd, look.usd, rig.usd
             EnumDef("contribution_layer",
@@ -507,7 +524,8 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                         "the list) will contribute as a stronger opinion."
                     ),
                     items=list(cls.contribution_layers.keys()),
-                    default="model"),
+                    default="model",
+                    hidden=disabled),
             BoolDef("contribution_apply_as_variant",
                     label="Add as variant",
                     tooltip=(
@@ -518,13 +536,16 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                         "appended to as a sublayer to the department layer "
                         "instead."
                     ),
-                    default=True),
+                    default=True,
+                    hidden=disabled),
             TextDef("contribution_variant_set_name",
                     label="Variant Set Name",
-                    default="{layer}"),
+                    default="{layer}",
+                    hidden=variant_disabled),
             TextDef("contribution_variant",
                     label="Variant Name",
-                    default="{variant}"),
+                    default="{variant}",
+                    hidden=variant_disabled),
             BoolDef("contribution_variant_is_default",
                     label="Set as default variant selection",
                     tooltip=(
@@ -535,9 +556,40 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                         "The behavior is unpredictable if multiple instances "
                         "for the same variant set have this enabled."
                     ),
-                    default=False),
+                    default=False,
+                    hidden=variant_disabled),
             UISeparatorDef("usd_container_settings3"),
         ]
+
+    @classmethod
+    def register_create_context_callbacks(cls, create_context):
+        create_context.add_value_changed_callback(cls.on_values_changed)
+
+    @classmethod
+    def on_values_changed(cls, event):
+        """Update instance attribute definitions on attribute changes."""
+
+        # Update attributes if any of the following plug-in attributes
+        # change:
+        keys = ["contribution_enabled", "contribution_apply_as_variant"]
+
+        for instance_change in event["changes"]:
+            instance = instance_change["instance"]
+            if not cls.instance_matches_plugin_families(instance):
+                continue
+            value_changes = instance_change["changes"]
+            plugin_attribute_changes = (
+                value_changes.get("publish_attributes", {})
+                .get(cls.__name__, {}))
+
+            if not any(key in plugin_attribute_changes for key in keys):
+                continue
+
+            # Update the attribute definitions
+            new_attrs = cls.get_attr_defs_for_instance(
+                event["create_context"], instance
+            )
+            instance.set_publish_plugin_attr_defs(cls.__name__, new_attrs)
 
 
 class CollectUSDLayerContributionsHoudiniLook(CollectUSDLayerContributions):
@@ -551,9 +603,8 @@ class CollectUSDLayerContributionsHoudiniLook(CollectUSDLayerContributions):
     label = CollectUSDLayerContributions.label + " (Look)"
 
     @classmethod
-    def get_attribute_defs(cls):
-        defs = super(CollectUSDLayerContributionsHoudiniLook,
-                     cls).get_attribute_defs()
+    def get_attr_defs_for_instance(cls, create_context, instance):
+        defs = super().get_attr_defs_for_instance(create_context, instance)
 
         # Update default for department layer to look
         layer_def = next(d for d in defs if d.key == "contribution_layer")


### PR DESCRIPTION
## Changelog Description

Show/hide attributes per instance for the USD contribution workflow based on status of other toggles in the Publisher UI.

## Additional info

Requires PR https://github.com/ynput/ayon-core/pull/935

(Note: This PR targets that PR's branch, just so the diff on Github is small. I'll leave it in draft until that is merged - but it allows this branch to be updated along and tested if needed. It'll act as a code reference on how the feature could be used.)

## Testing notes:

1. Create USD instance in Maya, Houdini or Blender
2. The attributes should update on toggling on/off the toggles for Contribution Worfklow.
3. Extra test: USD Look publishing in Houdini should still work.

See screenshots:

![image](https://github.com/user-attachments/assets/1450cf3d-9f67-47dc-b16c-d5c16c4d67a7)
![image](https://github.com/user-attachments/assets/9d3b10a7-1f28-466f-bc74-80b303f948fb)
![image](https://github.com/user-attachments/assets/9f3736fa-3d7a-43fa-b428-2c649806320e)

