### PR TITLE
Fix single frame publishing for publish job on farm (to Deadline from e.g. Maya)

### DIFF
--- a/client/ayon_core/pipeline/farm/pyblish_functions.py
+++ b/client/ayon_core/pipeline/farm/pyblish_functions.py
@@ -788,15 +788,15 @@ def _create_instances_for_aov(instance, skeleton, aov_filter, additional_data,
                 colorspace = product.colorspace
                 break
 
-        if isinstance(files, (list, tuple)):
-            files = [os.path.basename(f) for f in files]
+        if isinstance(collected_files, (list, tuple)):
+            collected_files = [os.path.basename(f) for f in collected_files]
         else:
-            files = os.path.basename(files)
+            collected_files = os.path.basename(collected_files)
 
         rep = {
             "name": ext,
             "ext": ext,
-            "files": files,
+            "files": collected_files,
             "frameStart": int(skeleton["frameStartHandle"]),
             "frameEnd": int(skeleton["frameEndHandle"]),
             # If expectedFile are absolute, we need only filenames


### PR DESCRIPTION
## Changelog Description

Fix publishing of single frame render jobs.

## Additional info

Why is this suddenly a new issue? It's due to this PR: https://github.com/ynput/ayon-core/pull/908

That actually fixed a long-standing bug... where a plug-in in Deadline would silently and secretly be fixing it, here: https://github.com/ynput/ayon-deadline/blob/368e2510dc3f8dc904168e51f9afa91c1428986c/client/ayon_deadline/plugins/publish/global/validate_expected_and_rendered_files.py#L74-L77

I couldn't fix this "on collect renders" for Maya - because that'd make it fail here where it still expects it to be a list: https://github.com/ynput/ayon-core/blob/e5fe964178c7fee39f8a62eda98fd5ad583a8213/client/ayon_core/pipeline/farm/tools.py#L80-L88

This likely also fixes it for other hosts that use `instance.data["expectedFiles"]` with the value being `list[dict[str, list[str]]]` (Basically the files per AOV, where the list of filenames is `list[str]` but the integrator and other areas really want a single `str` insteaf of `list[str]` if it's a single frame). One host I know that does so, is Houdini render submissions.

Metadata json before this PR for a single frame:
```
...
            "representations": [
                {
                    "colorspaceData": {
                        "colorspace": "ACES - ACEScg",
                        "config": {
                            "path": "C:/Users/User/AppData/Local/Ynput/AYON/addons/ayon_ocio_1.1.1/ayon_ocio/configs/OpenColorIOConfigs/aces_1.2/config.ocio",
                            "template": "C:/Users/User/AppData/Local/Ynput/AYON/addons/ayon_ocio_1.1.1/ayon_ocio/configs/OpenColorIOConfigs/aces_1.2/config.ocio"
                        },
                        "display": "ACES",
                        "view": "sRGB"
                    },
                    "ext": "png",
                    "files": [
                        "Main.1001.png"
                    ],
                    "fps": 25.0,
                    "frameEnd": 1001,
                    "frameStart": 1001,
                    "name": "png",
                    "stagingDir": "{root[work]}/ayontest/asset/char_hero/work/modeling/renders/maya/ynts_char_hero_workfileModeling_v281/Main",
                    "tags": []
                }
            ],
...
```

After this PR:
```
...
                        "representations": [
                {
                    "colorspaceData": {
                        "colorspace": "ACES - ACEScg",
                        "config": {
                            "path": "C:/Users/User/AppData/Local/Ynput/AYON/addons/ayon_ocio_1.1.1/ayon_ocio/configs/OpenColorIOConfigs/aces_1.2/config.ocio",
                            "template": "C:/Users/User/AppData/Local/Ynput/AYON/addons/ayon_ocio_1.1.1/ayon_ocio/configs/OpenColorIOConfigs/aces_1.2/config.ocio"
                        },
                        "display": "ACES",
                        "view": "sRGB"
                    },
                    "ext": "png",
                    "files": "Main.1001.png",
                    "fps": 25.0,
                    "frameEnd": 1001,
                    "frameStart": 1001,
                    "name": "png",
                    "stagingDir": "{root[work]}/ayontest/asset/char_hero/work/modeling/renders/maya/ynts_char_hero_workfileModeling_v281/Main",
                    "tags": []
                }
            ],
...
```

**Note the `files` key now being a single string instead of list of frames.**

Fixes https://github.com/ynput/ayon-maya/issues/150

## Testing notes:

1. Submit single frame render job from maya and houdini
2. It should publish to deadline fine, and the publish job should succeed (with this PR)
(Without this PR it should fail on deadline publish job)

Tested:
- [x] Maya
- [ ] Houdini