### PR TITLE
Remove `Logger.mongo_process_id`

### DIFF
--- a/client/ayon_core/lib/log.py
+++ b/client/ayon_core/lib/log.py
@@ -141,8 +141,6 @@ class Logger:
     process_data = None
     # Cached process name or ability to set different process name
     _process_name = None
-    # TODO Remove 'mongo_process_id' in 1.x.x
-    mongo_process_id = uuid.uuid4().hex
 
     @classmethod
     def get_logger(cls, name=None):

--- a/client/ayon_core/lib/log.py
+++ b/client/ayon_core/lib/log.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import uuid
 import getpass
 import logging
 import platform


### PR DESCRIPTION
## Changelog Description

Remove `Logger.mongo_process_id`

## Additional info

Was once used a long time ago in ftrack services back in OpenPype era?

## Testing notes:

1. Logger should work
2. Addons should still work (esp. ftrack)
