### PR TITLE
Chore: Set environment variables for farm

### DIFF
--- a/client/ayon_core/pipeline/publish/__init__.py
+++ b/client/ayon_core/pipeline/publish/__init__.py
@@ -3,6 +3,7 @@ from .constants import (
     ValidateContentsOrder,
     ValidateSceneOrder,
     ValidateMeshOrder,
+    FARM_JOB_ENV_DATA_KEY,
 )
 
 from .publish_plugins import (
@@ -59,6 +60,7 @@ __all__ = (
     "ValidateContentsOrder",
     "ValidateSceneOrder",
     "ValidateMeshOrder",
+    "FARM_JOB_ENV_DATA_KEY",
 
     "AbstractMetaInstancePlugin",
     "AbstractMetaContextPlugin",

--- a/client/ayon_core/pipeline/publish/constants.py
+++ b/client/ayon_core/pipeline/publish/constants.py
@@ -9,3 +9,5 @@ ValidateMeshOrder = pyblish.api.ValidatorOrder + 0.3
 DEFAULT_PUBLISH_TEMPLATE = "default"
 DEFAULT_HERO_PUBLISH_TEMPLATE = "default"
 TRANSIENT_DIR_TEMPLATE = "default"
+
+FARM_JOB_ENV_DATA_KEY: str = "farmJobEnv"

--- a/client/ayon_core/plugins/publish/collect_farm_env_variables.py
+++ b/client/ayon_core/plugins/publish/collect_farm_env_variables.py
@@ -14,15 +14,15 @@ class CollectCoreJobEnvVars(pyblish.api.ContextPlugin):
     def process(self, context):
         env = context.data.setdefault(FARM_JOB_ENV_DATA_KEY, {})
         for key in [
-            # AYON
             "AYON_BUNDLE_NAME",
             "AYON_DEFAULT_SETTINGS_VARIANT",
             "AYON_PROJECT_NAME",
             "AYON_FOLDER_PATH",
             "AYON_TASK_NAME",
-            "AYON_WORKDIR",
             "AYON_LOG_NO_COLORS",
             "AYON_IN_TESTS",
+            # NOTE Not sure why workdir is needed?
+            "AYON_WORKDIR",
         ]:
             value = os.getenv(key)
             if value:

--- a/client/ayon_core/plugins/publish/collect_farm_env_variables.py
+++ b/client/ayon_core/plugins/publish/collect_farm_env_variables.py
@@ -23,8 +23,6 @@ class CollectCoreJobEnvVars(pyblish.api.ContextPlugin):
             "AYON_WORKDIR",
             "AYON_LOG_NO_COLORS",
             "AYON_IN_TESTS",
-            # backwards compatibility
-            "IS_TEST",
         ]:
             value = os.getenv(key)
             if value:

--- a/client/ayon_core/plugins/publish/collect_farm_env_variables.py
+++ b/client/ayon_core/plugins/publish/collect_farm_env_variables.py
@@ -1,0 +1,48 @@
+import os
+
+import pyblish.api
+
+from ayon_core.pipeline.publish import FARM_JOB_ENV_DATA_KEY
+
+
+class CollectCoreJobEnvVars(pyblish.api.ContextPlugin):
+    """Collect set of environment variables to submit with deadline jobs"""
+    order = pyblish.api.CollectorOrder - 0.45
+    label = "AYON core Farm Environment Variables"
+    targets = ["local"]
+
+    ENV_KEYS = [
+        # AYON
+        "AYON_BUNDLE_NAME",
+        "AYON_DEFAULT_SETTINGS_VARIANT",
+        "AYON_PROJECT_NAME",
+        "AYON_FOLDER_PATH",
+        "AYON_TASK_NAME",
+        "AYON_APP_NAME",
+        "AYON_WORKDIR",
+        "AYON_APP_NAME",
+        "AYON_LOG_NO_COLORS",
+        "AYON_IN_TESTS",
+        "IS_TEST",  # backwards compatibility
+    ]
+
+    def process(self, context):
+        env = context.data.setdefault(FARM_JOB_ENV_DATA_KEY, {})
+        for key in [
+            # AYON
+            "AYON_BUNDLE_NAME",
+            "AYON_DEFAULT_SETTINGS_VARIANT",
+            "AYON_PROJECT_NAME",
+            "AYON_FOLDER_PATH",
+            "AYON_TASK_NAME",
+            "AYON_WORKDIR",
+            "AYON_LOG_NO_COLORS",
+            "AYON_IN_TESTS",
+            # backwards compatibility
+            "IS_TEST",
+        ]:
+            value = os.getenv(key)
+            if value:
+                self.log.debug(f"Setting job env: {key}: {value}")
+                env[key] = value
+

--- a/client/ayon_core/plugins/publish/collect_farm_env_variables.py
+++ b/client/ayon_core/plugins/publish/collect_farm_env_variables.py
@@ -11,21 +11,6 @@ class CollectCoreJobEnvVars(pyblish.api.ContextPlugin):
     label = "AYON core Farm Environment Variables"
     targets = ["local"]
 
-    ENV_KEYS = [
-        # AYON
-        "AYON_BUNDLE_NAME",
-        "AYON_DEFAULT_SETTINGS_VARIANT",
-        "AYON_PROJECT_NAME",
-        "AYON_FOLDER_PATH",
-        "AYON_TASK_NAME",
-        "AYON_APP_NAME",
-        "AYON_WORKDIR",
-        "AYON_APP_NAME",
-        "AYON_LOG_NO_COLORS",
-        "AYON_IN_TESTS",
-        "IS_TEST",  # backwards compatibility
-    ]
-
     def process(self, context):
         env = context.data.setdefault(FARM_JOB_ENV_DATA_KEY, {})
         for key in [


### PR DESCRIPTION
## Changelog Description
Moved some of logic to define farm job environment variables from ayon-deadline to ayon-core.

## Additional info
There already is plugin https://github.com/ynput/ayon-deadline/blob/develop/client/ayon_deadline/plugins/publish/global/collect_deadline_job_env_vars.py that is collecting environment variables, but that is not extedable because the constant defined in deadline should be supplied from ayon core, and most of the variables defined in the plugin should be defined by ayon-core, ayon-ftrack, ayon-shotgrid or ayon-applications addon. This is first step to be able to actually do it in the other plugins. Right now they would have to import from ayon-deadline and have dependency to ayon-deadline addon.

This PR also will take effect only with changes in this PR https://github.com/ynput/ayon-deadline/pull/67

### Future steps
- Remove those env variables from ayon-deadline.
- Use constant `FARM_JOB_ENV_DATA_KEY` defined in ayon core instead of constant defined in ayon deadline.
- Move remaining env variables to corresponding repositories (ftrack > ftrack addon, shotgrid > shotgrid addon, applications > applications addon.

## Testing notes:
1. With this PR https://github.com/ynput/ayon-deadline/pull/67 the environment variables should be set by ayon-core.
