### PR TITLE
Editorial: Don't require 'hierarchy' key on instance

### DIFF
--- a/client/ayon_core/plugins/publish/collect_anatomy_instance_data.py
+++ b/client/ayon_core/plugins/publish/collect_anatomy_instance_data.py
@@ -413,14 +413,16 @@ class CollectAnatomyInstanceData(pyblish.api.ContextPlugin):
             # Backwards compatible (Deprecated since 24/06/06)
             or instance.data.get("newAssetPublishing")
         ):
-            hierarchy = instance.data["hierarchy"]
-            anatomy_data["hierarchy"] = hierarchy
+            folder_path = instance.data["folderPath"]
+            parents = folder_path.lstrip("/").split("/")
+            folder_name = parents.pop(-1)
 
             parent_name = project_entity["name"]
-            if hierarchy:
-                parent_name = hierarchy.split("/")[-1]
+            hierarchy = ""
+            if parents:
+                parent_name = parents[-1]
+                hierarchy = "/".join(parents)
 
-            folder_name = instance.data["folderPath"].split("/")[-1]
             anatomy_data.update({
                 "asset": folder_name,
                 "hierarchy": hierarchy,


### PR DESCRIPTION
## Changelog Description
Use `folderPath` to calculate `hierarchy` instead of requiring `hierarchy` on instance data.

## Additional info
The hierarchy was required from OpenPype but with AYON we already have it available on `folderPath`.

## Testing notes:
1. Editorial instances don't have to fill `hierarchy` on instance to be integrated.
