### PR TITLE
Publisher: Refresh of create/publish values under correct conditions

### DIFF
--- a/client/ayon_core/tools/publisher/widgets/product_attributes.py
+++ b/client/ayon_core/tools/publisher/widgets/product_attributes.py
@@ -232,7 +232,7 @@ class CreatorAttrsWidget(QtWidgets.QWidget):
         for instance_id, changes in event["instance_changes"].items():
             if (
                 instance_id in self._current_instance_ids
-                and "creator_attributes" not in changes
+                and "creator_attributes" in changes
             ):
                 self._refresh_content()
                 break
@@ -498,7 +498,7 @@ class PublishPluginAttrsWidget(QtWidgets.QWidget):
         for instance_id, changes in event["instance_changes"].items():
             if (
                 instance_id in self._current_instance_ids
-                and "publish_attributes" not in changes
+                and "publish_attributes" in changes
             ):
                 self._refresh_content()
                 break


### PR DESCRIPTION
## Changelog Description
Fixed conditions triggering refresh of values in UI.

## Additional info
I've noticed that the condition that should trigger refresh of values in UI has opposite condition to what it should be. Both create and publish attributes should be updated if happened changes in those keys.

## Testing notes:
As far as I know this feature is not used at this moment. It should be possible to fake it. For example in Create plugin, register listen to value changes and make sure instance has 2 checkboxes, when checkbox 1 changes value, also change value of checkbox 2 to the same value in the callback. That change done by create plugin should be propagated to UI.