### PR TITLE
Create: Required keys in Create Instance data

### DIFF
--- a/client/ayon_core/pipeline/create/structures.py
+++ b/client/ayon_core/pipeline/create/structures.py
@@ -434,6 +434,13 @@ class CreatedInstance:
         "creator_attributes",
         "publish_attributes"
     )
+    # Keys that can be changed, but should not be removed from instance
+    __required_keys = {
+        "folderPath": None,
+        "task": None,
+        "productName": None,
+        "active": True,
+    }
 
     def __init__(
         self,
@@ -515,6 +522,9 @@ class CreatedInstance:
         if data:
             self._data.update(data)
 
+        for key, default in self.__required_keys.items():
+            self._data.setdefault(key, default)
+
         if not self._data.get("instance_id"):
             self._data["instance_id"] = str(uuid4())
 
@@ -567,6 +577,8 @@ class CreatedInstance:
         has_key = key in self._data
         output = self._data.pop(key, *args, **kwargs)
         if has_key:
+            if key in self.__required_keys:
+                self._data[key] = self.__required_keys[key]
             self._create_context.instance_values_changed(
                 self.id, {key: None}
             )

--- a/client/ayon_core/pipeline/create/structures.py
+++ b/client/ayon_core/pipeline/create/structures.py
@@ -429,7 +429,7 @@ class CreatedInstance:
     __immutable_keys = (
         "id",
         "instance_id",
-        "product_type",
+        "productType",
         "creator_identifier",
         "creator_attributes",
         "publish_attributes"

--- a/client/ayon_core/tools/publisher/models/create.py
+++ b/client/ayon_core/tools/publisher/models/create.py
@@ -296,7 +296,7 @@ class InstanceItem:
         return InstanceItem(
             instance.id,
             instance.creator_identifier,
-            instance.label,
+            instance.label or "N/A",
             instance.group_label,
             instance.product_type,
             instance.product_name,


### PR DESCRIPTION
## Changelog Description
Added required keys for `CreatedInstance`, required keys are meant to make sure instance data contains the key, even if someone tries to remove them, or is not passing them on initialization.

## Additional info
All the keys are not really mandatory for instance to exist, but most of logic expects them to be set and available. Also fixed immutable key name `product_type` > `productType`.

## TODOs
We should define those keys with setters/getters with typehints.

## Testing notes:
1. It is possible to initialize `CreatedInstance` without `"folderPath"` and `"task"` but `instance["folderPath"]` and `instance["task"]` can be used (returns `None`).
