### PR TITLE
Increment workfile even when no unsaved changes

### DIFF
--- a/client/ayon_core/pipeline/context_tools.py
+++ b/client/ayon_core/pipeline/context_tools.py
@@ -585,9 +585,6 @@ def version_up_current_workfile():
     """Function to increment and save workfile
     """
     host = registered_host()
-    if not host.has_unsaved_changes():
-        print("No unsaved changes, skipping file save..")
-        return
 
     project_name = get_current_project_name()
     folder_path = get_current_folder_path()


### PR DESCRIPTION
## Changelog Description

Always increment workfile when requested - instead of only when no unsaved changes

## Additional info

Fixes https://github.com/ynput/ayon-blender/issues/86
But also changes the same behavior for Maya and Blender.

## Testing notes:

1. Version up workfile menu entry should increment workfile even when no unsaved changes