### PR TITLE
Editorial: Fix clip_media source for review track.

### DIFF
--- a/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
+++ b/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
@@ -178,7 +178,8 @@ class CollectOtioSubsetResources(
             repre = self._create_representation(
                 frame_start, frame_end, collection=collection)
 
-            if "review" in instance.data["families"]:
+            if ("review" in instance.data["families"] and
+                not instance.data.get("otioReviewClips")):
                 review_repre = self._create_representation(
                 frame_start, frame_end, collection=collection,
                 delete=True, review=True)
@@ -197,7 +198,8 @@ class CollectOtioSubsetResources(
             repre = self._create_representation(
                 frame_start, frame_end, file=filename, trim=_trim)
 
-            if "review" in instance.data["families"]:
+            if ("review" in instance.data["families"] and
+                not instance.data.get("otioReviewClips")):
                 review_repre = self._create_representation(
                     frame_start, frame_end,
                     file=filename, delete=True, review=True)


### PR DESCRIPTION
## Changelog Description

This PR fixes the issue when Hiero does not publish `review` product properly.
Ensure that the following use-cases works properly:
* review disabled
* `[Clip's media]`
* `Track: current track`
* `Track: another track`

## Testing notes:
1. Setup a multi-tracks timeline in Hiero
2. Publish a timeline with review source set as `clip_media` and another one as `track:XX`
3. Ensure review media works for each scenarios
