### PR TITLE
Attribute defs: Fix serialize of text wihout regex

### DIFF
--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -523,7 +523,10 @@ class TextDef(AbstractAttrDef):
 
     def serialize(self):
         data = super().serialize()
-        data["regex"] = self.regex.pattern
+        regex = None
+        if self.regex is not None:
+            regex = self.regex.pattern
+        data["regex"] = regex
         data["multiline"] = self.multiline
         data["placeholder"] = self.placeholder
         return data

--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -327,8 +327,8 @@ class UISeparatorDef(UIDef):
 class UILabelDef(UIDef):
     type = "label"
 
-    def __init__(self, label, key=None):
-        super().__init__(label=label, key=key)
+    def __init__(self, label, key=None, *args, **kwargs):
+        super().__init__(label=label, key=key, *args, **kwargs)
 
     def _def_type_compare(self, other: "UILabelDef") -> bool:
         return self.label == other.label


### PR DESCRIPTION
## Changelog Description
TextDef can be serialized if does not have defined regex pattern.

## Testing notes:
1. Create `TextDef` object without `regex` and call `clone`.
2. It should not crash.
