### PR TITLE
Loader: Delivery - fix backwards compatibilit with older AYON python api

### DIFF
--- a/client/ayon_core/pipeline/delivery.py
+++ b/client/ayon_core/pipeline/delivery.py
@@ -387,7 +387,7 @@ def get_representations_delivery_template_data(
         #   convert representation entity. Fixed in 'ayon_api' 1.0.10.
         if isinstance(template_data, str):
             con = ayon_api.get_server_api_connection()
-            repre_entity = con._representation_conversion(repre_entity)
+            con._representation_conversion(repre_entity)
             template_data = repre_entity["context"]
 
         template_data.update(copy.deepcopy(general_template_data))


### PR DESCRIPTION
## Changelog Description

The `_representation_conversion` method converts in-place - it does not return anything

## Additional info

Avoids errors:
```python
Traceback (most recent call last):
  File "C:\Users\Maqina-RTX-03\AppData\Local\Ynput\AYON\addons\core_1.0.9+cb.1\ayon_core\plugins\load\delivery.py", line 210, in deliver
    get_representations_delivery_template_data(
  File "C:\Users\Maqina-RTX-03\AppData\Local\Ynput\AYON\addons\core_1.0.9+cb.1\ayon_core\pipeline\delivery.py", line 391, in get_representations_delivery_template_data
    template_data = repre_entity["context"]
TypeError: 'NoneType' object is not subscriptable
```

## Testing notes:

1. With AYON Python API 1.0.9 in dependency package, delivery tool should still work.
