### PR TITLE
Loader & Scene inventory: Ignore containers with invalid representation id

### DIFF
--- a/client/ayon_core/tools/loader/control.py
+++ b/client/ayon_core/tools/loader/control.py
@@ -382,7 +382,7 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
                 try:
                     uuid.UUID(repre_id)
                     repre_ids.add(repre_id)
-                except ValueError:
+                except (ValueError, TypeError, AttributeError):
                     pass
 
             product_ids = self._products_model.get_product_ids_by_repre_ids(

--- a/client/ayon_core/tools/loader/control.py
+++ b/client/ayon_core/tools/loader/control.py
@@ -372,14 +372,14 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
 
             repre_ids = set()
             for container in containers:
-                repre_id = container.get("representation")
-                # Ignore invalid representation ids.
-                # - invalid representation ids may be available if e.g. is
-                #   opened scene from OpenPype whe 'ObjectId' was used instead
-                #   of 'uuid'.
-                # NOTE: Server call would crash if there is any invalid id.
-                #   That would cause crash we won't get any information.
                 try:
+                    repre_id = container.get("representation")
+                    # Ignore invalid representation ids.
+                    # - invalid representation ids may be available if e.g. is
+                    #   opened scene from OpenPype whe 'ObjectId' was used instead
+                    #   of 'uuid'.
+                    # NOTE: Server call would crash if there is any invalid id.
+                    #   That would cause crash we won't get any information.
                     uuid.UUID(repre_id)
                     repre_ids.add(repre_id)
                 except (ValueError, TypeError, AttributeError):

--- a/client/ayon_core/tools/loader/control.py
+++ b/client/ayon_core/tools/loader/control.py
@@ -376,8 +376,8 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
                     repre_id = container.get("representation")
                     # Ignore invalid representation ids.
                     # - invalid representation ids may be available if e.g. is
-                    #   opened scene from OpenPype whe 'ObjectId' was used instead
-                    #   of 'uuid'.
+                    #   opened scene from OpenPype whe 'ObjectId' was used
+                    #   instead of 'uuid'.
                     # NOTE: Server call would crash if there is any invalid id.
                     #   That would cause crash we won't get any information.
                     uuid.UUID(repre_id)

--- a/client/ayon_core/tools/sceneinventory/models/containers.py
+++ b/client/ayon_core/tools/sceneinventory/models/containers.py
@@ -350,12 +350,14 @@ class ContainersModel:
             return
 
         host = self._controller.get_host()
-        if isinstance(host, ILoadHost):
-            containers = list(host.get_containers())
-        elif hasattr(host, "ls"):
-            containers = list(host.ls())
-        else:
-            containers = []
+        containers = []
+        try:
+            if isinstance(host, ILoadHost):
+                containers = list(host.get_containers())
+            elif hasattr(host, "ls"):
+                containers = list(host.ls())
+        except Exception:
+            self._log.error("Failed to get containers", exc_info=True)
 
         container_items = []
         containers_by_id = {}
@@ -363,6 +365,9 @@ class ContainersModel:
         invalid_ids_mapping = {}
         current_project_name = self._controller.get_current_project_name()
         for container in containers:
+            if not container:
+                continue
+
             try:
                 item = ContainerItem.from_container_data(
                     current_project_name, container)

--- a/client/ayon_core/tools/sceneinventory/models/containers.py
+++ b/client/ayon_core/tools/sceneinventory/models/containers.py
@@ -4,6 +4,7 @@ import collections
 import ayon_api
 from ayon_api.graphql import GraphQlQuery
 
+from ayon_core.lib import Logger
 from ayon_core.host import ILoadHost
 from ayon_core.tools.common_models.projects import StatusStates
 
@@ -196,6 +197,7 @@ class ContainersModel:
         self._container_items_by_id = {}
         self._version_items_by_product_id = {}
         self._repre_info_by_id = {}
+        self._log = Logger.get_logger("ContainersModel")
 
     def reset(self):
         self._items_cache = None
@@ -368,6 +370,10 @@ class ContainersModel:
                 try:
                     uuid.UUID(repre_id)
                 except (ValueError, TypeError, AttributeError):
+                    self._log.warning(
+                        "Container contains invalid representation id."
+                        f"\n{container}"
+                    )
                     # Fake not existing representation id so container
                     #   is shown in UI but as invalid
                     item.representation_id = invalid_ids_mapping.setdefault(

--- a/client/ayon_core/tools/sceneinventory/models/containers.py
+++ b/client/ayon_core/tools/sceneinventory/models/containers.py
@@ -230,7 +230,7 @@ class ContainersModel:
         for repre_id in representation_ids:
             try:
                 uuid.UUID(repre_id)
-            except ValueError:
+            except (ValueError, TypeError, AttributeError):
                 output[repre_id] = RepresentationInfo.new_invalid()
                 continue
             repre_info = self._repre_info_by_id.get(repre_id)

--- a/client/ayon_core/tools/sceneinventory/models/containers.py
+++ b/client/ayon_core/tools/sceneinventory/models/containers.py
@@ -388,7 +388,7 @@ class ContainersModel:
             except Exception:
                 # skip item if required data are missing
                 self._log.warning(
-                    f"Failed to create container item", exc_info=True
+                    "Failed to create container item", exc_info=True
                 )
                 continue
 

--- a/client/ayon_core/tools/sceneinventory/models/containers.py
+++ b/client/ayon_core/tools/sceneinventory/models/containers.py
@@ -380,10 +380,10 @@ class ContainersModel:
                         repre_id, uuid.uuid4().hex
                     )
 
-            except Exception as e:
+            except Exception:
                 # skip item if required data are missing
-                self._controller.log_error(
-                    f"Failed to create item: {e}"
+                self._log.warning(
+                    f"Failed to create container item", exc_info=True
                 )
                 continue
 


### PR DESCRIPTION
## Changelog Description
Loader and scene inventory should not cause issues when container in scene contains invalid representation id.

## Additional info
Capture all possible errors when validating representation ids. In case of Loader tool, we really need only the representation ids and we don't care about anything else. In scene inventory already happens some validation of the data. The validation does not fully preserve issues, but that probably should not be job of the tool.

Partially resolves https://github.com/ynput/ayon-core/issues/788 . The issue is more aboud full validation of container data, which might be actually production breaking change at this moment as we don't enforce container schema now. And it might be more work than a simple capture of unhandled exceptions. We do miss a lot of load related api, which is epic on it's own.

## Testing notes:
1. Container with invalid representation id (for example being `None`) does not break tools.
