### PR TITLE
Publisher: Revert to default value

### DIFF
--- a/client/ayon_core/style/style.css
+++ b/client/ayon_core/style/style.css
@@ -44,10 +44,6 @@ QLabel {
     background: transparent;
 }
 
-QLabel[overriden="1"] {
-    color: {color:font-overridden};
-}
-
 /* Inputs */
 QAbstractSpinBox, QLineEdit, QPlainTextEdit, QTextEdit {
     border: 1px solid {color:border};
@@ -1589,6 +1585,10 @@ CreateNextPageOverlay {
 }
 
 /* Attribute Definition widgets */
+AttributeDefinitionsLabel[overridden="1"] {
+    color: {color:font-overridden};
+}
+
 AttributeDefinitionsWidget QAbstractSpinBox, QLineEdit, QPlainTextEdit, QTextEdit {
     padding: 1px;
 }

--- a/client/ayon_core/tools/attribute_defs/__init__.py
+++ b/client/ayon_core/tools/attribute_defs/__init__.py
@@ -1,6 +1,7 @@
 from .widgets import (
     create_widget_for_attr_def,
     AttributeDefinitionsWidget,
+    AttributeDefinitionsLabel,
 )
 
 from .dialog import (
@@ -11,6 +12,7 @@ from .dialog import (
 __all__ = (
     "create_widget_for_attr_def",
     "AttributeDefinitionsWidget",
+    "AttributeDefinitionsLabel",
 
     "AttributeDefinitionsDialog",
 )

--- a/client/ayon_core/tools/attribute_defs/_constants.py
+++ b/client/ayon_core/tools/attribute_defs/_constants.py
@@ -1,0 +1,1 @@
+REVERT_TO_DEFAULT_LABEL = "Revert to default"

--- a/client/ayon_core/tools/attribute_defs/files_widget.py
+++ b/client/ayon_core/tools/attribute_defs/files_widget.py
@@ -17,6 +17,8 @@ from ayon_core.tools.utils import (
     PixmapLabel
 )
 
+from ._constants import REVERT_TO_DEFAULT_LABEL
+
 ITEM_ID_ROLE = QtCore.Qt.UserRole + 1
 ITEM_LABEL_ROLE = QtCore.Qt.UserRole + 2
 ITEM_ICON_ROLE = QtCore.Qt.UserRole + 3
@@ -598,7 +600,7 @@ class FilesView(QtWidgets.QListView):
     """View showing instances and their groups."""
 
     remove_requested = QtCore.Signal()
-    context_menu_requested = QtCore.Signal(QtCore.QPoint)
+    context_menu_requested = QtCore.Signal(QtCore.QPoint, bool)
 
     def __init__(self, *args, **kwargs):
         super(FilesView, self).__init__(*args, **kwargs)
@@ -690,9 +692,8 @@ class FilesView(QtWidgets.QListView):
 
     def _on_context_menu_request(self, pos):
         index = self.indexAt(pos)
-        if index.isValid():
-            point = self.viewport().mapToGlobal(pos)
-            self.context_menu_requested.emit(point)
+        point = self.viewport().mapToGlobal(pos)
+        self.context_menu_requested.emit(point, index.isValid())
 
     def _on_selection_change(self):
         self._remove_btn.setEnabled(self.has_selected_item_ids())
@@ -721,27 +722,34 @@ class FilesView(QtWidgets.QListView):
 
 class FilesWidget(QtWidgets.QFrame):
     value_changed = QtCore.Signal()
+    revert_requested = QtCore.Signal()
 
     def __init__(self, single_item, allow_sequences, extensions_label, parent):
-        super(FilesWidget, self).__init__(parent)
+        super().__init__(parent)
         self.setAcceptDrops(True)
 
+        wrapper_widget = QtWidgets.QWidget(self)
+
         empty_widget = DropEmpty(
-            single_item, allow_sequences, extensions_label, self
+            single_item, allow_sequences, extensions_label, wrapper_widget
         )
 
         files_model = FilesModel(single_item, allow_sequences)
         files_proxy_model = FilesProxyModel()
         files_proxy_model.setSourceModel(files_model)
-        files_view = FilesView(self)
+        files_view = FilesView(wrapper_widget)
         files_view.setModel(files_proxy_model)
 
-        layout = QtWidgets.QStackedLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setStackingMode(QtWidgets.QStackedLayout.StackAll)
-        layout.addWidget(empty_widget)
-        layout.addWidget(files_view)
-        layout.setCurrentWidget(empty_widget)
+        wrapper_layout = QtWidgets.QStackedLayout(wrapper_widget)
+        wrapper_layout.setContentsMargins(0, 0, 0, 0)
+        wrapper_layout.setStackingMode(QtWidgets.QStackedLayout.StackAll)
+        wrapper_layout.addWidget(empty_widget)
+        wrapper_layout.addWidget(files_view)
+        wrapper_layout.setCurrentWidget(empty_widget)
+
+        main_layout = QtWidgets.QHBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+        main_layout.addWidget(wrapper_widget, 1)
 
         files_proxy_model.rowsInserted.connect(self._on_rows_inserted)
         files_proxy_model.rowsRemoved.connect(self._on_rows_removed)
@@ -761,7 +769,11 @@ class FilesWidget(QtWidgets.QFrame):
 
         self._widgets_by_id = {}
 
-        self._layout = layout
+        self._wrapper_widget = wrapper_widget
+        self._wrapper_layout = wrapper_layout
+
+        self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.customContextMenuRequested.connect(self._on_context_menu)
 
     def _set_multivalue(self, multivalue):
         if self._multivalue is multivalue:
@@ -770,7 +782,7 @@ class FilesWidget(QtWidgets.QFrame):
         self._files_view.set_multivalue(multivalue)
         self._files_model.set_multivalue(multivalue)
         self._files_proxy_model.set_multivalue(multivalue)
-        self.setEnabled(not multivalue)
+        self._wrapper_widget.setEnabled(not multivalue)
 
     def set_value(self, value, multivalue):
         self._in_set_value = True
@@ -888,22 +900,28 @@ class FilesWidget(QtWidgets.QFrame):
         if items_to_delete:
             self._remove_item_by_ids(items_to_delete)
 
-    def _on_context_menu_requested(self, pos):
-        if self._multivalue:
-            return
+    def _on_context_menu(self, pos):
+        self._on_context_menu_requested(pos, False)
 
+    def _on_context_menu_requested(self, pos, valid_index):
         menu = QtWidgets.QMenu(self._files_view)
+        if valid_index and not self._multivalue:
+            if self._files_view.has_selected_sequence():
+                split_action = QtWidgets.QAction("Split sequence", menu)
+                split_action.triggered.connect(self._on_split_request)
+                menu.addAction(split_action)
 
-        if self._files_view.has_selected_sequence():
-            split_action = QtWidgets.QAction("Split sequence", menu)
-            split_action.triggered.connect(self._on_split_request)
-            menu.addAction(split_action)
+            remove_action = QtWidgets.QAction("Remove", menu)
+            remove_action.triggered.connect(self._on_remove_requested)
+            menu.addAction(remove_action)
 
-        remove_action = QtWidgets.QAction("Remove", menu)
-        remove_action.triggered.connect(self._on_remove_requested)
-        menu.addAction(remove_action)
+        if not valid_index:
+            revert_action = QtWidgets.QAction(REVERT_TO_DEFAULT_LABEL, menu)
+            revert_action.triggered.connect(self.revert_requested)
+            menu.addAction(revert_action)
 
-        menu.popup(pos)
+        if menu.actions():
+            menu.popup(pos)
 
     def dragEnterEvent(self, event):
         if self._multivalue:
@@ -1011,5 +1029,5 @@ class FilesWidget(QtWidgets.QFrame):
             current_widget = self._files_view
         else:
             current_widget = self._empty_widget
-        self._layout.setCurrentWidget(current_widget)
+        self._wrapper_layout.setCurrentWidget(current_widget)
         self._files_view.update_remove_btn_visibility()

--- a/client/ayon_core/tools/attribute_defs/widgets.py
+++ b/client/ayon_core/tools/attribute_defs/widgets.py
@@ -364,7 +364,7 @@ class ClickableLineEdit(QtWidgets.QLineEdit):
     clicked = QtCore.Signal()
 
     def __init__(self, text, parent):
-        super(ClickableLineEdit, self).__init__(parent)
+        super().__init__(parent)
         self.setText(text)
         self.setReadOnly(True)
 
@@ -373,7 +373,7 @@ class ClickableLineEdit(QtWidgets.QLineEdit):
     def mousePressEvent(self, event):
         if event.button() == QtCore.Qt.LeftButton:
             self._mouse_pressed = True
-        super(ClickableLineEdit, self).mousePressEvent(event)
+        super().mousePressEvent(event)
 
     def mouseReleaseEvent(self, event):
         if self._mouse_pressed:
@@ -381,7 +381,7 @@ class ClickableLineEdit(QtWidgets.QLineEdit):
             if self.rect().contains(event.pos()):
                 self.clicked.emit()
 
-        super(ClickableLineEdit, self).mouseReleaseEvent(event)
+        super().mouseReleaseEvent(event)
 
 
 class NumberAttrWidget(_BaseAttrDefWidget):
@@ -596,7 +596,7 @@ class BoolAttrWidget(_BaseAttrDefWidget):
 class EnumAttrWidget(_BaseAttrDefWidget):
     def __init__(self, *args, **kwargs):
         self._multivalue = False
-        super(EnumAttrWidget, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @property
     def multiselection(self):
@@ -723,7 +723,7 @@ class HiddenAttrWidget(_BaseAttrDefWidget):
     def setVisible(self, visible):
         if visible:
             visible = False
-        super(HiddenAttrWidget, self).setVisible(visible)
+        super().setVisible(visible)
 
     def current_value(self):
         if self._multivalue:

--- a/client/ayon_core/tools/attribute_defs/widgets.py
+++ b/client/ayon_core/tools/attribute_defs/widgets.py
@@ -1,4 +1,6 @@
 import copy
+import typing
+from typing import Optional
 
 from qtpy import QtWidgets, QtCore
 
@@ -26,11 +28,20 @@ from ayon_core.tools.utils import NiceCheckbox
 
 from .files_widget import FilesWidget
 
+if typing.TYPE_CHECKING:
+    from typing import Union
+
 _REVERT_TO_DEFAULT_LABEL = "Revert to default"
 
 
-def create_widget_for_attr_def(attr_def, parent=None):
-    widget = _create_widget_for_attr_def(attr_def, parent)
+def create_widget_for_attr_def(
+    attr_def: AbstractAttrDef,
+    parent: Optional[QtWidgets.QWidget] = None,
+    handle_revert_to_default: Optional[bool] = True,
+):
+    widget = _create_widget_for_attr_def(
+        attr_def, parent, handle_revert_to_default
+    )
     if not attr_def.visible:
         widget.setVisible(False)
 
@@ -39,42 +50,50 @@ def create_widget_for_attr_def(attr_def, parent=None):
     return widget
 
 
-def _create_widget_for_attr_def(attr_def, parent=None):
+def _create_widget_for_attr_def(
+    attr_def: AbstractAttrDef,
+    parent: "Union[QtWidgets.QWidget, None]",
+    handle_revert_to_default: bool,
+):
     if not isinstance(attr_def, AbstractAttrDef):
         raise TypeError("Unexpected type \"{}\" expected \"{}\"".format(
             str(type(attr_def)), AbstractAttrDef
         ))
 
+    cls = None
     if isinstance(attr_def, NumberDef):
-        return NumberAttrWidget(attr_def, parent)
+        cls = NumberAttrWidget
 
-    if isinstance(attr_def, TextDef):
-        return TextAttrWidget(attr_def, parent)
+    elif isinstance(attr_def, TextDef):
+        cls = TextAttrWidget
 
-    if isinstance(attr_def, EnumDef):
-        return EnumAttrWidget(attr_def, parent)
+    elif isinstance(attr_def, EnumDef):
+        cls = EnumAttrWidget
 
-    if isinstance(attr_def, BoolDef):
-        return BoolAttrWidget(attr_def, parent)
+    elif isinstance(attr_def, BoolDef):
+        cls = BoolAttrWidget
 
-    if isinstance(attr_def, UnknownDef):
-        return UnknownAttrWidget(attr_def, parent)
+    elif isinstance(attr_def, UnknownDef):
+        cls = UnknownAttrWidget
 
-    if isinstance(attr_def, HiddenDef):
-        return HiddenAttrWidget(attr_def, parent)
+    elif isinstance(attr_def, HiddenDef):
+        cls = HiddenAttrWidget
 
-    if isinstance(attr_def, FileDef):
-        return FileAttrWidget(attr_def, parent)
+    elif isinstance(attr_def, FileDef):
+        cls = FileAttrWidget
 
-    if isinstance(attr_def, UISeparatorDef):
-        return SeparatorAttrWidget(attr_def, parent)
+    elif isinstance(attr_def, UISeparatorDef):
+        cls = SeparatorAttrWidget
 
-    if isinstance(attr_def, UILabelDef):
-        return LabelAttrWidget(attr_def, parent)
+    elif isinstance(attr_def, UILabelDef):
+        cls = LabelAttrWidget
 
-    raise ValueError("Unknown attribute definition \"{}\"".format(
-        str(type(attr_def))
-    ))
+    if cls is None:
+        raise ValueError("Unknown attribute definition \"{}\"".format(
+            str(type(attr_def))
+        ))
+
+    return cls(attr_def, parent, handle_revert_to_default)
 
 
 class AttributeDefinitionsLabel(QtWidgets.QLabel):

--- a/client/ayon_core/tools/attribute_defs/widgets.py
+++ b/client/ayon_core/tools/attribute_defs/widgets.py
@@ -811,9 +811,24 @@ class FileAttrWidget(_BaseAttrDefWidget):
 
         self.main_layout.addWidget(input_widget, 0)
 
+        input_widget.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        input_widget.customContextMenuRequested.connect(self._on_context_menu)
+        input_widget.revert_requested.connect(self.revert_to_default_value)
+
     def _on_value_change(self):
         new_value = self.current_value()
         self.value_changed.emit(new_value, self.attr_def.id)
+
+    def _on_context_menu(self, pos):
+        menu = QtWidgets.QMenu(self)
+
+        action = QtWidgets.QAction(menu)
+        action.setText(REVERT_TO_DEFAULT_LABEL)
+        action.triggered.connect(self.revert_to_default_value)
+        menu.addAction(action)
+
+        global_pos = self.mapToGlobal(pos)
+        menu.exec_(global_pos)
 
     def current_value(self):
         return self._input_widget.current_value()

--- a/client/ayon_core/tools/attribute_defs/widgets.py
+++ b/client/ayon_core/tools/attribute_defs/widgets.py
@@ -241,11 +241,18 @@ class AttributeDefinitionsWidget(QtWidgets.QWidget):
 class _BaseAttrDefWidget(QtWidgets.QWidget):
     # Type 'object' may not work with older PySide versions
     value_changed = QtCore.Signal(object, str)
+    revert_to_default_requested = QtCore.Signal(str)
 
-    def __init__(self, attr_def, parent):
-        super(_BaseAttrDefWidget, self).__init__(parent)
+    def __init__(
+        self,
+        attr_def: AbstractAttrDef,
+        parent: "Union[QtWidgets.QWidget, None]",
+        handle_revert_to_default: Optional[bool] = True,
+    ):
+        super().__init__(parent)
 
-        self.attr_def = attr_def
+        self.attr_def: AbstractAttrDef = attr_def
+        self._handle_revert_to_default: bool = handle_revert_to_default
 
         main_layout = QtWidgets.QHBoxLayout(self)
         main_layout.setContentsMargins(0, 0, 0, 0)
@@ -253,6 +260,15 @@ class _BaseAttrDefWidget(QtWidgets.QWidget):
         self.main_layout = main_layout
 
         self._ui_init()
+
+    def revert_to_default_value(self):
+        if not self.attr_def.is_value_def:
+            return
+
+        if self._handle_revert_to_default:
+            self.set_value(self.attr_def.default)
+        else:
+            self.revert_to_default_requested.emit(self.attr_def.id)
 
     def _ui_init(self):
         raise NotImplementedError(

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -376,6 +376,14 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         pass
 
     @abstractmethod
+    def revert_instances_create_attr_values(
+        self,
+        instance_ids: List["Union[str, None]"],
+        key: str,
+    ):
+        pass
+
+    @abstractmethod
     def get_publish_attribute_definitions(
         self,
         instance_ids: Iterable[str],
@@ -394,6 +402,15 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         plugin_name: str,
         key: str,
         value: Any
+    ):
+        pass
+
+    @abstractmethod
+    def revert_instances_publish_attr_values(
+        self,
+        instance_ids: List["Union[str, None]"],
+        plugin_name: str,
+        key: str,
     ):
         pass
 

--- a/client/ayon_core/tools/publisher/control.py
+++ b/client/ayon_core/tools/publisher/control.py
@@ -412,6 +412,11 @@ class PublisherController(
             instance_ids, key, value
         )
 
+    def revert_instances_create_attr_values(self, instance_ids, key):
+        self._create_model.revert_instances_create_attr_values(
+            instance_ids, key
+        )
+
     def get_publish_attribute_definitions(self, instance_ids, include_context):
         """Collect publish attribute definitions for passed instances.
 
@@ -430,6 +435,13 @@ class PublisherController(
     ):
         return self._create_model.set_instances_publish_attr_values(
             instance_ids, plugin_name, key, value
+        )
+
+    def revert_instances_publish_attr_values(
+        self, instance_ids, plugin_name, key
+    ):
+        return self._create_model.revert_instances_publish_attr_values(
+            instance_ids, plugin_name, key
         )
 
     def get_product_name(

--- a/client/ayon_core/tools/publisher/models/create.py
+++ b/client/ayon_core/tools/publisher/models/create.py
@@ -40,6 +40,7 @@ from ayon_core.tools.publisher.abstract import (
 )
 
 CREATE_EVENT_SOURCE = "publisher.create.model"
+_DEFAULT_VALUE = object()
 
 
 class CreatorType:
@@ -752,20 +753,12 @@ class CreateModel:
         self._remove_instances_from_context(instance_ids)
 
     def set_instances_create_attr_values(self, instance_ids, key, value):
-        with self._create_context.bulk_value_changes(CREATE_EVENT_SOURCE):
-            for instance_id in instance_ids:
-                instance = self._get_instance_by_id(instance_id)
-                creator_attributes = instance["creator_attributes"]
-                attr_def = creator_attributes.get_attr_def(key)
-                if (
-                    attr_def is None
-                    or not attr_def.is_value_def
-                    or not attr_def.visible
-                    or not attr_def.enabled
-                    or not attr_def.is_value_valid(value)
-                ):
-                    continue
-                creator_attributes[key] = value
+        self._set_instances_create_attr_values(instance_ids, key, value)
+
+    def revert_instances_create_attr_values(self, instance_ids, key):
+        self._set_instances_create_attr_values(
+            instance_ids, key, _DEFAULT_VALUE
+        )
 
     def get_creator_attribute_definitions(
         self, instance_ids: List[str]
@@ -816,28 +809,18 @@ class CreateModel:
         return output
 
     def set_instances_publish_attr_values(
-        self, instance_ids, plugin_name,  key, value
+        self, instance_ids, plugin_name, key, value
     ):
-        with self._create_context.bulk_value_changes(CREATE_EVENT_SOURCE):
-            for instance_id in instance_ids:
-                if instance_id is None:
-                    instance = self._create_context
-                else:
-                    instance = self._get_instance_by_id(instance_id)
-                plugin_val = instance.publish_attributes[plugin_name]
-                attr_def = plugin_val.get_attr_def(key)
-                # Ignore if attribute is not available or enabled/visible
-                #   on the instance, or the value is not valid for definition
-                if (
-                    attr_def is None
-                    or not attr_def.is_value_def
-                    or not attr_def.visible
-                    or not attr_def.enabled
-                    or not attr_def.is_value_valid(value)
-                ):
-                    continue
+        self._set_instances_publish_attr_values(
+            instance_ids, plugin_name, key, value
+        )
 
-                plugin_val[key] = value
+    def revert_instances_publish_attr_values(
+        self, instance_ids, plugin_name, key
+    ):
+        self._set_instances_publish_attr_values(
+            instance_ids, plugin_name, key, _DEFAULT_VALUE
+        )
 
     def get_publish_attribute_definitions(
         self,
@@ -1063,6 +1046,53 @@ class CreateModel:
             self._creator_items[identifier] = (
                 CreatorItem.from_creator(creator)
             )
+
+    def _set_instances_create_attr_values(self, instance_ids, key, value):
+        with self._create_context.bulk_value_changes(CREATE_EVENT_SOURCE):
+            for instance_id in instance_ids:
+                instance = self._get_instance_by_id(instance_id)
+                creator_attributes = instance["creator_attributes"]
+                attr_def = creator_attributes.get_attr_def(key)
+                if (
+                    attr_def is None
+                    or not attr_def.is_value_def
+                    or not attr_def.visible
+                    or not attr_def.enabled
+                ):
+                    continue
+
+                if value is _DEFAULT_VALUE:
+                    creator_attributes[key] = attr_def.default
+
+                elif attr_def.is_value_valid(value):
+                    creator_attributes[key] = value
+
+    def _set_instances_publish_attr_values(
+        self, instance_ids, plugin_name, key, value
+    ):
+        with self._create_context.bulk_value_changes(CREATE_EVENT_SOURCE):
+            for instance_id in instance_ids:
+                if instance_id is None:
+                    instance = self._create_context
+                else:
+                    instance = self._get_instance_by_id(instance_id)
+                plugin_val = instance.publish_attributes[plugin_name]
+                attr_def = plugin_val.get_attr_def(key)
+                # Ignore if attribute is not available or enabled/visible
+                #   on the instance, or the value is not valid for definition
+                if (
+                    attr_def is None
+                    or not attr_def.is_value_def
+                    or not attr_def.visible
+                    or not attr_def.enabled
+                ):
+                    continue
+
+                if value is _DEFAULT_VALUE:
+                    plugin_val[key] = attr_def.default
+
+                elif attr_def.is_value_valid(value):
+                    plugin_val[key] = value
 
     def _cc_added_instance(self, event):
         instance_ids = {

--- a/client/ayon_core/tools/publisher/widgets/product_attributes.py
+++ b/client/ayon_core/tools/publisher/widgets/product_attributes.py
@@ -4,8 +4,10 @@ from typing import Dict, List, Any
 from qtpy import QtWidgets, QtCore
 
 from ayon_core.lib.attribute_definitions import AbstractAttrDef, UnknownDef
-from ayon_core.tools.utils import set_style_property
-from ayon_core.tools.attribute_defs import create_widget_for_attr_def
+from ayon_core.tools.attribute_defs import (
+    create_widget_for_attr_def,
+    AttributeDefinitionsLabel,
+)
 from ayon_core.tools.publisher.abstract import AbstractPublisherFrontend
 from ayon_core.tools.publisher.constants import (
     INPUTS_LAYOUT_HSPACING,
@@ -16,14 +18,6 @@ if typing.TYPE_CHECKING:
     from typing import Union
 
 
-def _set_label_overriden(label: QtWidgets.QLabel, overriden: bool):
-    set_style_property(
-        label,
-        "overriden",
-        "1" if overriden else ""
-    )
-
-
 class _CreateAttrDefInfo:
     """Helper class to store information about create attribute definition."""
     def __init__(
@@ -31,12 +25,14 @@ class _CreateAttrDefInfo:
         attr_def: AbstractAttrDef,
         instance_ids: List["Union[str, None]"],
         defaults: List[Any],
-        label_widget: "Union[None, QtWidgets.QLabel]",
+        label_widget: "Union[AttributeDefinitionsLabel, None]",
     ):
         self.attr_def: AbstractAttrDef = attr_def
         self.instance_ids: List["Union[str, None]"] = instance_ids
         self.defaults: List[Any] = defaults
-        self.label_widget: "Union[None, QtWidgets.QLabel]" = label_widget
+        self.label_widget: "Union[AttributeDefinitionsLabel, None]" = (
+            label_widget
+        )
 
 
 class _PublishAttrDefInfo:
@@ -47,13 +43,15 @@ class _PublishAttrDefInfo:
         plugin_name: str,
         instance_ids: List["Union[str, None]"],
         defaults: List[Any],
-        label_widget: "Union[None, QtWidgets.QLabel]",
+        label_widget: "Union[AttributeDefinitionsLabel, None]",
     ):
         self.attr_def: AbstractAttrDef = attr_def
         self.plugin_name: str = plugin_name
         self.instance_ids: List["Union[str, None]"] = instance_ids
         self.defaults: List[Any] = defaults
-        self.label_widget: "Union[None, QtWidgets.QLabel]" = label_widget
+        self.label_widget: "Union[AttributeDefinitionsLabel, None]" = (
+            label_widget
+        )
 
 
 class CreatorAttrsWidget(QtWidgets.QWidget):
@@ -187,7 +185,9 @@ class CreatorAttrsWidget(QtWidgets.QWidget):
                 label = attr_def.label or attr_def.key
 
             if label:
-                label_widget = QtWidgets.QLabel(label, self)
+                label_widget = AttributeDefinitionsLabel(
+                    attr_def.id, label, self
+                )
                 tooltip = attr_def.tooltip
                 if tooltip:
                     label_widget.setToolTip(tooltip)
@@ -202,7 +202,7 @@ class CreatorAttrsWidget(QtWidgets.QWidget):
                 if not attr_def.is_label_horizontal:
                     row += 1
                 attr_def_info.label_widget = label_widget
-                _set_label_overriden(label_widget, is_overriden)
+                label_widget.set_overridden(is_overriden)
 
             content_layout.addWidget(
                 widget, row, col_num, 1, expand_cols
@@ -237,7 +237,7 @@ class CreatorAttrsWidget(QtWidgets.QWidget):
         if attr_def_info.label_widget is not None:
             defaults = attr_def_info.defaults
             is_overriden = len(defaults) != 1 or value not in defaults
-            _set_label_overriden(attr_def_info.label_widget, is_overriden)
+            attr_def_info.label_widget.set_overridden(is_overriden)
 
         self._controller.set_instances_create_attr_values(
             attr_def_info.instance_ids,
@@ -367,7 +367,9 @@ class PublishPluginAttrsWidget(QtWidgets.QWidget):
                     if attr_def.is_value_def:
                         label = attr_def.label or attr_def.key
                     if label:
-                        label_widget = QtWidgets.QLabel(label, content_widget)
+                        label_widget = AttributeDefinitionsLabel(
+                            attr_def.id, label, content_widget
+                        )
                         tooltip = attr_def.tooltip
                         if tooltip:
                             label_widget.setToolTip(tooltip)
@@ -423,7 +425,7 @@ class PublishPluginAttrsWidget(QtWidgets.QWidget):
                     widget.set_value(values[0])
 
                 if label_widget is not None:
-                    _set_label_overriden(label_widget, is_overriden)
+                    label_widget.set_overridden(is_overriden)
 
         self._scroll_area.setWidget(content_widget)
         self._content_widget = content_widget
@@ -436,7 +438,7 @@ class PublishPluginAttrsWidget(QtWidgets.QWidget):
         if attr_def_info.label_widget is not None:
             defaults = attr_def_info.defaults
             is_overriden = len(defaults) != 1 or value not in defaults
-            _set_label_overriden(attr_def_info.label_widget, is_overriden)
+            attr_def_info.label_widget.set_overridden(is_overriden)
 
         self._controller.set_instances_publish_attr_values(
             attr_def_info.instance_ids,

--- a/client/ayon_core/tools/publisher/widgets/product_attributes.py
+++ b/client/ayon_core/tools/publisher/widgets/product_attributes.py
@@ -261,6 +261,7 @@ class CreatorAttrsWidget(QtWidgets.QWidget):
             attr_def_info.instance_ids,
             attr_def_info.attr_def.key,
         )
+        self._refresh_content()
 
 
 class PublishPluginAttrsWidget(QtWidgets.QWidget):
@@ -480,6 +481,7 @@ class PublishPluginAttrsWidget(QtWidgets.QWidget):
             attr_def_info.plugin_name,
             attr_def_info.attr_def.key,
         )
+        self._refresh_content()
 
     def _on_instance_attr_defs_change(self, event):
         for instance_id in event.data:


### PR DESCRIPTION
## Changelog Description
Implemented context menu option on attribute definitions to reset attribute values to default states.

## Additional info
All attribute definition widgets should have implemented logic to be able to reset value of attributes to default value. In Publisher it does reset to default value per instance.

## Testing notes:
1. Open Publisher in host of your choice.
2. Create instance/s.
3. In Publish tab select instance/s and change their values.
4. When you right click them and choose `Revert to default` it should set value to default value defined by create/publish plugin. It should also work on multiselection.
