### PR TITLE
AY-7242_Implement review representations in OTIO subset resources.

### DIFF
--- a/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
+++ b/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
@@ -199,8 +199,8 @@ class CollectOtioSubsetResources(
 
             if "review" in instance.data["families"]:
                 review_repre = self._create_representation(
-                frame_start, frame_end,
-                file=filename, delete=True, review=True)
+                    frame_start, frame_end,
+                    file=filename, delete=True, review=True)
 
         instance.data["originalDirname"] = self.staging_dir
 

--- a/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
+++ b/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
@@ -215,7 +215,7 @@ class CollectOtioSubsetResources(
 
         # add review representation to instance data
         if review_repre:
-            instance.data["representations"].append(review_repre)            
+            instance.data["representations"].append(review_repre)
 
         self.log.debug(instance.data)
 


### PR DESCRIPTION
## Changelog Description
These changes fixes the bug for Hiero, Flame and Resolve where we realized that the [Clip media] option of Reviewable Source did not work properly.
See https://github.com/ynput/ayon-hiero/pull/38 for more details.

## Additional info
This changes needs to be tested alongside https://github.com/ynput/ayon-hiero/pull/38

## Testing notes:
1. Open Hiero and create instance(s) through the `Create Publishable Clip`
2. Set the review source media to `[Clip media]`
![image](https://github.com/user-attachments/assets/bb472e65-c905-42b0-97e8-f82bac164bb8)
3. Publish and ensure that the resulting review product is created from the original clip media entire range (untrimmed)

AY-7242