### PR TITLE
Add ShapeFX Loki support

### DIFF
--- a/client/ayon_core/hooks/pre_add_last_workfile_arg.py
+++ b/client/ayon_core/hooks/pre_add_last_workfile_arg.py
@@ -29,7 +29,8 @@ class AddLastWorkfileToLaunchArgs(PreLaunchHook):
         "aftereffects",
         "wrap",
         "openrv",
-        "cinema4d"
+        "cinema4d",
+        "loki"
     }
     launch_types = {LaunchTypes.local}
 

--- a/client/ayon_core/hooks/pre_ocio_hook.py
+++ b/client/ayon_core/hooks/pre_ocio_hook.py
@@ -20,7 +20,8 @@ class OCIOEnvHook(PreLaunchHook):
         "hiero",
         "resolve",
         "openrv",
-        "cinema4d"
+        "cinema4d",
+        "loki"
     }
     launch_types = set()
 

--- a/client/ayon_core/plugins/publish/validate_file_saved.py
+++ b/client/ayon_core/plugins/publish/validate_file_saved.py
@@ -37,7 +37,7 @@ class ValidateCurrentSaveFile(pyblish.api.ContextPlugin):
     label = "Validate File Saved"
     order = pyblish.api.ValidatorOrder - 0.1
     hosts = ["fusion", "houdini", "max", "maya", "nuke", "substancepainter",
-             "cinema4d"]
+             "cinema4d", "loki"]
     actions = [SaveByVersionUpAction, ShowWorkfilesAction]
 
     def process(self, context):


### PR DESCRIPTION
## Changelog Description

Add [ShapeFX Loki](https://shapefx.app/) support.

## Additional info

Requires Loki in [`ayon-applications`](https://github.com/ynput/ayon-applications/pull/40) and the [`ayon-loki` integration](https://github.com/BigRoy/ayon-loki).

## Testing notes:

1. Install ShapeFX Loki
2. Run through AYON
3. Basics should work.
4. OCIO env var should be set according to settings.
5. Last workfile should be opened on launch.
