### PR TITLE
Farm env: Collect correct values for farm

### DIFF
--- a/client/ayon_core/plugins/publish/collect_farm_env_variables.py
+++ b/client/ayon_core/plugins/publish/collect_farm_env_variables.py
@@ -2,6 +2,7 @@ import os
 
 import pyblish.api
 
+from ayon_core.lib import get_ayon_username
 from ayon_core.pipeline.publish import FARM_JOB_ENV_DATA_KEY
 
 
@@ -15,16 +16,22 @@ class CollectCoreJobEnvVars(pyblish.api.ContextPlugin):
         env = context.data.setdefault(FARM_JOB_ENV_DATA_KEY, {})
 
         # Disable colored logs on farm
-        env["AYON_LOG_NO_COLORS"] = "1"
+        for key, value in (
+            ("AYON_LOG_NO_COLORS", "1"),
+            ("AYON_PROJECT_NAME", context.data["projectName"]),
+            ("AYON_FOLDER_PATH", context.data.get("folderPath")),
+            ("AYON_TASK_NAME", context.data.get("task")),
+            # NOTE we should use 'context.data["user"]' but that has higher
+            #   order.
+            ("AYON_USERNAME", get_ayon_username()),
+        ):
+            if value:
+                self.log.debug(f"Setting job env: {key}: {value}")
+                env[key] = value
 
         for key in [
             "AYON_BUNDLE_NAME",
             "AYON_DEFAULT_SETTINGS_VARIANT",
-            "AYON_USERNAME",
-            "AYON_PROJECT_NAME",
-            "AYON_FOLDER_PATH",
-            "AYON_TASK_NAME",
-            "AYON_LOG_NO_COLORS",
             "AYON_IN_TESTS",
             # NOTE Not sure why workdir is needed?
             "AYON_WORKDIR",


### PR DESCRIPTION
## Changelog Description
Actually collect valid values for farm environment variables.

## Additional info
The plugin did use values from os.environ but most of the values are not set in env variables, or it should not be based on env variables.

- AYON_USERNAME - is not filled in os.environ
- AYON project/folder/task - should be filled from context data instead of os.environ
- AYON_LOG_NO_COLORS - should be forced to be `"1"` for farm

## Testing notes:
1. The values under farm key are correct.
