### PR TITLE
Colorspace: Resolve OCIO template

### DIFF
--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -1709,10 +1709,11 @@ def resolve_colorspace_config_template(
             custom_paths.append(profile["custom_path"])
             continue
 
-        #
+        # Try to resolve builtin path (only once)
         if profile_type != "builtin_path" or builtin_tried:
             continue
 
+        builtin_tried = True
         template = profile["builtin_path"]
         try:
             path = template.format(**os.environ)

--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -879,7 +879,7 @@ def _get_global_config_data(
     }
 
 
-def _is_host_ocio_enabled_n_overriden(host_name, project_settings):
+def _is_host_ocio_enabled_n_overridden(host_name, project_settings):
     imageio_global, imageio_host = _get_imageio_settings(
         project_settings, host_name
     )
@@ -955,7 +955,7 @@ def get_imageio_config_preset(
     if not project_settings:
         project_settings = get_project_settings(project_name)
 
-    is_enabled, override_global_config = _is_host_ocio_enabled_n_overriden(
+    is_enabled, override_global_config = _is_host_ocio_enabled_n_overridden(
         host_name, project_settings
     )
     if not is_enabled:

--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -1696,17 +1696,17 @@ def resolve_colorspace_config_template(
     )
 
     builtin_tried = False
-    # Collect custom paths for last step
-    custom_paths = []
-    # Add host path to custom paths
+    # Collect custom templates for last step
+    custom_templates = []
+    # Add host path to custom templates
     host_path = imageio_host.get("ocio_config", {}).get("filepath")
     if host_path:
-        custom_paths.append(host_path)
+        custom_templates.append(host_path)
 
     for profile in imageio_global["ocio_config_profiles"]:
         profile_type = profile["type"]
         if profile_type == "custom_path":
-            custom_paths.append(profile["custom_path"])
+            custom_templates.append(profile["custom_path"])
             continue
 
         # Try to resolve builtin path (only once)
@@ -1729,21 +1729,21 @@ def resolve_colorspace_config_template(
     if success:
         return rootless_path
 
-    # Try to fill custom paths only with 'os.environ'
-    failed_custom_paths = []
-    for custom_path in custom_paths:
+    # Try to fill custom templates only with 'os.environ'
+    failed_custom_templates = []
+    for custom_template in custom_templates:
         try:
-            path = custom_path.format(**os.environ)
+            path = custom_template.format(**os.environ)
         except Exception:
-            failed_custom_paths.append(custom_path)
+            failed_custom_templates.append(custom_template)
             continue
 
         if os.path.realpath(path) == os.path.realpath(config_path):
-            return custom_path
+            return custom_template
 
-    # If none of custom paths formatting failed it means we don't need to try
-    #   with entities template data.
-    if not failed_custom_paths:
+    # If none of custom templates formatting failed it means we don't need to
+    #   try with entities template data.
+    if not failed_custom_templates:
         raise ValueError("Failed to resolve OCIO config template.")
 
     # Prepare all entities for template data
@@ -1766,13 +1766,13 @@ def resolve_colorspace_config_template(
     )
     template_data.update(os.environ.items())
 
-    # Try to fill custom paths with template data passed to function
-    for custom_path in failed_custom_paths:
+    # Try to fill custom templates with template data passed to function
+    for custom_template in failed_custom_templates:
         try:
-            path = custom_path.format(**template_data)
+            path = custom_template.format(**template_data)
         except Exception:
             continue
         if os.path.realpath(path) == os.path.realpath(config_path):
-            return custom_path
+            return custom_template
 
     raise ValueError("Failed to resolve OCIO config template.")


### PR DESCRIPTION
## Changelog Description
Implemented helper function to resolve ocio config template from path.

## Additional info
The previous logic used only anatomy roots to find out template of the path, but if builtin configs (from ayon-config) are used, the path leads to appdirs, which are not in any project root. That means it passes full path to farm job, leading to crash on the target machine.

The new function goes through all possible templates from settings and tries them one by one. The order is from fastest approach to slowest. First tries to check if the path is builtin path, then tries to use Anatomy to find rootless path, then tries to look into custom paths from settings, and from host settings (if availabe) and fill them with env variables and template data based on passed in context.

## Testing notes:
1. Set up OCIO in core to use builtin config.
2. Send a job to farm (with aovs?).
3. The metadata json file should contain colorspace template in `"colorspaceData"`.

Resolves https://github.com/ynput/ayon-core/issues/969