### PR TITLE
Loader UI: Don't change selection on version combobox hover

### DIFF
--- a/client/ayon_core/tools/loader/ui/products_delegates.py
+++ b/client/ayon_core/tools/loader/ui/products_delegates.py
@@ -222,6 +222,7 @@ class VersionDelegate(QtWidgets.QStyledItemDelegate):
 
         editor = VersionComboBox(product_id, parent)
         editor.setProperty("itemId", item_id)
+        editor.setFocusPolicy(QtCore.Qt.NoFocus)
 
         editor.value_changed.connect(self._on_editor_change)
         editor.destroyed.connect(self._on_destroy)


### PR DESCRIPTION
## Changelog Description
Product/version selection does not change on hover over version combobox.

## Additional info
It looks like views do change selection based on focus and having available editor widget. It skips that logic if editor has `NoFocus` policy. Based on documentation they should have set focus policy ti `NoFocus` as we don't want to be able to "focus" into the widget.

## Testing notes:
1. Hover over version combobox does not change selection of products in loader tool.
2. It is possible to change version in loader tool ->this should be probably tested in Qt native DCC (e.g. maya) and some non-native DCC (e.g. blender).

Resolves https://github.com/ynput/ayon-core/issues/1007