### PR TITLE
Thumbnails: add Unreal to hosts

### DIFF
--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -36,7 +36,8 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         "traypublisher",
         "substancepainter",
         "nuke",
-        "aftereffects"
+        "aftereffects",
+        "unreal"
     ]
     enabled = False
 


### PR DESCRIPTION
## Changelog Description
Unreal can do local rendering/publishing too, enabling thumbnails for renders

## Testing notes:
1. Publish local render from unreal
2. Observe nice and shiny thumbnail
