### PR TITLE
Scene manager: Filter to outdated toggle does work

### DIFF
--- a/client/ayon_core/tools/sceneinventory/model.py
+++ b/client/ayon_core/tools/sceneinventory/model.py
@@ -426,7 +426,7 @@ class FilterProxyModel(QtCore.QSortFilterProxyModel):
         state = bool(state)
 
         if state != self._filter_outdated:
-            self._filter_outdated = bool(state)
+            self._filter_outdated = state
             self.invalidateFilter()
 
     def set_hierarchy_view(self, state):

--- a/client/ayon_core/tools/sceneinventory/model.py
+++ b/client/ayon_core/tools/sceneinventory/model.py
@@ -194,14 +194,14 @@ class InventoryModel(QtGui.QStandardItemModel):
         group_items = []
         for repre_id, container_items in items_by_repre_id.items():
             repre_info = repre_info_by_id[repre_id]
-            version_label = "N/A"
             version_color = None
-            is_latest = False
-            is_hero = False
-            status_name = None
             if not repre_info.is_valid:
+                version_label = "N/A"
                 group_name = "< Entity N/A >"
                 item_icon = invalid_item_icon
+                is_latest = False
+                is_hero = False
+                status_name = None
 
             else:
                 group_name = "{}_{}: ({})".format(
@@ -217,6 +217,7 @@ class InventoryModel(QtGui.QStandardItemModel):
                 version_item = version_items[repre_info.version_id]
                 version_label = format_version(version_item.version)
                 is_hero = version_item.version < 0
+                is_latest = version_item.is_latest
                 if not version_item.is_latest:
                     version_color = self.OUTDATED_COLOR
                 status_name = version_item.status

--- a/client/ayon_core/tools/sceneinventory/models/containers.py
+++ b/client/ayon_core/tools/sceneinventory/models/containers.py
@@ -383,7 +383,6 @@ class ContainersModel:
             container_items_by_id[item.item_id] = item
             container_items.append(item)
 
-
         self._containers_by_id = containers_by_id
         self._container_items_by_id = container_items_by_id
         self._items_cache = container_items


### PR DESCRIPTION
## Changelog Description
Filter to outdated works again in scene inventory.

## Testing notes:
1. Open host of your choice.
2. Open loader.
3. Load some representations that are **not** from latest version and some that are from latest version.
4. In Scene manager check `Filter to outdated`.
5. It should keep only those that are outdated.

Resolves https://github.com/ynput/ayon-core/issues/886