### PR TITLE
Delivery: Fix representation entity data

### DIFF
--- a/client/ayon_core/pipeline/delivery.py
+++ b/client/ayon_core/pipeline/delivery.py
@@ -383,6 +383,13 @@ def get_representations_delivery_template_data(
             continue
 
         template_data = repre_entity["context"]
+        # Bug in 'ayon_api', 'get_representations_hierarchy' did not fully
+        #   convert representation entity. Fixed in 'ayon_api' 1.0.10 .
+        if isinstance(template_data, str):
+            con = ayon_api.get_server_api_connection()
+            repre_entity = con._representation_conversion(repre_entity)
+            template_data = repre_entity["context"]
+
         template_data.update(copy.deepcopy(general_template_data))
         template_data.update(get_folder_template_data(
             repre_hierarchy.folder, project_name

--- a/client/ayon_core/pipeline/delivery.py
+++ b/client/ayon_core/pipeline/delivery.py
@@ -384,7 +384,7 @@ def get_representations_delivery_template_data(
 
         template_data = repre_entity["context"]
         # Bug in 'ayon_api', 'get_representations_hierarchy' did not fully
-        #   convert representation entity. Fixed in 'ayon_api' 1.0.10 .
+        #   convert representation entity. Fixed in 'ayon_api' 1.0.10.
         if isinstance(template_data, str):
             con = ayon_api.get_server_api_connection()
             repre_entity = con._representation_conversion(repre_entity)


### PR DESCRIPTION
## Changelog Description
Fixed bug caused by ayon api which did not fully convert representation entity data in `get_representations_hierarchy`.

## Additional info
The issue is already fixed in newer version of ayon api 1.0.10 (AYON launcher 1.1.1). But added this fix for those who still use older versions.

### Traceback
```
Traceback (most recent call last):
  File "C:\Users\...\AppData\Local\Ynput\AYON\addons\core_1.0.3\ayon_core\plugins\load\delivery.py", line 210, in deliver
    get_representations_delivery_template_data(
  File "C:\Users\...\AppData\Local\Ynput\AYON\addons\core_1.0.3\ayon_core\pipeline\delivery.py", line 386, in get_representations_delivery_template_data
    template_data.update(copy.deepcopy(general_template_data))
AttributeError: 'str' object has no attribute 'update'
```

## Testing notes:
1. Use AYON launcher 1.1.0 to run delivery action.
2. It should not fail with error above.
