### PR TITLE
Add houdini to thumbnail extraction

### DIFF
--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -37,7 +37,8 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         "substancepainter",
         "nuke",
         "aftereffects",
-        "unreal"
+        "unreal",
+        "houdini"
     ]
     enabled = False
 


### PR DESCRIPTION
## Changelog Description
resolve https://github.com/ynput/ayon-houdini/issues/188
Add missing houdini host to thumbnail extraction
![image](https://github.com/user-attachments/assets/72e33523-90a6-41e8-9704-9a0d20911a42)


## Testing notes:
1. Enable thumbnail extraction
2. Publish render or review from Houdini. Thumbnail should be set from the image sequence.
