### PR TITLE
AY-7222 Fix otio_review no handles and tempdir for Resolve

### DIFF
--- a/client/ayon_core/pipeline/tempdir.py
+++ b/client/ayon_core/pipeline/tempdir.py
@@ -71,8 +71,8 @@ def _create_local_staging_dir(prefix, suffix, dirpath=None):
     )
 
 
-def create_custom_tempdir(project_name, anatomy):
-    """ Deprecated 09/12/2024, here for backward-compatibility with Resolve.
+def create_custom_tempdir(project_name, anatomy=None):
+    """Backward compatibility deprecated since 2024/12/09.
     """
     warnings.warn(
         "Used deprecated 'create_custom_tempdir' "

--- a/client/ayon_core/pipeline/tempdir.py
+++ b/client/ayon_core/pipeline/tempdir.py
@@ -80,6 +80,9 @@ def create_custom_tempdir(project_name, anatomy=None):
         DeprecationWarning,
     )
 
+    if anatomy is None:
+        anatomy = Anatomy(project_name)
+
     return _create_custom_tempdir(project_name, anatomy)
 
 

--- a/client/ayon_core/pipeline/tempdir.py
+++ b/client/ayon_core/pipeline/tempdir.py
@@ -5,6 +5,7 @@ Temporary folder operations
 import os
 import tempfile
 from pathlib import Path
+import warnings
 
 from ayon_core.lib import StringTemplate
 from ayon_core.pipeline import Anatomy
@@ -68,6 +69,18 @@ def _create_local_staging_dir(prefix, suffix, dirpath=None):
     return tempfile.mkdtemp(
         prefix=prefix, suffix=suffix, dir=dirpath
     )
+
+
+def create_custom_tempdir(project_name, anatomy):
+    """ Deprecated 09/12/2024, here for backward-compatibility with Resolve.
+    """
+    warnings.warn(
+        "Used deprecated 'create_custom_tempdir' "
+        "use 'ayon_core.pipeline.tempdir.get_temp_dir' instead.",
+        DeprecationWarning,
+    )
+
+    return _create_custom_tempdir(project_name, anatomy)
 
 
 def _create_custom_tempdir(project_name, anatomy):

--- a/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
+++ b/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
@@ -157,6 +157,7 @@ class CollectOtioSubsetResources(
                 self.staging_dir = media_ref.target_url_base
                 head = media_ref.name_prefix
                 tail = media_ref.name_suffix
+                import rpdb ; rpdb.Rpdb().set_trace()
                 collection = clique.Collection(
                     head=head,
                     tail=tail,

--- a/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
+++ b/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
@@ -157,7 +157,6 @@ class CollectOtioSubsetResources(
                 self.staging_dir = media_ref.target_url_base
                 head = media_ref.name_prefix
                 tail = media_ref.name_suffix
-                import rpdb ; rpdb.Rpdb().set_trace()
                 collection = clique.Collection(
                     head=head,
                     tail=tail,

--- a/client/ayon_core/plugins/publish/extract_otio_review.py
+++ b/client/ayon_core/plugins/publish/extract_otio_review.py
@@ -71,14 +71,15 @@ class ExtractOTIOReview(
         # TODO: convert resulting image sequence to mp4
 
         # get otio clip and other time info from instance clip
-        # TODO: what if handles are different in `versionData`?
-        handle_start = instance.data["handleStart"]
-        handle_end = instance.data["handleEnd"]
         otio_review_clips = instance.data.get("otioReviewClips")
 
         if otio_review_clips is None:
             self.log.info(f"Instance `{instance}` has no otioReviewClips")
             return
+
+        # TODO: what if handles are different in `versionData`?
+        handle_start = instance.data["handleStart"]
+        handle_end = instance.data["handleEnd"]
 
         # add plugin wide attributes
         self.representation_files = []


### PR DESCRIPTION
## Changelog Description

Resolve https://github.com/ynput/ayon-resolve/issues/44

* Ensure `ayon-core.pipeline.tempdir.create_custom_tempdir` is still exposed but flagged as backward compatible.
  This function is not officially exposed in the `__init__.py` but directly called from within resolve:
  https://github.com/search?q=org%3Aynput+create_custom_tempdir&type=code
  
* Ensure extract OTIO review does not expect handle values when no otioClip is set

## Testing notes:
Testing procedure through Resolve is here: https://github.com/ynput/ayon-resolve/pull/46
