### PR TITLE
Create Attribute values: Implemented iter

### DIFF
--- a/client/ayon_core/pipeline/create/structures.py
+++ b/client/ayon_core/pipeline/create/structures.py
@@ -132,6 +132,10 @@ class AttributeValues:
     def __contains__(self, key):
         return key in self._attr_defs_by_key
 
+    def __iter__(self):
+        for key in self._attr_defs_by_key:
+            yield key
+
     def get(self, key, default=None):
         if key in self._attr_defs_by_key:
             return self[key]


### PR DESCRIPTION
## Changelog Description
Added implementation to iterate over `AttributeValues`.

## Additional info
`AttributeValues` should behave as dict but iterating over it does not behave the same way.

## Testing notes:
1. If is possible to iterate over `AttributeValues` object to get keys.

Resolves https://github.com/ynput/ayon-core/issues/804