### PR TITLE
Create Context: Helper function to get entities

### DIFF
--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -1481,9 +1481,8 @@ class CreateContext:
         }
         remainder_paths = set()
         for folder_path in output:
-            # Skip invalid folder paths (e.g. if only folder name
-            #   is passed in)
-            if "/" not in folder_path:
+            # Skip invalid folder paths (folder name or empty path)
+            if not folder_path or "/" not in folder_path:
                 continue
 
             if folder_path not in self._folder_entities_by_path:

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -1584,24 +1584,24 @@ class CreateContext:
         folder_entities_by_path = self.get_folder_entities(
             missing_folder_paths
         )
-        folder_ids = set()
+        folder_path_by_id = {}
         for folder_path, folder_entity in folder_entities_by_path.items():
             if folder_entity is not None:
-                folder_ids.add(folder_entity["id"])
+                folder_path_by_id[folder_entity["id"]] = folder_path
 
-        if not folder_ids:
+        if not folder_path_by_id:
             return output
 
         task_entities_by_parent_id = collections.defaultdict(list)
         for task_entity in ayon_api.get_tasks(
             self.project_name,
-            folder_ids=folder_ids
+            folder_ids=folder_path_by_id.keys()
         ):
             folder_id = task_entity["folderId"]
             task_entities_by_parent_id[folder_id].append(task_entity)
 
         for folder_id, task_entities in task_entities_by_parent_id.items():
-            folder_path = self._folder_id_by_folder_path.get(folder_id)
+            folder_path = folder_path_by_id[folder_id]
             task_ids = set()
             task_names = set()
             for task_entity in task_entities:

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -1482,14 +1482,14 @@ class CreateContext:
             for folder_path in folder_paths
             if folder_path is not None
         }
-        remainders = set()
+        remainder_paths = set()
         for folder_path in output:
             # Skip empty/invalid folder paths
             if folder_path is None or "/" not in folder_path:
                 continue
 
             if folder_path not in self._folder_id_by_folder_path:
-                remainders.add(folder_path)
+                remainder_paths.add(folder_path)
                 continue
 
             folder_id = self._folder_id_by_folder_path.get(folder_path)
@@ -1501,15 +1501,15 @@ class CreateContext:
             if folder_entity:
                 output[folder_path] = folder_entity
             else:
-                remainders.add(folder_path)
+                remainder_paths.add(folder_path)
 
-        if not remainders:
+        if not remainder_paths:
             return output
 
         folder_paths_by_id = {}
         for folder_entity in ayon_api.get_folders(
             self.project_name,
-            folder_paths=remainders,
+            folder_paths=remainder_paths,
         ):
             folder_id = folder_entity["id"]
             folder_path = folder_entity["path"]

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -254,7 +254,7 @@ class CreateContext:
 
         # Context validation cache
         self._folder_id_by_folder_path = {}
-        self._task_infos_by_folder_path = {}
+        self._task_names_by_folder_path = {}
 
         self.thumbnail_paths_by_instance_id = {}
 
@@ -567,7 +567,7 @@ class CreateContext:
         # Give ability to store shared data for collection phase
         self._collection_shared_data = {}
         self._folder_id_by_folder_path = {}
-        self._task_infos_by_folder_path = {}
+        self._task_names_by_folder_path = {}
         self._event_hub.clear_callbacks()
 
     def reset_finalization(self):
@@ -1561,7 +1561,7 @@ class CreateContext:
 
             task_name = context_info.task_name
             if task_name is not None:
-                tasks_cache = self._task_infos_by_folder_path.get(folder_path)
+                tasks_cache = self._task_names_by_folder_path.get(folder_path)
                 if tasks_cache is not None:
                     context_info.task_is_valid = task_name in tasks_cache
                     continue
@@ -1613,17 +1613,16 @@ class CreateContext:
         tasks_entities = ayon_api.get_tasks(
             project_name,
             folder_ids=folder_paths_by_id.keys(),
-            fields={"name", "folderId", "taskType"}
+            fields={"name", "folderId"}
         )
 
-        task_infos_by_folder_path = collections.defaultdict(dict)
+        task_names_by_folder_path = collections.defaultdict(set)
         for task_entity in tasks_entities:
             folder_id = task_entity["folderId"]
             folder_path = folder_paths_by_id[folder_id]
-            task_infos_by_folder_path[folder_path][task_entity["name"]] = {
-                "task_type": task_entity["taskType"],
-            }
-        self._task_infos_by_folder_path.update(task_infos_by_folder_path)
+            task_names_by_folder_path[folder_path].add(task_entity["name"])
+
+        self._task_names_by_folder_path.update(task_names_by_folder_path)
 
         for instance in to_validate:
             folder_path = instance["folderPath"]

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -1490,17 +1490,19 @@ class CreateContext:
         context_infos = self.get_instances_context_info(instances)
         output = {}
         for instance_id, context_info in context_infos.items():
-            folder_path = context_info.folder_path
             task_name = context_info.task_name
-            if not task_name or not folder_path:
+            if not task_name or not context_info.is_valid:
                 output[instance_id] = None
                 continue
-            task_info = (
-                self._task_infos_by_folder_path.get(folder_path) or {}
-            ).get(task_name)
+
             task_type = None
-            if task_info is not None:
-                task_type = task_info["task_type"]
+            tasks_cache = self._task_infos_by_folder_path.get(
+                context_info.folder_path
+            )
+            if tasks_cache is not None:
+                task_info = tasks_cache.get(task_name)
+                if task_info is not None:
+                    task_type = task_info["task_type"]
             output[instance_id] = task_type
         return output
 

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -1666,6 +1666,7 @@ class CreateContext:
             instance.get("folderPath")
             for instance in instances
         }
+        folder_paths.discard(None)
         folder_entities_by_path = self.get_folder_entities(folder_paths)
         for instance in instances:
             folder_path = instance.get("folderPath")

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -1478,11 +1478,11 @@ class CreateContext:
         output = {
             folder_path: None
             for folder_path in folder_paths
-            if folder_path is not None
         }
         remainder_paths = set()
         for folder_path in output:
-            # Skip empty/invalid folder paths
+            # Skip invalid folder paths (e.g. if only folder name
+            #   is passed in)
             if "/" not in folder_path:
                 continue
 
@@ -1505,7 +1505,7 @@ class CreateContext:
             output[folder_path] = folder_entity
             self._folder_entities_by_path[folder_path] = folder_entity
 
-        # Cache empty folders
+        # Cache empty folder entities
         for path in remainder_paths - found_paths:
             self._folder_entities_by_path[path] = None
 

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -1468,7 +1468,7 @@ class CreateContext:
         if failed_info:
             raise CreatorsCreateFailed(failed_info)
 
-    def get_instances_task_type(
+    def get_instances_task_types(
         self, instances: Optional[Iterable["CreatedInstance"]] = None
     ) -> Dict[str, Optional[str]]:
         """Helper function to get task type of task on instance.


### PR DESCRIPTION
## Changelog Description
Create context has helper functions to collect and cache entities.

## Additional info
The need came with https://github.com/ynput/ayon-deadline/pull/49 . That PR is fetching entities on each instance change which slows down the whole logic a lot. This way the entities are cached on CreateContext which avoids unnecessary re-fetching of the same data. The PR needed specifically task type, but I guess there will come soon more that will want to use attributes etc.

The methods are using folder path and task name for filtering as that is what instances have available in data.

The same methods are not used for context validation and to get current context entities.

## Testing notes:
1. All should be ok when publisher UI is opened in any host.
2. Validation of context should still happen without any issues.
3. Invalid context on existing instance should be properly displayed as invalid.
4. It is possible to use new helper methods to get corresponding entities.