### PR TITLE
Launcher: Addon actions are shown

### DIFF
--- a/client/ayon_core/addon/base.py
+++ b/client/ayon_core/addon/base.py
@@ -894,6 +894,21 @@ class AddonsManager:
                 output.extend(paths)
         return output
 
+    def collect_launcher_action_paths(self):
+        """Helper to collect launcher action paths from addons.
+
+        Returns:
+            list: List of paths to launcher actions.
+
+        """
+        output = self._collect_plugin_paths(
+            "get_launcher_action_paths"
+        )
+        # Add default core actions
+        actions_dir = os.path.join(AYON_CORE_ROOT, "plugins", "actions")
+        output.insert(0, actions_dir)
+        return output
+
     def collect_create_plugin_paths(self, host_name):
         """Helper to collect creator plugin paths from addons.
 

--- a/client/ayon_core/addon/interfaces.py
+++ b/client/ayon_core/addon/interfaces.py
@@ -54,6 +54,13 @@ class IPluginPaths(AYONInterface):
             paths = [paths]
         return paths
 
+    def get_launcher_action_paths(self):
+        """Receive launcher actions paths.
+
+        Give addons ability to add launcher actions paths.
+        """
+        return self._get_plugin_paths_by_type("actions")
+
     def get_create_plugin_paths(self, host_name):
         """Receive create plugin paths.
 

--- a/client/ayon_core/tools/launcher/models/actions.py
+++ b/client/ayon_core/tools/launcher/models/actions.py
@@ -7,6 +7,7 @@ from ayon_core.pipeline.actions import (
     discover_launcher_actions,
     LauncherAction,
     LauncherActionSelection,
+    register_launcher_action_path,
 )
 from ayon_core.pipeline.workfile import should_use_last_workfile_on_launch
 
@@ -459,6 +460,14 @@ class ActionsModel:
 
     def _get_discovered_action_classes(self):
         if self._discovered_actions is None:
+            # NOTE We don't need to register the paths, but that would
+            #   require to change discovery logic and deprecate all functions
+            #   related to registering and discovering launcher actions.
+            addons_manager = self._get_addons_manager()
+            actions_paths = addons_manager.collect_launcher_action_paths()
+            for path in actions_paths:
+                if path and os.path.exists(path):
+                    register_launcher_action_path(path)
             self._discovered_actions = (
                 discover_launcher_actions()
                 + self._get_applications_action_classes()

--- a/client/ayon_core/tools/launcher/ui/window.py
+++ b/client/ayon_core/tools/launcher/ui/window.py
@@ -202,8 +202,9 @@ class LauncherWindow(QtWidgets.QWidget):
             self._go_to_hierarchy_page(project_name)
 
     def _on_projects_refresh(self):
-        # There is nothing to do, we're on projects page
+        # Refresh only actions on projects page
         if self._is_on_projects_page:
+            self._actions_widget.refresh()
             return
 
         # No projects were found -> go back to projects page


### PR DESCRIPTION
## Changelog Description
Show all addon actions.

## Additional info
Fixing bug caused by https://github.com/ynput/ayon-core/pull/1044.

## Testing notes:
1. Create package, upload ad use in bundle.
2. Start AYON launcher and open Launcher.
3. Select a context.
4. Actions from all addons should be shown, not just applications.

Resolves https://github.com/ynput/ayon-core/issues/1055