### PR TITLE
Attribute definitions: Fix FileDef value conversions

### DIFF
--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -966,7 +966,9 @@ class FileDef(AbstractAttrDef):
                     FileDefItem.from_dict(default)
 
                 elif isinstance(default, str):
-                    default = FileDefItem.from_paths([default.strip()])[0]
+                    default = FileDefItem.from_paths(
+                        [default.strip()], allow_sequences
+                    )[0]
 
                 else:
                     raise TypeError((
@@ -1044,7 +1046,9 @@ class FileDef(AbstractAttrDef):
                         pass
 
             if string_paths:
-                file_items = FileDefItem.from_paths(string_paths)
+                file_items = FileDefItem.from_paths(
+                    string_paths, self.allow_sequences
+                )
                 dict_items.extend([
                     file_item.to_dict()
                     for file_item in file_items


### PR DESCRIPTION
## Changelog Description
Fix issues connected to calling `from_paths` with invalid arguments.

## Additional info
Pass to `from_paths` all required arguments.

## Testing notes:
Validate the changes in code.
1. Create `FileDef` with default value set to a path (`FileDef(..., default=["/path/to/file"])`).
2. It should not crash.

Resolves https://github.com/ynput/ayon-core/issues/991