### PR TITLE
Fix extract_otio_review

### DIFF
--- a/client/ayon_core/plugins/publish/extract_otio_review.py
+++ b/client/ayon_core/plugins/publish/extract_otio_review.py
@@ -78,6 +78,7 @@ class ExtractOTIOReview(
 
         if otio_review_clips is None:
             self.log.info(f"Instance `{instance}` has no otioReviewClips")
+            return
 
         # add plugin wide attributes
         self.representation_files = []


### PR DESCRIPTION
## Changelog Description
Minor fix, ensure `extract_otio_review` is skipped when no OTIO clip is available.

This fixes the following issue:
![image](https://github.com/user-attachments/assets/c960bee5-dbdf-4afd-b0e2-4b8a6ece1b1d)
