### PR TITLE
Editorial: Prepare for new args and kwarg in EntiyHub

### DIFF
--- a/client/ayon_core/plugins/publish/extract_hierarchy_to_ayon.py
+++ b/client/ayon_core/plugins/publish/extract_hierarchy_to_ayon.py
@@ -154,7 +154,9 @@ class ExtractHierarchyToAYON(pyblish.api.ContextPlugin):
                 # TODO check if existing entity have 'task' type
                 if task_entity is None:
                     task_entity = entity_hub.add_new_task(
-                        task_info["type"],
+                        task_type=task_info["type"],
+                        # TODO change 'parent_id' to 'folder_id' when ayon api
+                        #   is updated
                         parent_id=entity.id,
                         name=task_name
                     )
@@ -182,7 +184,7 @@ class ExtractHierarchyToAYON(pyblish.api.ContextPlugin):
                         folder_type = "Folder"
 
                     child_entity = entity_hub.add_new_folder(
-                        folder_type,
+                        folder_type=folder_type,
                         parent_id=entity.id,
                         name=child_name
                     )


### PR DESCRIPTION
## Changelog Description
Preparation for upcoming changes in ayon api EntityHub.

## Additional info
Use explicit kwargs to fill task type and folder type.

## Testing notes:
I really don't know exact steps.
1. Creation of new folders and tasks during editorial publishing should work as before.
