### PR TITLE
Fix support for scriptsmenu running commands in PySide6

### DIFF
--- a/client/ayon_core/vendor/python/scriptsmenu/action.py
+++ b/client/ayon_core/vendor/python/scriptsmenu/action.py
@@ -1,6 +1,6 @@
 import os
 
-from qtpy import QtWidgets
+from qtpy import QtWidgets, QT6
 
 
 class Action(QtWidgets.QAction):
@@ -112,20 +112,21 @@ module.{module_name}()"""
         Run the command of the instance or copy the command to the active shelf
         based on the current modifiers.
 
-        If callbacks have been registered with fouind modifier integer the
+        If callbacks have been registered with found modifier integer the
         function will trigger all callbacks. When a callback function returns a
         non zero integer it will not execute the action's command
-
         """
 
         # get the current application and its linked keyboard modifiers
         app = QtWidgets.QApplication.instance()
         modifiers = app.keyboardModifiers()
+        if not QT6:
+            modifiers = int(modifiers)
 
         # If the menu has a callback registered for the current modifier
         # we run the callback instead of the action itself.
         registered = self._root.registered_callbacks
-        callbacks = registered.get(int(modifiers), [])
+        callbacks = registered.get(modifiers, [])
         for callback in callbacks:
             signal = callback(self)
             if signal != 0:

--- a/client/ayon_core/vendor/python/scriptsmenu/launchformaya.py
+++ b/client/ayon_core/vendor/python/scriptsmenu/launchformaya.py
@@ -4,7 +4,7 @@ import maya.cmds as cmds
 import maya.mel as mel
 
 import scriptsmenu
-from qtpy import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets, QT6
 
 log = logging.getLogger(__name__)
 
@@ -130,7 +130,7 @@ def main(title="Scripts", parent=None, objectName=None):
 
     # Register control + shift callback to add to shelf (maya behavior)
     modifiers = QtCore.Qt.ControlModifier | QtCore.Qt.ShiftModifier
-    if int(cmds.about(version=True)) < 2025:
+    if not QT6:
         modifiers = int(modifiers)
 
     menu.register_callback(modifiers, to_shelf)


### PR DESCRIPTION
## Changelog Description

Fix support of scripts menu in Qt6, e.g. Maya 2025.

## Additional info

This initially tried to fix it https://github.com/ynput/ayon-core/pull/669 however it did fix the "startup" error but it did make it fail to trigger the actual command from the menu entry due to the callback check when running a menu entry.

## Testing notes:

1. Launch Maya 2025
2. Run an action from the Custom Tools menu

This should also be backwards compatible in older Python versions, so also test e.g. Maya 2022, 2023 or 2024.

I personally tested on Windows in Maya 2022.3, Maya 2024.2 and 2025.3.