### PR TITLE
Chore: Add type hints to attribute definitions

### DIFF
--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -6,13 +6,32 @@ import json
 import copy
 import warnings
 from abc import ABCMeta, abstractmethod
-from typing import Any, Optional
+import typing
+from typing import Any, Optional, List, TypedDict
 
 import clique
 
+if typing.TYPE_CHECKING:
+    from typing import Union
 # Global variable which store attribute definitions by type
 #   - default types are registered on import
 _attr_defs_by_type = {}
+
+# Type hint helpers
+IntFloatType = "Union[int, float]"
+
+
+class EnumItemDict(TypedDict):
+    label: str
+    value: Any
+
+
+class FileDefItemDict(TypedDict):
+    directory: str
+    filenames: List[str]
+    frames: Optional[List[int]]
+    template: Optional[str]
+    is_sequence: Optional[bool]
 
 
 class AbstractAttrDefMeta(ABCMeta):

--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -15,67 +15,6 @@ import clique
 _attr_defs_by_type = {}
 
 
-def register_attr_def_class(cls):
-    """Register attribute definition.
-
-    Currently registered definitions are used to deserialize data to objects.
-
-    Attrs:
-        cls (AbstractAttrDef): Non-abstract class to be registered with unique
-            'type' attribute.
-
-    Raises:
-        KeyError: When type was already registered.
-    """
-
-    if cls.type in _attr_defs_by_type:
-        raise KeyError("Type \"{}\" was already registered".format(cls.type))
-    _attr_defs_by_type[cls.type] = cls
-
-
-def get_attributes_keys(attribute_definitions):
-    """Collect keys from list of attribute definitions.
-
-    Args:
-        attribute_definitions (List[AbstractAttrDef]): Objects of attribute
-            definitions.
-
-    Returns:
-        Set[str]: Keys that will be created using passed attribute definitions.
-    """
-
-    keys = set()
-    if not attribute_definitions:
-        return keys
-
-    for attribute_def in attribute_definitions:
-        if not isinstance(attribute_def, UIDef):
-            keys.add(attribute_def.key)
-    return keys
-
-
-def get_default_values(attribute_definitions):
-    """Receive default values for attribute definitions.
-
-    Args:
-        attribute_definitions (List[AbstractAttrDef]): Attribute definitions
-            for which default values should be collected.
-
-    Returns:
-        Dict[str, Any]: Default values for passed attribute definitions.
-    """
-
-    output = {}
-    if not attribute_definitions:
-        return output
-
-    for attr_def in attribute_definitions:
-        # Skip UI definitions
-        if not isinstance(attr_def, UIDef):
-            output[attr_def.key] = attr_def.default
-    return output
-
-
 class AbstractAttrDefMeta(ABCMeta):
     """Metaclass to validate the existence of 'key' attribute.
 
@@ -1060,6 +999,67 @@ class FileDef(AbstractAttrDef):
         if self.single_item:
             return FileDefItem.create_empty_item().to_dict()
         return []
+
+
+def register_attr_def_class(cls):
+    """Register attribute definition.
+
+    Currently registered definitions are used to deserialize data to objects.
+
+    Attrs:
+        cls (AbstractAttrDef): Non-abstract class to be registered with unique
+            'type' attribute.
+
+    Raises:
+        KeyError: When type was already registered.
+    """
+
+    if cls.type in _attr_defs_by_type:
+        raise KeyError("Type \"{}\" was already registered".format(cls.type))
+    _attr_defs_by_type[cls.type] = cls
+
+
+def get_attributes_keys(attribute_definitions):
+    """Collect keys from list of attribute definitions.
+
+    Args:
+        attribute_definitions (List[AbstractAttrDef]): Objects of attribute
+            definitions.
+
+    Returns:
+        Set[str]: Keys that will be created using passed attribute definitions.
+    """
+
+    keys = set()
+    if not attribute_definitions:
+        return keys
+
+    for attribute_def in attribute_definitions:
+        if not isinstance(attribute_def, UIDef):
+            keys.add(attribute_def.key)
+    return keys
+
+
+def get_default_values(attribute_definitions):
+    """Receive default values for attribute definitions.
+
+    Args:
+        attribute_definitions (List[AbstractAttrDef]): Attribute definitions
+            for which default values should be collected.
+
+    Returns:
+        Dict[str, Any]: Default values for passed attribute definitions.
+    """
+
+    output = {}
+    if not attribute_definitions:
+        return output
+
+    for attr_def in attribute_definitions:
+        # Skip UI definitions
+        if not isinstance(attr_def, UIDef):
+            output[attr_def.key] = attr_def.default
+    return output
 
 
 def serialize_attr_def(attr_def):

--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -21,7 +21,7 @@ from typing import (
 import clique
 
 if typing.TYPE_CHECKING:
-    from typing import Tuple, Self, Union, Pattern
+    from typing import Self, Union, Pattern
 
 # Global variable which store attribute definitions by type
 #   - default types are registered on import

--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -7,12 +7,14 @@ import copy
 import warnings
 from abc import ABCMeta, abstractmethod
 import typing
-from typing import Any, Optional, List, TypedDict
+from typing import (
+    Any, Optional, List, Set, Dict, Iterable, TypedDict, TypeVar,
+)
 
 import clique
 
 if typing.TYPE_CHECKING:
-    from typing import Union
+    from typing import Self, Union, Pattern
 # Global variable which store attribute definitions by type
 #   - default types are registered on import
 _attr_defs_by_type = {}
@@ -51,8 +53,12 @@ class AbstractAttrDefMeta(ABCMeta):
 
 
 def _convert_reversed_attr(
-    main_value, depr_value, main_label, depr_label, default
-):
+    main_value: Any,
+    depr_value: Any,
+    main_label: str,
+    depr_label: str,
+    default: Any,
+) -> Any:
     if main_value is not None and depr_value is not None:
         if main_value == depr_value:
             print(
@@ -141,7 +147,7 @@ class AbstractAttrDef(metaclass=AbstractAttrDefMeta):
     def id(self) -> str:
         return self._id
 
-    def clone(self):
+    def clone(self) -> "Self":
         data = self.serialize()
         data.pop("type")
         return self.deserialize(data)
@@ -214,7 +220,7 @@ class AbstractAttrDef(metaclass=AbstractAttrDefMeta):
         pass
 
     @abstractmethod
-    def convert_value(self, value):
+    def convert_value(self, value: Any) -> Any:
         """Convert value to a valid one.
 
         Convert passed value to a valid type. Use default if value can't be
@@ -223,7 +229,7 @@ class AbstractAttrDef(metaclass=AbstractAttrDefMeta):
 
         pass
 
-    def serialize(self):
+    def serialize(self) -> Dict[str, Any]:
         """Serialize object to data so it's possible to recreate it.
 
         Returns:
@@ -246,7 +252,7 @@ class AbstractAttrDef(metaclass=AbstractAttrDefMeta):
         return data
 
     @classmethod
-    def deserialize(cls, data):
+    def deserialize(cls, data: Dict[str, Any]) -> "Self":
         """Recreate object from data.
 
         Data can be received using 'serialize' method.
@@ -257,7 +263,7 @@ class AbstractAttrDef(metaclass=AbstractAttrDefMeta):
 
         return cls(**data)
 
-    def _def_type_compare(self, other: "AbstractAttrDef") -> bool:
+    def _def_type_compare(self, other: "Self") -> bool:
         return True
 
 
@@ -268,13 +274,19 @@ class AbstractAttrDef(metaclass=AbstractAttrDefMeta):
 class UIDef(AbstractAttrDef):
     is_value_def = False
 
-    def __init__(self, key=None, default=None, *args, **kwargs):
+    def __init__(
+        self,
+        key: Optional[str] = None,
+        default: Optional[Any] = None,
+        *args,
+        **kwargs
+    ):
         super().__init__(key, default, *args, **kwargs)
 
     def is_value_valid(self, value: Any) -> bool:
         return True
 
-    def convert_value(self, value):
+    def convert_value(self, value: Any) -> Any:
         return value
 
 
@@ -305,14 +317,14 @@ class UnknownDef(AbstractAttrDef):
 
     type = "unknown"
 
-    def __init__(self, key, default=None, **kwargs):
+    def __init__(self, key: str, default: Optional[Any] = None, **kwargs):
         kwargs["default"] = default
         super().__init__(key, **kwargs)
 
     def is_value_valid(self, value: Any) -> bool:
         return True
 
-    def convert_value(self, value):
+    def convert_value(self, value: Any) -> Any:
         return value
 
 
@@ -327,7 +339,7 @@ class HiddenDef(AbstractAttrDef):
 
     type = "hidden"
 
-    def __init__(self, key, default=None, **kwargs):
+    def __init__(self, key: str, default: Optional[Any] = None, **kwargs):
         kwargs["default"] = default
         kwargs["visible"] = False
         super().__init__(key, **kwargs)
@@ -335,7 +347,7 @@ class HiddenDef(AbstractAttrDef):
     def is_value_valid(self, value: Any) -> bool:
         return True
 
-    def convert_value(self, value):
+    def convert_value(self, value: Any) -> Any:
         return value
 
 
@@ -360,7 +372,12 @@ class NumberDef(AbstractAttrDef):
     ]
 
     def __init__(
-        self, key, minimum=None, maximum=None, decimals=None, default=None,
+        self,
+        key: str,
+        minimum: Optional[IntFloatType] = None,
+        maximum: Optional[IntFloatType] = None,
+        decimals: Optional[int] = None,
+        default: Optional[IntFloatType] = None,
         **kwargs
     ):
         minimum = 0 if minimum is None else minimum
@@ -386,9 +403,9 @@ class NumberDef(AbstractAttrDef):
 
         super().__init__(key, default=default, **kwargs)
 
-        self.minimum = minimum
-        self.maximum = maximum
-        self.decimals = 0 if decimals is None else decimals
+        self.minimum: IntFloatType = minimum
+        self.maximum: IntFloatType = maximum
+        self.decimals: int = 0 if decimals is None else decimals
 
     def is_value_valid(self, value: Any) -> bool:
         if self.decimals == 0:
@@ -400,7 +417,7 @@ class NumberDef(AbstractAttrDef):
             return False
         return True
 
-    def convert_value(self, value):
+    def convert_value(self, value: Any) -> IntFloatType:
         if isinstance(value, str):
             try:
                 value = float(value)
@@ -444,7 +461,12 @@ class TextDef(AbstractAttrDef):
     ]
 
     def __init__(
-        self, key, multiline=None, regex=None, placeholder=None, default=None,
+        self,
+        key: str,
+        multiline: Optional[bool] = None,
+        regex: Optional[str] = None,
+        placeholder: Optional[str] = None,
+        default: Optional[str] = None,
         **kwargs
     ):
         if default is None:
@@ -463,9 +485,9 @@ class TextDef(AbstractAttrDef):
         if isinstance(regex, str):
             regex = re.compile(regex)
 
-        self.multiline = multiline
-        self.placeholder = placeholder
-        self.regex = regex
+        self.multiline: bool = multiline
+        self.placeholder: Optional[str] = placeholder
+        self.regex: Optional["Pattern"] = regex
 
     def is_value_valid(self, value: Any) -> bool:
         if not isinstance(value, str):
@@ -474,12 +496,12 @@ class TextDef(AbstractAttrDef):
             return False
         return True
 
-    def convert_value(self, value):
+    def convert_value(self, value: Any) -> str:
         if isinstance(value, str):
             return value
         return self.default
 
-    def serialize(self):
+    def serialize(self) -> Dict[str, Any]:
         data = super().serialize()
         regex = None
         if self.regex is not None:
@@ -503,8 +525,9 @@ class EnumDef(AbstractAttrDef):
     is enabled.
 
     Args:
-        items (Union[list[str], list[dict[str, Any]]): Items definition that
-            can be converted using 'prepare_enum_items'.
+        key (str): Key under which value is stored.
+        items (Union[Dict[Any, str], List[Any], List[EnumItemDict]]): Items
+            definition that can be converted using 'prepare_enum_items'.
         default (Optional[Any]): Default value. Must be one key(value) from
             passed items or list of values for multiselection.
         multiselection (Optional[bool]): If True, multiselection is allowed.
@@ -514,7 +537,12 @@ class EnumDef(AbstractAttrDef):
     type = "enum"
 
     def __init__(
-        self, key, items, default=None, multiselection=False, **kwargs
+        self,
+        key: str,
+        items: "Union[Dict[Any, str], List[Any], List[EnumItemDict]]",
+        default: "Union[str, List[Any]]" = None,
+        multiselection: Optional[bool] = False,
+        **kwargs
     ):
         if not items:
             raise ValueError((
@@ -525,6 +553,9 @@ class EnumDef(AbstractAttrDef):
         items = self.prepare_enum_items(items)
         item_values = [item["value"] for item in items]
         item_values_set = set(item_values)
+        if multiselection is None:
+            multiselection = False
+
         if multiselection:
             if default is None:
                 default = []
@@ -535,9 +566,9 @@ class EnumDef(AbstractAttrDef):
 
         super().__init__(key, default=default, **kwargs)
 
-        self.items = items
-        self._item_values = item_values_set
-        self.multiselection = multiselection
+        self.items: List[EnumItemDict] = items
+        self._item_values: Set[Any] = item_values_set
+        self.multiselection: bool = multiselection
 
     def convert_value(self, value):
         if not self.multiselection:
@@ -567,7 +598,7 @@ class EnumDef(AbstractAttrDef):
         return data
 
     @staticmethod
-    def prepare_enum_items(items):
+    def prepare_enum_items(items) -> List[EnumItemDict]:
         """Convert items to unified structure.
 
         Output is a list where each item is dictionary with 'value'
@@ -583,13 +614,13 @@ class EnumDef(AbstractAttrDef):
         ```
 
         Args:
-            items (Union[Dict[str, Any], List[Any], List[Dict[str, Any]]): The
+            items (Union[Dict[Any, str], List[Any], List[EnumItemDict]]): The
                 items to convert.
 
         Returns:
-            List[Dict[str, Any]]: Unified structure of items.
-        """
+            List[EnumItemDict]: Unified structure of items.
 
+        """
         output = []
         if isinstance(items, dict):
             for value, label in items.items():
@@ -644,7 +675,7 @@ class BoolDef(AbstractAttrDef):
 
     type = "bool"
 
-    def __init__(self, key, default=None, **kwargs):
+    def __init__(self, key: str, default: Optional[bool] = None, **kwargs):
         if default is None:
             default = False
         super().__init__(key, default=default, **kwargs)
@@ -652,7 +683,7 @@ class BoolDef(AbstractAttrDef):
     def is_value_valid(self, value: Any) -> bool:
         return isinstance(value, bool)
 
-    def convert_value(self, value):
+    def convert_value(self, value: Any) -> bool:
         if isinstance(value, bool):
             return value
         return self.default
@@ -660,7 +691,11 @@ class BoolDef(AbstractAttrDef):
 
 class FileDefItem:
     def __init__(
-        self, directory, filenames, frames=None, template=None
+        self,
+        directory: str,
+        filenames: List[str],
+        frames: Optional[List[int]] = None,
+        template: Optional[str] = None,
     ):
         self.directory = directory
 
@@ -689,7 +724,7 @@ class FileDefItem:
         )
 
     @property
-    def label(self):
+    def label(self) -> Optional[str]:
         if self.is_empty:
             return None
 
@@ -732,7 +767,7 @@ class FileDefItem:
             filename_template, ",".join(ranges)
         )
 
-    def split_sequence(self):
+    def split_sequence(self) -> List["Self"]:
         if not self.is_sequence:
             raise ValueError("Cannot split single file item")
 
@@ -743,7 +778,7 @@ class FileDefItem:
         return self.from_paths(paths, False)
 
     @property
-    def ext(self):
+    def ext(self) -> Optional[str]:
         if self.is_empty:
             return None
         _, ext = os.path.splitext(self.filenames[0])
@@ -752,14 +787,14 @@ class FileDefItem:
         return None
 
     @property
-    def lower_ext(self):
+    def lower_ext(self) -> Optional[str]:
         ext = self.ext
         if ext is not None:
             return ext.lower()
         return ext
 
     @property
-    def is_dir(self):
+    def is_dir(self) -> bool:
         if self.is_empty:
             return False
 
@@ -768,10 +803,15 @@ class FileDefItem:
             return False
         return True
 
-    def set_directory(self, directory):
+    def set_directory(self, directory: str):
         self.directory = directory
 
-    def set_filenames(self, filenames, frames=None, template=None):
+    def set_filenames(
+        self,
+        filenames: List[str],
+        frames: Optional[List[int]] = None,
+        template: Optional[str] = None,
+    ):
         if frames is None:
             frames = []
         is_sequence = False
@@ -788,11 +828,15 @@ class FileDefItem:
         self.is_sequence = is_sequence
 
     @classmethod
-    def create_empty_item(cls):
+    def create_empty_item(cls) -> "Self":
         return cls("", "")
 
     @classmethod
-    def from_value(cls, value, allow_sequences):
+    def from_value(
+        cls,
+        value: "Union[List[FileDefItemDict], FileDefItemDict]",
+        allow_sequences: bool,
+    ) -> List["Self"]:
         """Convert passed value to FileDefItem objects.
 
         Returns:
@@ -830,7 +874,7 @@ class FileDefItem:
         return output
 
     @classmethod
-    def from_dict(cls, data):
+    def from_dict(cls, data: FileDefItemDict) -> "Self":
         return cls(
             data["directory"],
             data["filenames"],
@@ -839,7 +883,11 @@ class FileDefItem:
         )
 
     @classmethod
-    def from_paths(cls, paths, allow_sequences):
+    def from_paths(
+        cls,
+        paths: List[str],
+        allow_sequences: bool,
+    ) -> List["Self"]:
         filenames_by_dir = collections.defaultdict(list)
         for path in paths:
             normalized = os.path.normpath(path)
@@ -868,7 +916,7 @@ class FileDefItem:
 
         return output
 
-    def to_dict(self):
+    def to_dict(self) -> FileDefItemDict:
         output = {
             "is_sequence": self.is_sequence,
             "directory": self.directory,
@@ -906,8 +954,15 @@ class FileDef(AbstractAttrDef):
     ]
 
     def __init__(
-        self, key, single_item=True, folders=None, extensions=None,
-        allow_sequences=True, extensions_label=None, default=None, **kwargs
+        self,
+        key: str,
+        single_item: Optional[bool] = True,
+        folders: Optional[bool] = None,
+        extensions: Optional[Iterable[str]] = None,
+        allow_sequences: Optional[bool] = True,
+        extensions_label: Optional[str] = None,
+        default: Optional["Union[FileDefItemDict, List[str]]"] = None,
+        **kwargs
     ):
         if folders is None and extensions is None:
             folders = True
@@ -943,14 +998,14 @@ class FileDef(AbstractAttrDef):
         if is_label_horizontal is None:
             kwargs["is_label_horizontal"] = False
 
-        self.single_item = single_item
-        self.folders = folders
-        self.extensions = set(extensions)
-        self.allow_sequences = allow_sequences
-        self.extensions_label = extensions_label
+        self.single_item: bool = single_item
+        self.folders: bool = folders
+        self.extensions: Set[str] = set(extensions)
+        self.allow_sequences: bool = allow_sequences
+        self.extensions_label: Optional[str] = extensions_label
         super().__init__(key, default=default, **kwargs)
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if not super().__eq__(other):
             return False
 
@@ -984,7 +1039,9 @@ class FileDef(AbstractAttrDef):
                 return False
         return True
 
-    def convert_value(self, value):
+    def convert_value(
+        self, value: Any
+    ) -> "Union[FileDefItemDict, List[FileDefItemDict]]":
         if isinstance(value, (str, dict)):
             value = [value]
 

--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -52,8 +52,8 @@ class AbstractAttrDefMeta(ABCMeta):
     """Metaclass to validate the existence of 'key' attribute.
 
     Each object of `AbstractAttrDef` must have defined 'key' attribute.
-    """
 
+    """
     def __call__(cls, *args, **kwargs):
         obj = super(AbstractAttrDefMeta, cls).__call__(*args, **kwargs)
         init_class = getattr(obj, "__init__class__", None)
@@ -116,8 +116,8 @@ class AbstractAttrDef(metaclass=AbstractAttrDefMeta):
         enabled (Optional[bool]): Item is enabled (for UI purposes).
         hidden (Optional[bool]): DEPRECATED: Use 'visible' instead.
         disabled (Optional[bool]): DEPRECATED: Use 'enabled' instead.
-    """
 
+    """
     type_attributes = []
 
     is_value_def = True
@@ -227,8 +227,8 @@ class AbstractAttrDef(metaclass=AbstractAttrDefMeta):
 
         Returns:
             str: Type of attribute definition.
-        """
 
+        """
         pass
 
     @abstractmethod
@@ -237,8 +237,8 @@ class AbstractAttrDef(metaclass=AbstractAttrDefMeta):
 
         Convert passed value to a valid type. Use default if value can't be
         converted.
-        """
 
+        """
         pass
 
     def serialize(self) -> Dict[str, Any]:
@@ -247,8 +247,8 @@ class AbstractAttrDef(metaclass=AbstractAttrDefMeta):
         Returns:
             Dict[str, Any]: Serialized object that can be passed to
                 'deserialize' method.
-        """
 
+        """
         data = {
             "type": self.type,
             "key": self.key,
@@ -327,8 +327,8 @@ class UnknownDef(AbstractAttrDef):
 
     This attribute can be used to keep existing data unchanged but does not
     have known definition of type.
-    """
 
+    """
     type = "unknown"
 
     def __init__(self, key: str, default: Optional[Any] = None, **kwargs):
@@ -349,8 +349,8 @@ class HiddenDef(AbstractAttrDef):
     to other attributes (e.g. in multi-page UIs).
 
     Keep in mind the value should be possible to parse by json parser.
-    """
 
+    """
     type = "hidden"
 
     def __init__(self, key: str, default: Optional[Any] = None, **kwargs):
@@ -376,8 +376,8 @@ class NumberDef(AbstractAttrDef):
         maximum(int, float): Maximum possible value.
         decimals(int): Maximum decimal points of value.
         default(int, float): Default value for conversion.
-    """
 
+    """
     type = "number"
     type_attributes = [
         "minimum",
@@ -466,8 +466,8 @@ class TextDef(AbstractAttrDef):
         regex(str, re.Pattern): Regex validation.
         placeholder(str): UI placeholder for attribute.
         default(str, None): Default value. Empty string used when not defined.
-    """
 
+    """
     type = "text"
     type_attributes = [
         "multiline",
@@ -546,8 +546,8 @@ class EnumDef(AbstractAttrDef):
             passed items or list of values for multiselection.
         multiselection (Optional[bool]): If True, multiselection is allowed.
             Output is list of selected items.
-    """
 
+    """
     type = "enum"
 
     def __init__(
@@ -684,8 +684,8 @@ class BoolDef(AbstractAttrDef):
 
     Args:
         default(bool): Default value. Set to `False` if not defined.
-    """
 
+    """
     type = "bool"
 
     def __init__(self, key: str, default: Optional[bool] = None, **kwargs):
@@ -854,8 +854,8 @@ class FileDefItem:
 
         Returns:
             list: Created FileDefItem objects.
-        """
 
+        """
         # Convert single item to iterable
         if not isinstance(value, (list, tuple, set)):
             value = [value]
@@ -1101,8 +1101,8 @@ def register_attr_def_class(cls: AttrDefType):
 
     Raises:
         KeyError: When type was already registered.
-    """
 
+    """
     if cls.type in _attr_defs_by_type:
         raise KeyError("Type \"{}\" was already registered".format(cls.type))
     _attr_defs_by_type[cls.type] = cls
@@ -1119,8 +1119,8 @@ def get_attributes_keys(
 
     Returns:
         Set[str]: Keys that will be created using passed attribute definitions.
-    """
 
+    """
     keys = set()
     if not attribute_definitions:
         return keys
@@ -1142,8 +1142,8 @@ def get_default_values(
 
     Returns:
         Dict[str, Any]: Default values for passed attribute definitions.
-    """
 
+    """
     output = {}
     if not attribute_definitions:
         return output
@@ -1163,8 +1163,8 @@ def serialize_attr_def(attr_def: AttrDefType) -> Dict[str, Any]:
 
     Returns:
         Dict[str, Any]: Serialized data.
-    """
 
+    """
     return attr_def.serialize()
 
 
@@ -1178,8 +1178,8 @@ def serialize_attr_defs(
 
     Returns:
         List[Dict[str, Any]]: Serialized data.
-    """
 
+    """
     return [
         serialize_attr_def(attr_def)
         for attr_def in attr_defs
@@ -1192,8 +1192,8 @@ def deserialize_attr_def(attr_def_data: Dict[str, Any]) -> AttrDefType:
     Args:
         attr_def_data (Dict[str, Any]): Attribute definition data to
             deserialize.
-    """
 
+    """
     attr_type = attr_def_data.pop("type")
     cls = _attr_defs_by_type[attr_type]
     return cls.deserialize(attr_def_data)
@@ -1206,8 +1206,8 @@ def deserialize_attr_defs(
 
     Args:
         List[Dict[str, Any]]: List of attribute definitions.
-    """
 
+    """
     return [
         deserialize_attr_def(attr_def_data)
         for attr_def_data in attr_defs_data

--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -10,7 +10,6 @@ import typing
 from typing import (
     Any,
     Optional,
-    Tuple,
     List,
     Set,
     Dict,
@@ -22,7 +21,7 @@ from typing import (
 import clique
 
 if typing.TYPE_CHECKING:
-    from typing import Self, Union, Pattern
+    from typing import Tuple, Self, Union, Pattern
 
 # Global variable which store attribute definitions by type
 #   - default types are registered on import

--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -279,6 +279,8 @@ class AbstractAttrDef(metaclass=AbstractAttrDefMeta):
         return True
 
 
+AttrDefType = TypeVar("AttrDefType", bound=AbstractAttrDef)
+
 # -----------------------------------------
 # UI attribute definitions won't hold value
 # -----------------------------------------
@@ -1088,13 +1090,13 @@ class FileDef(AbstractAttrDef):
         return []
 
 
-def register_attr_def_class(cls):
+def register_attr_def_class(cls: AttrDefType):
     """Register attribute definition.
 
     Currently registered definitions are used to deserialize data to objects.
 
     Attrs:
-        cls (AbstractAttrDef): Non-abstract class to be registered with unique
+        cls (AttrDefType): Non-abstract class to be registered with unique
             'type' attribute.
 
     Raises:
@@ -1106,11 +1108,13 @@ def register_attr_def_class(cls):
     _attr_defs_by_type[cls.type] = cls
 
 
-def get_attributes_keys(attribute_definitions):
+def get_attributes_keys(
+    attribute_definitions: List[AttrDefType]
+) -> Set[str]:
     """Collect keys from list of attribute definitions.
 
     Args:
-        attribute_definitions (List[AbstractAttrDef]): Objects of attribute
+        attribute_definitions (List[AttrDefType]): Objects of attribute
             definitions.
 
     Returns:
@@ -1127,11 +1131,13 @@ def get_attributes_keys(attribute_definitions):
     return keys
 
 
-def get_default_values(attribute_definitions):
+def get_default_values(
+    attribute_definitions: List[AttrDefType]
+) -> Dict[str, Any]:
     """Receive default values for attribute definitions.
 
     Args:
-        attribute_definitions (List[AbstractAttrDef]): Attribute definitions
+        attribute_definitions (List[AttrDefType]): Attribute definitions
             for which default values should be collected.
 
     Returns:
@@ -1149,11 +1155,11 @@ def get_default_values(attribute_definitions):
     return output
 
 
-def serialize_attr_def(attr_def):
+def serialize_attr_def(attr_def: AttrDefType) -> Dict[str, Any]:
     """Serialize attribute definition to data.
 
     Args:
-        attr_def (AbstractAttrDef): Attribute definition to serialize.
+        attr_def (AttrDefType): Attribute definition to serialize.
 
     Returns:
         Dict[str, Any]: Serialized data.
@@ -1162,11 +1168,13 @@ def serialize_attr_def(attr_def):
     return attr_def.serialize()
 
 
-def serialize_attr_defs(attr_defs):
+def serialize_attr_defs(
+    attr_defs: List[AttrDefType]
+) -> List[Dict[str, Any]]:
     """Serialize attribute definitions to data.
 
     Args:
-        attr_defs (List[AbstractAttrDef]): Attribute definitions to serialize.
+        attr_defs (List[AttrDefType]): Attribute definitions to serialize.
 
     Returns:
         List[Dict[str, Any]]: Serialized data.
@@ -1178,7 +1186,7 @@ def serialize_attr_defs(attr_defs):
     ]
 
 
-def deserialize_attr_def(attr_def_data):
+def deserialize_attr_def(attr_def_data: Dict[str, Any]) -> AttrDefType:
     """Deserialize attribute definition from data.
 
     Args:
@@ -1191,7 +1199,9 @@ def deserialize_attr_def(attr_def_data):
     return cls.deserialize(attr_def_data)
 
 
-def deserialize_attr_defs(attr_defs_data):
+def deserialize_attr_defs(
+    attr_defs_data: List[Dict[str, Any]]
+) -> List[AttrDefType]:
     """Deserialize attribute definitions.
 
     Args:

--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -8,13 +8,22 @@ import warnings
 from abc import ABCMeta, abstractmethod
 import typing
 from typing import (
-    Any, Optional, List, Set, Dict, Iterable, TypedDict, TypeVar,
+    Any,
+    Optional,
+    Tuple,
+    List,
+    Set,
+    Dict,
+    Iterable,
+    TypedDict,
+    TypeVar,
 )
 
 import clique
 
 if typing.TYPE_CHECKING:
     from typing import Self, Union, Pattern
+
 # Global variable which store attribute definitions by type
 #   - default types are registered on import
 _attr_defs_by_type = {}
@@ -26,6 +35,9 @@ IntFloatType = "Union[int, float]"
 class EnumItemDict(TypedDict):
     label: str
     value: Any
+
+
+EnumItemsInputType = "Union[Dict[Any, str], List[Tuple[Any, str]], List[Any], List[EnumItemDict]]"  # noqa: E501
 
 
 class FileDefItemDict(TypedDict):
@@ -526,8 +538,8 @@ class EnumDef(AbstractAttrDef):
 
     Args:
         key (str): Key under which value is stored.
-        items (Union[Dict[Any, str], List[Any], List[EnumItemDict]]): Items
-            definition that can be converted using 'prepare_enum_items'.
+        items (EnumItemsInputType): Items definition that can be converted
+            using 'prepare_enum_items'.
         default (Optional[Any]): Default value. Must be one key(value) from
             passed items or list of values for multiselection.
         multiselection (Optional[bool]): If True, multiselection is allowed.
@@ -539,7 +551,7 @@ class EnumDef(AbstractAttrDef):
     def __init__(
         self,
         key: str,
-        items: "Union[Dict[Any, str], List[Any], List[EnumItemDict]]",
+        items: EnumItemsInputType,
         default: "Union[str, List[Any]]" = None,
         multiselection: Optional[bool] = False,
         **kwargs
@@ -598,7 +610,7 @@ class EnumDef(AbstractAttrDef):
         return data
 
     @staticmethod
-    def prepare_enum_items(items) -> List[EnumItemDict]:
+    def prepare_enum_items(items: EnumItemsInputType) -> List[EnumItemDict]:
         """Convert items to unified structure.
 
         Output is a list where each item is dictionary with 'value'
@@ -614,8 +626,7 @@ class EnumDef(AbstractAttrDef):
         ```
 
         Args:
-            items (Union[Dict[Any, str], List[Any], List[EnumItemDict]]): The
-                items to convert.
+            items (EnumItemsInputType): The items to convert.
 
         Returns:
             List[EnumItemDict]: Unified structure of items.

--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -14,14 +14,35 @@ from typing import (
     Set,
     Dict,
     Iterable,
-    TypedDict,
     TypeVar,
 )
 
 import clique
 
 if typing.TYPE_CHECKING:
-    from typing import Self, Union, Pattern
+    from typing import Self, Tuple, Union, TypedDict, Pattern
+
+
+    class EnumItemDict(TypedDict):
+        label: str
+        value: Any
+
+
+    EnumItemsInputType = Union[
+        Dict[Any, str],
+        List[Tuple[Any, str]],
+        List[Any],
+        List[EnumItemDict]
+    ]
+
+
+    class FileDefItemDict(TypedDict):
+        directory: str
+        filenames: List[str]
+        frames: Optional[List[int]]
+        template: Optional[str]
+        is_sequence: Optional[bool]
+
 
 # Global variable which store attribute definitions by type
 #   - default types are registered on import
@@ -29,22 +50,6 @@ _attr_defs_by_type = {}
 
 # Type hint helpers
 IntFloatType = "Union[int, float]"
-
-
-class EnumItemDict(TypedDict):
-    label: str
-    value: Any
-
-
-EnumItemsInputType = "Union[Dict[Any, str], List[Tuple[Any, str]], List[Any], List[EnumItemDict]]"  # noqa: E501
-
-
-class FileDefItemDict(TypedDict):
-    directory: str
-    filenames: List[str]
-    frames: Optional[List[int]]
-    template: Optional[str]
-    is_sequence: Optional[bool]
 
 
 class AbstractAttrDefMeta(ABCMeta):
@@ -552,7 +557,7 @@ class EnumDef(AbstractAttrDef):
     def __init__(
         self,
         key: str,
-        items: EnumItemsInputType,
+        items: "EnumItemsInputType",
         default: "Union[str, List[Any]]" = None,
         multiselection: Optional[bool] = False,
         **kwargs
@@ -579,7 +584,7 @@ class EnumDef(AbstractAttrDef):
 
         super().__init__(key, default=default, **kwargs)
 
-        self.items: List[EnumItemDict] = items
+        self.items: List["EnumItemDict"] = items
         self._item_values: Set[Any] = item_values_set
         self.multiselection: bool = multiselection
 
@@ -611,7 +616,7 @@ class EnumDef(AbstractAttrDef):
         return data
 
     @staticmethod
-    def prepare_enum_items(items: EnumItemsInputType) -> List[EnumItemDict]:
+    def prepare_enum_items(items: "EnumItemsInputType") -> List["EnumItemDict"]:
         """Convert items to unified structure.
 
         Output is a list where each item is dictionary with 'value'
@@ -886,7 +891,7 @@ class FileDefItem:
         return output
 
     @classmethod
-    def from_dict(cls, data: FileDefItemDict) -> "Self":
+    def from_dict(cls, data: "FileDefItemDict") -> "Self":
         return cls(
             data["directory"],
             data["filenames"],
@@ -928,7 +933,7 @@ class FileDefItem:
 
         return output
 
-    def to_dict(self) -> FileDefItemDict:
+    def to_dict(self) -> "FileDefItemDict":
         output = {
             "is_sequence": self.is_sequence,
             "directory": self.directory,


### PR DESCRIPTION
## Changelog Description
Small enhancement in attribute definitions.

## Additional info
I got lost a little when I was developing something related attribute definitons lately, during that time I've added typehints so I don't have to go back and forth. The original PR is merged so not I though I'll create PR adding the typehints.

## Testing notes:
1. Make sure it makes sense.

Resolves https://github.com/ynput/ayon-core/issues/993