### PR TITLE
Settings: Use markdown instead of html tags

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -459,8 +459,8 @@ class ExtractReviewFilterModel(BaseSettingsModel):
     single_frame_filter: str = SettingsField(
         "everytime",  # codespell:ignore everytime
         description=(
-            "Use output <b>always</b> / only if input <b>is 1 frame</b>"
-            " image / only if has <b>2+ frames</b> or <b>is video</b>"
+            "Use output **always** / only if input **is 1 frame**"
+            " image / only if has **2+ frames** or **is video**"
         ),
         enum_resolver=extract_review_filter_enum
     )


### PR DESCRIPTION
## Changelog Description
Replaced bold tags with markdown syntax.

## Testing notes:
1. Create package, upload to server and use in bundle.
2. Go to settings `ayon+settings://core/publish/ExtractReview/profiles/1/outputs/0/single_frame_filter`.
3. Hovering over it should show bold description.