### PR TITLE
Delivery: Fill hierarchy data unused during publishing

### DIFF
--- a/client/ayon_core/pipeline/delivery.py
+++ b/client/ayon_core/pipeline/delivery.py
@@ -4,14 +4,13 @@ import copy
 import shutil
 import glob
 import collections
-from typing import List, Dict, Any, Iterable
+from typing import Dict, Any, Iterable
 
 import clique
 import ayon_api
 
 from ayon_core.lib import create_hard_link
 
-from .anatomy import Anatomy
 from .template_data import (
     get_general_template_data,
     get_folder_template_data,

--- a/client/ayon_core/pipeline/delivery.py
+++ b/client/ayon_core/pipeline/delivery.py
@@ -3,10 +3,20 @@ import os
 import copy
 import shutil
 import glob
-import clique
 import collections
+from typing import List, Dict, Any, Iterable
+
+import clique
+import ayon_api
 
 from ayon_core.lib import create_hard_link
+
+from .anatomy import Anatomy
+from .template_data import (
+    get_general_template_data,
+    get_folder_template_data,
+    get_task_template_data,
+)
 
 
 def _copy_file(src_path, dst_path):
@@ -327,3 +337,71 @@ def deliver_sequence(
         uploaded += 1
 
     return report_items, uploaded
+
+
+def _merge_data(data, new_data):
+    queue = collections.deque()
+    queue.append((data, new_data))
+    while queue:
+        q_data, q_new_data = queue.popleft()
+        for key, value in q_new_data.items():
+            if key in q_data and isinstance(value, dict):
+                queue.append((q_data[key], value))
+                continue
+            q_data[key] = value
+
+
+def get_representations_delivery_template_data(
+    project_name: str,
+    representation_ids: Iterable[str],
+) -> Dict[str, Dict[str, Any]]:
+    representation_ids = set(representation_ids)
+
+    output = {
+        repre_id: {}
+        for repre_id in representation_ids
+    }
+    if not representation_ids:
+        return output
+
+    project_entity = ayon_api.get_project(project_name)
+
+    general_template_data = get_general_template_data()
+
+    repres_hierarchy = ayon_api.get_representations_hierarchy(
+        project_name,
+        representation_ids,
+        project_fields=set(),
+        folder_fields={"path", "folderType"},
+        task_fields={"name", "taskType"},
+        product_fields={"name", "productType"},
+        version_fields={"version", "productId"},
+        representation_fields=None,
+    )
+    for repre_id, repre_hierarchy in repres_hierarchy.items():
+        repre_entity = repre_hierarchy.representation
+        if repre_entity is None:
+            continue
+
+        template_data = repre_entity["context"]
+        template_data.update(copy.deepcopy(general_template_data))
+        template_data.update(get_folder_template_data(
+            repre_hierarchy.folder, project_name
+        ))
+        if repre_hierarchy.task:
+            template_data.update(get_task_template_data(
+                project_entity, repre_hierarchy.task
+            ))
+
+        product_entity = repre_hierarchy.product
+        version_entity = repre_hierarchy.version
+        template_data.update({
+            "product": {
+                "name": product_entity["name"],
+                "type": product_entity["productType"],
+            },
+            "version": version_entity["version"],
+        })
+        _merge_data(template_data, repre_entity["context"])
+        output[repre_id] = template_data
+    return output

--- a/client/ayon_core/plugins/load/delivery.py
+++ b/client/ayon_core/plugins/load/delivery.py
@@ -16,7 +16,7 @@ from ayon_core.pipeline.delivery import (
     get_format_dict,
     check_destination_path,
     deliver_single_file,
-    get_representations_template_data,
+    get_representations_delivery_template_data,
 )
 
 
@@ -206,8 +206,10 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
                 filtered_repres.append(repre)
                 repre_ids.add(repre["id"])
 
-        template_data_by_repre_id = get_representations_template_data(
-            self.anatomy.project_name, repre_ids
+        template_data_by_repre_id = (
+            get_representations_delivery_template_data(
+                self.anatomy.project_name, repre_ids
+            )
         )
         for repre in filtered_repres:
             repre_path = get_representation_path_with_anatomy(

--- a/client/ayon_core/plugins/load/delivery.py
+++ b/client/ayon_core/plugins/load/delivery.py
@@ -1,23 +1,22 @@
-import copy
 import platform
 from collections import defaultdict
 
 import ayon_api
 from qtpy import QtWidgets, QtCore, QtGui
 
-from ayon_core.pipeline import load, Anatomy
 from ayon_core import resources, style
-
 from ayon_core.lib import (
     format_file_size,
     collect_frames,
     get_datetime_data,
 )
+from ayon_core.pipeline import load, Anatomy
 from ayon_core.pipeline.load import get_representation_path_with_anatomy
 from ayon_core.pipeline.delivery import (
     get_format_dict,
     check_destination_path,
-    deliver_single_file
+    deliver_single_file,
+    get_representations_template_data,
 )
 
 

--- a/client/ayon_core/plugins/load/delivery.py
+++ b/client/ayon_core/plugins/load/delivery.py
@@ -350,8 +350,8 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
     def _get_selected_repres(self):
         """Returns list of representation names filtered from checkboxes."""
         selected_repres = []
-        for repre_name, chckbox in self._representation_checkboxes.items():
-            if chckbox.isChecked():
+        for repre_name, checkbox in self._representation_checkboxes.items():
+            if checkbox.isChecked():
                 selected_repres.append(repre_name)
 
         return selected_repres


### PR DESCRIPTION
## Changelog Description
Delivery template data recalculates all entity keys from representation hierarchy.

## Additional info
It is common that representation context, with data used for publish template, does not contain all keys that can be used during delivery. For that purposes was implemented new function `get_representations_delivery_template_data` which prepares the data of representation.

## Notes
We don't have very good delivery api functions, created issue for improvement https://github.com/ynput/ayon-core/issues/953 .

## Testing notes:
1. Deliver template that contains `{parent}` should be possible to use for delivery of representation that didn't have `{parent}` in publish template.

Resolves https://github.com/ynput/ayon-core/issues/929