### PR TITLE
Fix missing slate frame in Deadline publish

### DIFF
--- a/client/ayon_core/pipeline/farm/pyblish_functions.py
+++ b/client/ayon_core/pipeline/farm/pyblish_functions.py
@@ -384,6 +384,7 @@ def prepare_representations(
         frame_end = frames_to_render[-1]
         if skeleton_data.get("slate"):
             frame_start -= 1
+            frames_to_render.insert(0, frame_start)
 
         files = _get_real_files_to_rendered(collection, frames_to_render)
 


### PR DESCRIPTION
## Changelog Description
Solves bug where Deadline now ignores Nuke slate, and offsets the published exr sequence.

## Additional info
Solves https://github.com/ynput/ayon-deadline/issues/73

## Testing notes:
1. setup Nuke workfile with slate, publish in DL
2. same setup publish locally
3. both `publish` version folders should contains same amount of files
