### PR TITLE
Tray: Don't kill other processes

### DIFF
--- a/client/ayon_core/tools/tray/lib.py
+++ b/client/ayon_core/tools/tray/lib.py
@@ -126,6 +126,8 @@ def _windows_get_pid_args(pid: int) -> Optional[List[str]]:
     finally:
         ctypes.windll.kernel32.CloseHandle(handle)
     return output
+
+
 def _windows_pid_is_running(pid: int) -> bool:
     args = _windows_get_pid_args(pid)
     if not args:

--- a/client/ayon_core/tools/tray/lib.py
+++ b/client/ayon_core/tools/tray/lib.py
@@ -3,12 +3,9 @@ import sys
 import json
 import hashlib
 import platform
-import subprocess
-import csv
 import time
 import signal
-import locale
-from typing import Optional, Dict, Tuple, Any
+from typing import Optional, List, Dict, Tuple, Any
 
 import requests
 from ayon_api.utils import get_default_settings_variant
@@ -53,15 +50,99 @@ def _get_server_and_variant(
     return server_url, variant
 
 
+def _windows_get_pid_args(pid: int) -> Optional[List[str]]:
+    import ctypes
+    from ctypes import wintypes
+
+    # Define constants
+    PROCESS_COMMANDLINE_INFO = 60
+    STATUS_NOT_FOUND = 0xC0000225
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+
+    # Define the UNICODE_STRING structure
+    class UNICODE_STRING(ctypes.Structure):
+        _fields_ = [
+            ("Length", wintypes.USHORT),
+            ("MaximumLength", wintypes.USHORT),
+            ("Buffer", wintypes.LPWSTR)
+        ]
+
+    shell32 = ctypes.WinDLL("shell32", use_last_error=True)
+
+    CommandLineToArgvW = shell32.CommandLineToArgvW
+    CommandLineToArgvW.argtypes = [
+        wintypes.LPCWSTR, ctypes.POINTER(ctypes.c_int)
+    ]
+    CommandLineToArgvW.restype = ctypes.POINTER(wintypes.LPWSTR)
+
+    output = None
+    # Open the process
+    handle = ctypes.windll.kernel32.OpenProcess(
+        PROCESS_QUERY_LIMITED_INFORMATION, False, pid
+    )
+    if not handle:
+        return output
+
+    try:
+        buffer_len = wintypes.ULONG()
+        # Get the right buffer size first
+        status = ctypes.windll.ntdll.NtQueryInformationProcess(
+            handle,
+            PROCESS_COMMANDLINE_INFO,
+            ctypes.c_void_p(None),
+            0,
+            ctypes.byref(buffer_len)
+        )
+
+        if status == STATUS_NOT_FOUND:
+            return output
+
+        # Create buffer with collected size
+        buffer = ctypes.create_string_buffer(buffer_len.value)
+
+        # Get the command line
+        status = ctypes.windll.ntdll.NtQueryInformationProcess(
+            handle,
+            PROCESS_COMMANDLINE_INFO,
+            buffer,
+            buffer_len,
+            ctypes.byref(buffer_len)
+        )
+        if status:
+            return output
+        # Build the string
+        tmp = ctypes.cast(buffer, ctypes.POINTER(UNICODE_STRING)).contents
+        size = tmp.Length // 2 + 1
+        cmdline_buffer = ctypes.create_unicode_buffer(size)
+        ctypes.cdll.msvcrt.wcscpy(cmdline_buffer, tmp.Buffer)
+
+        args_len = ctypes.c_int()
+        args = CommandLineToArgvW(
+            cmdline_buffer, ctypes.byref(args_len)
+        )
+        output = [args[idx] for idx in range(args_len.value)]
+        ctypes.windll.kernel32.LocalFree(args)
+
+    finally:
+        ctypes.windll.kernel32.CloseHandle(handle)
+    return output
 def _windows_pid_is_running(pid: int) -> bool:
-    args = ["tasklist.exe", "/fo", "csv", "/fi", f"PID eq {pid}"]
-    output = subprocess.check_output(args)
-    encoding = locale.getpreferredencoding()
-    csv_content = csv.DictReader(output.decode(encoding).splitlines())
-    # if "PID" not in csv_content.fieldnames:
-    #     return False
-    for _ in csv_content:
+    args = _windows_get_pid_args(pid)
+    if not args:
+        return False
+    executable_path = args[0]
+
+    filename = os.path.basename(executable_path).lower()
+    if "ayon" in filename:
         return True
+
+    # Try to handle tray running from code
+    # - this might be potential danger that kills other python process running
+    #   'start.py' script (low chance, but still)
+    if "python" in filename and len(args) > 1:
+        script_filename = os.path.basename(args[1].lower())
+        if script_filename == "start.py":
+            return True
     return False
 
 


### PR DESCRIPTION
## Changelog Description
Tray is not trying to kill other than AYON processes.

## Additional info
Implemented function that collects command line arguments of the running process. Based on the executable name detects if the process is AYON process.

## Testing notes:
1. Be on Windows.
2. Start tray.
3. Go to `%LOCALAPPDATA%\Ynput\AYON\tray`, there should be one file.
4. Duplicate the file with some prefix (e.g. `_`).
5. Close tray.
6. Go to `%LOCALAPPDATA%\Ynput\AYON\tray` and rename the file to origin name.
7. Start any application you'd like (other than AYON).
8. In task manager find PID of the process (I chose Notepad which in my case have PID 29780).
![image](https://github.com/user-attachments/assets/9135e64b-7203-4948-b3f8-a9aa79879be5)
9. Modify the file and change pid to pid of your application.
10. Start tray again.
11. Your application should not be closed and tray should start.

Resolves https://github.com/ynput/ayon-core/issues/918