### PR TITLE
Use open -R for opening explorer on MacOS

### DIFF
--- a/client/ayon_core/plugins/actions/open_file_explorer.py
+++ b/client/ayon_core/plugins/actions/open_file_explorer.py
@@ -99,7 +99,7 @@ class OpenTaskPath(LauncherAction):
         if platform_name == "windows":
             args = ["start", path]
         elif platform_name == "darwin":
-            args = ["open", "-na", path]
+            args = ["open", "-R", path]
         elif platform_name == "linux":
             args = ["xdg-open", path]
         else:


### PR DESCRIPTION
## Changelog Description
Explore here launcher action does work on macOs.

## Additional information
- As suggested by @BigRoy (see [here](https://stackoverflow.com/a/3520693)), use `open -R` instead of `open -na` for opening a folder using the explorer.

---

## Testing notes:
1. Open AYON Launcher
2. Browse folders
3. Use `Explore here`

Resolves https://github.com/ynput/ayon-launcher/issues/183
Resolves https://github.com/ynput/ayon-core/issues/964