### PR TITLE
Editorial: Distribution of colorspaceData within instance resources and reviewables

### DIFF
--- a/client/ayon_core/plugins/publish/collect_otio_review.py
+++ b/client/ayon_core/plugins/publish/collect_otio_review.py
@@ -100,37 +100,33 @@ class CollectOtioReview(pyblish.api.InstancePlugin):
                 "Creating review track: {}".format(otio_review_clips))
 
             # get colorspace from metadata if available
-            if len(otio_review_clips) >= 1 and any(
-                # lets make sure any clip with media reference is found
+            # get metadata from first clip with media reference
+            r_otio_cl = next(
                 (
                     clip
                     for clip in otio_review_clips
-                    if isinstance(clip, otio.schema.Clip)
-                    and clip.media_reference
-                )
-            ):
-                # get metadata from first clip
-                # get colorspace from metadata if available
-                # check if resolution is the same as source
-                r_otio_cl = next(
-                    (
-                        clip
-                        for clip in otio_review_clips
-                        if isinstance(clip, otio.schema.Clip)
+                    if (
+                        isinstance(clip, otio.schema.Clip)
                         and clip.media_reference
-                    ),
-                    None,
-                )
-
-                # get metadata from first clip with media reference
+                    )
+                ),
+                None
+            )
+            if r_otio_cl is not None:
                 media_ref = r_otio_cl.media_reference
                 media_metadata = media_ref.metadata
 
                 # TODO: we might need some alternative method since
                 #       native OTIO exports do not support ayon metadata
-                if review_colorspace := media_metadata.get(
+                review_colorspace = media_metadata.get(
                     "ayon.source.colorspace"
-                ):
+                )
+                if review_colorspace is None:
+                    # Backwards compatibility for older scenes
+                    review_colorspace = media_metadata.get(
+                        "openpype.source.colourtransform"
+                    )
+                if review_colorspace:
                     instance.data["reviewColorspace"] = review_colorspace
                     self.log.info(
                         "Review colorspace: {}".format(review_colorspace))

--- a/client/ayon_core/plugins/publish/collect_otio_review.py
+++ b/client/ayon_core/plugins/publish/collect_otio_review.py
@@ -95,8 +95,45 @@ class CollectOtioReview(pyblish.api.InstancePlugin):
             instance.data["label"] = label + " (review)"
             instance.data["families"] += ["review", "ftrack"]
             instance.data["otioReviewClips"] = otio_review_clips
+
             self.log.info(
                 "Creating review track: {}".format(otio_review_clips))
+
+            # get colorspace from metadata if available
+            if len(otio_review_clips) >= 1 and any(
+                # lets make sure any clip with media reference is found
+                (
+                    clip
+                    for clip in otio_review_clips
+                    if isinstance(clip, otio.schema.Clip)
+                    and clip.media_reference
+                )
+            ):
+                # get metadata from first clip
+                # get colorspace from metadata if available
+                # check if resolution is the same as source
+                r_otio_cl = next(
+                    (
+                        clip
+                        for clip in otio_review_clips
+                        if isinstance(clip, otio.schema.Clip)
+                        and clip.media_reference
+                    ),
+                    None,
+                )
+
+                # get metadata from first clip with media reference
+                media_ref = r_otio_cl.media_reference
+                media_metadata = media_ref.metadata
+
+                # TODO: we might need some alternative method since
+                #       native OTIO exports do not support ayon metadata
+                if review_colorspace := media_metadata.get(
+                    "ayon.source.colorspace"
+                ):
+                    instance.data["reviewColorspace"] = review_colorspace
+                    self.log.info(
+                        "Review colorspace: {}".format(review_colorspace))
 
         self.log.debug(
             "_ instance.data: {}".format(pformat(instance.data)))

--- a/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
+++ b/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
@@ -10,12 +10,16 @@ import os
 import clique
 import pyblish.api
 
+from ayon_core.pipeline import publish
 from ayon_core.pipeline.publish import (
     get_publish_template_name
 )
 
 
-class CollectOtioSubsetResources(pyblish.api.InstancePlugin):
+class CollectOtioSubsetResources(
+    pyblish.api.InstancePlugin,
+    publish.ColormanagedPyblishPluginMixin
+):
     """Get Resources for a product version"""
 
     label = "Collect OTIO Subset Resources"
@@ -190,9 +194,13 @@ class CollectOtioSubsetResources(pyblish.api.InstancePlugin):
         instance.data["originalDirname"] = self.staging_dir
 
         if repre:
+            colorspace = instance.data.get("colorspace")
+            # add colorspace data to representation
+            self.set_representation_colorspace(
+                repre, instance.context, colorspace)
+
             # add representation to instance data
             instance.data["representations"].append(repre)
-            self.log.debug(">>>>>>>> {}".format(repre))
 
         self.log.debug(instance.data)
 

--- a/client/ayon_core/plugins/publish/extract_color_transcode.py
+++ b/client/ayon_core/plugins/publish/extract_color_transcode.py
@@ -161,7 +161,7 @@ class ExtractOIIOTranscode(publish.Extractor):
                     output_path = self._get_output_file_path(input_path,
                                                              new_staging_dir,
                                                              output_extension)
-                    self.log.debug("Ynput path: `{}`".format(input_path))
+
                     convert_colorspace(
                         input_path,
                         output_path,

--- a/client/ayon_core/plugins/publish/extract_color_transcode.py
+++ b/client/ayon_core/plugins/publish/extract_color_transcode.py
@@ -5,7 +5,6 @@ import pyblish.api
 
 from ayon_core.pipeline import publish
 from ayon_core.lib import (
-
     is_oiio_supported,
 )
 
@@ -154,12 +153,15 @@ class ExtractOIIOTranscode(publish.Extractor):
 
                 files_to_convert = self._translate_to_sequence(
                     files_to_convert)
+                self.log.debug("Files to convert: {}".format(files_to_convert))
                 for file_name in files_to_convert:
+                    self.log.debug("Transcoding file: `{}`".format(file_name))
                     input_path = os.path.join(original_staging_dir,
                                               file_name)
                     output_path = self._get_output_file_path(input_path,
                                                              new_staging_dir,
                                                              output_extension)
+                    self.log.debug("Ynput path: `{}`".format(input_path))
                     convert_colorspace(
                         input_path,
                         output_path,

--- a/client/ayon_core/plugins/publish/extract_colorspace_data.py
+++ b/client/ayon_core/plugins/publish/extract_colorspace_data.py
@@ -37,6 +37,9 @@ class ExtractColorspaceData(publish.Extractor,
         # get colorspace settings
         context = instance.context
 
+        # colorspace name could be kept in instance.data
+        colorspace = instance.data.get("colorspace")
+
         # loop representations
         for representation in representations:
             # skip if colorspaceData is already at representation
@@ -44,5 +47,5 @@ class ExtractColorspaceData(publish.Extractor,
                 continue
 
             self.set_representation_colorspace(
-                representation, context
+                representation, context, colorspace)
             )

--- a/client/ayon_core/plugins/publish/extract_colorspace_data.py
+++ b/client/ayon_core/plugins/publish/extract_colorspace_data.py
@@ -48,4 +48,3 @@ class ExtractColorspaceData(publish.Extractor,
 
             self.set_representation_colorspace(
                 representation, context, colorspace)
-            )

--- a/client/ayon_core/plugins/publish/extract_otio_review.py
+++ b/client/ayon_core/plugins/publish/extract_otio_review.py
@@ -74,7 +74,10 @@ class ExtractOTIOReview(
         # TODO: what if handles are different in `versionData`?
         handle_start = instance.data["handleStart"]
         handle_end = instance.data["handleEnd"]
-        otio_review_clips = instance.data["otioReviewClips"]
+        otio_review_clips = instance.data.get("otioReviewClips")
+
+        if otio_review_clips is None:
+            self.log.info(f"Instance `{instance}` has no otioReviewClips")
 
         # add plugin wide attributes
         self.representation_files = []

--- a/client/ayon_core/plugins/publish/extract_otio_review.py
+++ b/client/ayon_core/plugins/publish/extract_otio_review.py
@@ -26,7 +26,10 @@ from ayon_core.lib import (
 from ayon_core.pipeline import publish
 
 
-class ExtractOTIOReview(publish.Extractor):
+class ExtractOTIOReview(
+    publish.Extractor,
+    publish.ColormanagedPyblishPluginMixin
+):
     """
     Extract OTIO timeline into one concuted image sequence file.
 
@@ -78,7 +81,9 @@ class ExtractOTIOReview(publish.Extractor):
         self.used_frames = []
         self.workfile_start = int(instance.data.get(
             "workfileFrameStart", 1001)) - handle_start
-        self.padding = len(str(self.workfile_start))
+        # NOTE: padding has to be converted from
+        #       end frame since start could be lower then 1000
+        self.padding = len(str(instance.data.get("frameEnd", 1001)))
         self.used_frames.append(self.workfile_start)
         self.to_width = instance.data.get(
             "resolutionWidth") or self.to_width
@@ -86,8 +91,10 @@ class ExtractOTIOReview(publish.Extractor):
             "resolutionHeight") or self.to_height
 
         # skip instance if no reviewable data available
-        if (not isinstance(otio_review_clips[0], otio.schema.Clip)) \
-                and (len(otio_review_clips) == 1):
+        if (
+            not isinstance(otio_review_clips[0], otio.schema.Clip)
+            and len(otio_review_clips) == 1
+        ):
             self.log.warning(
                 "Instance `{}` has nothing to process".format(instance))
             return
@@ -168,7 +175,7 @@ class ExtractOTIOReview(publish.Extractor):
                 start -= clip_handle_start
                 duration += clip_handle_start
             elif len(otio_review_clips) > 1 \
-                    and (index == len(otio_review_clips) - 1):
+                        and (index == len(otio_review_clips) - 1):
                 # more clips | last clip reframing with handle
                 duration += clip_handle_end
             elif len(otio_review_clips) == 1:
@@ -263,6 +270,13 @@ class ExtractOTIOReview(publish.Extractor):
 
         # creating and registering representation
         representation = self._create_representation(start, duration)
+
+        # add colorspace data to representation
+        if colorspace := instance.data.get("reviewColorspace"):
+            self.set_representation_colorspace(
+                representation, instance.context, colorspace
+            )
+
         instance.data["representations"].append(representation)
         self.log.info("Adding representation: {}".format(representation))
 


### PR DESCRIPTION
## Changelog Description
Editorial supports distribution of colorspace data within editorial otio media resources and reviewable clips.

## Additional info
Within the scope of https://github.com/ynput/ayon-hiero/issues/22
This needs to be tested together with https://github.com/ynput/ayon-hiero/pull/23

## Testing notes:
1. all should work as it was, but colorspace in editorial is now distributed 
