### PR TITLE
Fix loader load option box widgets

### DIFF
--- a/client/ayon_core/tools/attribute_defs/widgets.py
+++ b/client/ayon_core/tools/attribute_defs/widgets.py
@@ -202,7 +202,6 @@ class AttributeDefinitionsWidget(QtWidgets.QWidget):
 
                 self._current_keys.add(attr_def.key)
             widget = create_widget_for_attr_def(attr_def, self)
-            self._widgets.append(widget)
             self._widgets_by_id[attr_def.id] = widget
 
             if not attr_def.visible:


### PR DESCRIPTION
## Changelog Description

Fix Attribute Definitions for Loader options

## Additional info

Fixes:
```python
Traceback (most recent call last):
  File "F:\dev/ayon-core/client\ayon_core\tools\loader\ui\products_widget.py", line 351, in _on_context_menu
    result = show_actions_menu(
  File "F:\dev/ayon-core/client\ayon_core\tools\loader\ui\actions_utils.py", line 61, in show_actions_menu
    selected_options = _get_options(action, selected_action_item, parent)
  File "F:\dev/ayon-core/client\ayon_core\tools\loader\ui\actions_utils.py", line 89, in _get_options
    dialog = AttributeDefinitionsDialog(options, parent)
  File "F:\dev/ayon-core/client\ayon_core\tools\attribute_defs\dialog.py", line 10, in __init__
    attrs_widget = AttributeDefinitionsWidget(attr_defs, self)
  File "F:\dev/ayon-core/client\ayon_core\tools\attribute_defs\widgets.py", line 159, in __init__
    self.set_attr_defs(attr_defs)
  File "F:\dev/ayon-core/client\ayon_core\tools\attribute_defs\widgets.py", line 190, in set_attr_defs
    self.add_attr_defs(attr_defs)
  File "F:\dev/ayon-core/client\ayon_core\tools\attribute_defs\widgets.py", line 205, in add_attr_defs
    self._widgets.append(widget)
AttributeError: 'AttributeDefinitionsWidget' object has no attribute '_widgets'
```

Broken by https://github.com/ynput/ayon-core/pull/986

## Testing notes:

1. Clicking the option box on loader actions should work