### PR TITLE
Delivery: Use current roots during delivery

### DIFF
--- a/client/ayon_core/pipeline/delivery.py
+++ b/client/ayon_core/pipeline/delivery.py
@@ -411,7 +411,7 @@ def get_representations_delivery_template_data(
         _merge_data(template_data, repre_entity["context"])
 
         # Remove roots from template data to auto-fill them with anatomy data
-        template_data.pop("root")
+        template_data.pop("root", None)
 
         output[repre_id] = template_data
     return output


### PR DESCRIPTION
## Changelog Description
Make sure that root is not re-used from published representation during delivery.

## Additional info
Because we do copy `"context"` it also copied `"root"` there, if root is filled in template data, anatomy does not auto-fill it which causes issues during delivery.

## Testing notes:
1. Publish some representation (can skip if you have any).
2. Create new root in the project.
3. Use the new root in delivery template.
4. Run delivery action in loader.
5. It should work fine and should not raise error because of missing root key.