### PR TITLE
Refactor filtering by explicit frames

### DIFF
--- a/client/ayon_core/pipeline/farm/pyblish_functions.py
+++ b/client/ayon_core/pipeline/farm/pyblish_functions.py
@@ -435,13 +435,10 @@ def prepare_representations(
                 " This may cause issues on farm."
             ).format(staging))
 
-        files = _get_real_files_to_rendered(
-            [os.path.basename(remainder)], frames_to_render)
-
         rep = {
             "name": ext,
             "ext": ext,
-            "files": files[0],
+            "files": os.path.basename(remainder),
             "stagingDir": staging,
         }
 


### PR DESCRIPTION
## Changelog Description
Simplified filtering of explicit frames set by artist in Publisher UI. This should be more explicit and safer.
Removed filtering on remainders, eg. single files as there is no real safe way how to get frame pattern there and it doesn't make sense for artist to filter on single file.

## Testing notes:
1. publish in your DCC of choice as usuall
2. try set `Frames` to explicitly filter only specific frames
![image](https://github.com/user-attachments/assets/26842f40-dc2b-416a-adc0-38ecab191aff)

