### PR TITLE
Representation defined by traits

### DIFF
--- a/client/ayon_core/hooks/pre_global_host_data.py
+++ b/client/ayon_core/hooks/pre_global_host_data.py
@@ -1,12 +1,15 @@
 from ayon_api import get_project, get_folder_by_path, get_task_by_name
 
+from ayon_core.pipeline import Anatomy
+from ayon_core.pipeline.anatomy import RootMissingEnv
+
 from ayon_applications import PreLaunchHook
+from ayon_applications.exceptions import ApplicationLaunchFailed
 from ayon_applications.utils import (
     EnvironmentPrepData,
     prepare_app_environments,
     prepare_context_environments
 )
-from ayon_core.pipeline import Anatomy
 
 
 class GlobalHostDataHook(PreLaunchHook):
@@ -67,9 +70,12 @@ class GlobalHostDataHook(PreLaunchHook):
         self.data["project_entity"] = project_entity
 
         # Anatomy
-        self.data["anatomy"] = Anatomy(
-            project_name, project_entity=project_entity
-        )
+        try:
+            self.data["anatomy"] = Anatomy(
+                project_name, project_entity=project_entity
+            )
+        except RootMissingEnv as exc:
+            raise ApplicationLaunchFailed(str(exc))
 
         folder_path = self.data.get("folder_path")
         if not folder_path:

--- a/client/ayon_core/pipeline/anatomy/__init__.py
+++ b/client/ayon_core/pipeline/anatomy/__init__.py
@@ -1,5 +1,6 @@
 from .exceptions import (
     ProjectNotSet,
+    RootMissingEnv,
     RootCombinationError,
     TemplateMissingKey,
     AnatomyTemplateUnsolved,
@@ -9,6 +10,7 @@ from .anatomy import Anatomy
 
 __all__ = (
     "ProjectNotSet",
+    "RootMissingEnv",
     "RootCombinationError",
     "TemplateMissingKey",
     "AnatomyTemplateUnsolved",

--- a/client/ayon_core/pipeline/anatomy/exceptions.py
+++ b/client/ayon_core/pipeline/anatomy/exceptions.py
@@ -5,6 +5,11 @@ class ProjectNotSet(Exception):
     """Exception raised when is created Anatomy without project name."""
 
 
+class RootMissingEnv(KeyError):
+    """Raised when root requires environment variables which is not filled."""
+    pass
+
+
 class RootCombinationError(Exception):
     """This exception is raised when templates has combined root types."""
 

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -2303,10 +2303,16 @@ class CreateContext:
                 for plugin_name, plugin_value in item_changes.pop(
                     "publish_attributes"
                 ).items():
+                    if plugin_value is None:
+                        current_publish[plugin_name] = None
+                        continue
                     plugin_changes = current_publish.setdefault(
                         plugin_name, {}
                     )
-                    plugin_changes.update(plugin_value)
+                    if plugin_changes is None:
+                        current_publish[plugin_name] = plugin_value
+                    else:
+                        plugin_changes.update(plugin_value)
 
             item_values.update(item_changes)
 

--- a/client/ayon_core/pipeline/thumbnails.py
+++ b/client/ayon_core/pipeline/thumbnails.py
@@ -226,11 +226,26 @@ class _CacheItems:
     thumbnails_cache = ThumbnailsCache()
 
 
-def get_thumbnail_path(project_name, thumbnail_id):
+def get_thumbnail_path(
+    project_name: str,
+    entity_type: str,
+    entity_id: str,
+    thumbnail_id: str
+):
     """Get path to thumbnail image.
+
+    Thumbnail is cached by thumbnail id but is received using entity type and
+        entity id.
+
+    Notes:
+        Function 'get_thumbnail_by_id' can't be used because does not work
+            for artists. The endpoint can't validate artist permissions.
 
     Args:
         project_name (str): Project where thumbnail belongs to.
+        entity_type (str): Entity type "folder", "task", "version"
+            and "workfile".
+        entity_id (str): Entity id.
         thumbnail_id (Union[str, None]): Thumbnail id.
 
     Returns:
@@ -251,7 +266,7 @@ def get_thumbnail_path(project_name, thumbnail_id):
     #   'get_thumbnail_by_id' did not return output of
     #   'ServerAPI' method.
     con = ayon_api.get_server_api_connection()
-    result = con.get_thumbnail_by_id(project_name, thumbnail_id)
+    result = con.get_thumbnail(project_name, entity_type, entity_id)
 
     if result is not None and result.is_valid:
         return _CacheItems.thumbnails_cache.store_thumbnail(

--- a/client/ayon_core/pipeline/workfile/__init__.py
+++ b/client/ayon_core/pipeline/workfile/__init__.py
@@ -16,6 +16,7 @@ from .path_resolving import (
 from .utils import (
     should_use_last_workfile_on_launch,
     should_open_workfiles_tool_on_launch,
+    MissingWorkdirError,
 )
 
 from .build_workfile import BuildWorkfile
@@ -46,6 +47,7 @@ __all__ = (
 
     "should_use_last_workfile_on_launch",
     "should_open_workfiles_tool_on_launch",
+    "MissingWorkdirError",
 
     "BuildWorkfile",
 

--- a/client/ayon_core/pipeline/workfile/utils.py
+++ b/client/ayon_core/pipeline/workfile/utils.py
@@ -2,6 +2,11 @@ from ayon_core.lib import filter_profiles
 from ayon_core.settings import get_project_settings
 
 
+class MissingWorkdirError(Exception):
+    """Raised when accessing a work directory not found on disk."""
+    pass
+
+
 def should_use_last_workfile_on_launch(
     project_name,
     host_name,

--- a/client/ayon_core/tools/loader/abstract.py
+++ b/client/ayon_core/tools/loader/abstract.py
@@ -733,7 +733,12 @@ class FrontendLoaderController(_BaseLoaderController):
         pass
 
     @abstractmethod
-    def get_thumbnail_path(self, project_name, thumbnail_id):
+    def get_thumbnail_paths(
+        self,
+        project_name,
+        entity_type,
+        entity_ids
+    ):
         """Get thumbnail path for thumbnail id.
 
         This method should get a path to a thumbnail based on thumbnail id.
@@ -742,10 +747,11 @@ class FrontendLoaderController(_BaseLoaderController):
 
         Args:
             project_name (str): Project name.
-            thumbnail_id (str): Thumbnail id.
+            entity_type (str): Entity type.
+            entity_ids (set[str]): Entity ids.
 
         Returns:
-            Union[str, None]: Thumbnail path or None if not found.
+            dict[str, Union[str, None]]: Thumbnail path by entity id.
         """
 
         pass

--- a/client/ayon_core/tools/loader/control.py
+++ b/client/ayon_core/tools/loader/control.py
@@ -259,9 +259,14 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
             project_name, version_ids
         )
 
-    def get_thumbnail_path(self, project_name, thumbnail_id):
-        return self._thumbnails_model.get_thumbnail_path(
-            project_name, thumbnail_id
+    def get_thumbnail_paths(
+        self,
+        project_name,
+        entity_type,
+        entity_ids,
+    ):
+        return self._thumbnails_model.get_thumbnail_paths(
+            project_name, entity_type, entity_ids
         )
 
     def change_products_group(self, project_name, product_ids, group_name):

--- a/client/ayon_core/tools/loader/ui/window.py
+++ b/client/ayon_core/tools/loader/ui/window.py
@@ -501,38 +501,29 @@ class LoaderWindow(QtWidgets.QWidget):
         self._update_thumbnails()
 
     def _update_thumbnails(self):
+        # TODO make this threaded and show loading animation while running
         project_name = self._selected_project_name
-        thumbnail_ids = set()
+        entity_type = None
+        entity_ids = set()
         if self._selected_version_ids:
-            thumbnail_id_by_entity_id = (
-                self._controller.get_version_thumbnail_ids(
-                    project_name,
-                    self._selected_version_ids
-                )
-            )
-            thumbnail_ids = set(thumbnail_id_by_entity_id.values())
+            entity_ids = set(self._selected_version_ids)
+            entity_type = "version"
         elif self._selected_folder_ids:
-            thumbnail_id_by_entity_id = (
-                self._controller.get_folder_thumbnail_ids(
-                    project_name,
-                    self._selected_folder_ids
-                )
-            )
-            thumbnail_ids = set(thumbnail_id_by_entity_id.values())
+            entity_ids = set(self._selected_folder_ids)
+            entity_type = "folder"
 
-        thumbnail_ids.discard(None)
-
-        if not thumbnail_ids:
-            self._thumbnails_widget.set_current_thumbnails(None)
-            return
-
-        thumbnail_paths = set()
-        for thumbnail_id in thumbnail_ids:
-            thumbnail_path = self._controller.get_thumbnail_path(
-                project_name, thumbnail_id)
-            thumbnail_paths.add(thumbnail_path)
+        thumbnail_path_by_entity_id = self._controller.get_thumbnail_paths(
+            project_name, entity_type, entity_ids
+        )
+        thumbnail_paths = set(thumbnail_path_by_entity_id.values())
         thumbnail_paths.discard(None)
-        self._thumbnails_widget.set_current_thumbnail_paths(thumbnail_paths)
+
+        if thumbnail_paths:
+           self._thumbnails_widget.set_current_thumbnail_paths(
+               thumbnail_paths
+           )
+        else:
+            self._thumbnails_widget.set_current_thumbnails(None)
 
     def _on_projects_refresh(self):
         self._refresh_handler.set_project_refreshed()

--- a/client/ayon_core/version.py
+++ b/client/ayon_core/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'core' version."""
-__version__ = "1.1.6+dev"
+__version__ = "1.1.7+dev"

--- a/package.py
+++ b/package.py
@@ -1,6 +1,6 @@
 name = "core"
 title = "Core"
-version = "1.1.6+dev"
+version = "1.1.7+dev"
 
 client_dir = "ayon_core"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 
 [tool.poetry]
 name = "ayon-core"
-version = "1.1.6+dev"
+version = "1.1.7+dev"
 description = ""
 authors = ["Ynput Team <team@ynput.io>"]
 readme = "README.md"


### PR DESCRIPTION
## Changelog Description
Introducing new way of defining representations. Developer friendly, flexible yet strictly typed, easy to extend using Traits as building blocks defining what representation IS.

## Additional info

New representation is holder for traits. Each trait define some properties and together with other traits describes the representation. Traits can be anything- their purpose is to help publisher, loader (and basically any other systems) to clearly identify data needed for processing. Like file system path, or frame per second, or resolution. Those properties are grouped together to logical block - frame range specific, resolution specific, etc.

This PR is introducing several new features:

**TraitBase** - this is a model for all Traits. It defines abstract properties like `id`, `name`, `description` that needs to be in all Traits.

> [!NOTE]
> Every Trait can re-implement `validate()` method. The one in `TraitBase` always returns `True`. `Representation` is passed to that method so every Trait can validate against all other Trait present in representation.

**Representation** - this is "container" of sorts to hold all Traits. It holds representation`name` and `id`. And lot of "helper" methods to work with Traits:
 
- methods to check if Trait exists in the Representation
- methods to add and remove Traits
- methods to get Traits
- method to return whole Representation serialized as Python dict
- method to reconstruct Representation from the dict

Most of them can run on bulk of Traits and you can access Traits by their class or by their Id. More on that below.

There is also mechanism for upgrading and versioning Traits.

### Traits

There are some pre-defined Traits that should come with **ayon-core** to provide "common language". They are all based on `TraitBase` and are grouped to logical chunks or namespaces - **content**, **lifecycle**, **meta**, **three_dimensional**, **time**, **two_dimensional**. Their complete list can be found in the code and is obviously subject to change based on the need.

### Practical examples

So how to work with traits and representations? To define traits (for example in *Collector* plugin or in *Extractor* plugin:
```python
from ayon_core.pipeline.traits import (
	FileLocation,
	Image,,
	MimeType,
    PixelBased,
	Representation
)

# define traits
file_location = FileLocation(
    file_path=Path("/path/to/file.jpg"),
)

pixel_based = PixelBased(
	display_window_width=1920,
    display_window_height=1080,
    pixel_aspect_ratio=1.0 
)

# create representation itself

representation = Representation(
    name="Image test",
	traits=[file_location, Image(), pixel_based])

# add additional traits
mime_type = MimeType(mime_type="image/jpeg")
representation.add_trait(mime_type)

# remove trait
representation.remove_trait(MimeType)

if representation.contains_trait(PixelBased):
	print(f"width: {representation.get_trait(PixelBased).display_window_width)}")

```

You can work with Traits using classes, but you can also utilize their ids. That is useful when working with representation that was serialized into "plain' dictionary:

```python

# some pseudo-function to get representation as dict
representation = Representation.from_dict(get_representation_dict(...))

# get trait by its id
# note: the use of version in the ID. You can test if trait is present in representation, or if trait of specific version is present.
if representation.contains_trait_by_id("ayon.content.FileLocation"):
	print(f"path: {representation.get_trait_by_id("ayon.content.FileLocation.v1")

# serialize back to dict
representation.traits_as_dict()
```

There is also feature of version upgrade on Traits. Whenever you want to de-serialize data that are using older version of trait, `upgrade()` method on newer trait definition is called to reconstruct new version (downgrading isn't possible). So, you can have serialized trait like so (type trait without properties):

```python
{
		ayon.2d.Image.v1: {}
}
```
But your current runtime has **Image** trait `ayon.2d.Image.v2` that is also adding property `foo`.

Whenever you run `representation.get_trait_by_id("ayon.2d.Image")` without version specifier, it can try to find out the latest Trait definition available and if it differs - `v1 != v2` it tries to call `upgrade()` method on the latest trait.

### Notes

Traits are no longer Pydantic models because Pydantic 2 is based on rust and we would need to support it in all possible host (distribute it somehow in AYON too). So until this issue is resolved, it is better to have them as pure Python dataclasses.
