### PR TITLE
AY-6502_Fix Maya dirmap settings

### DIFF
--- a/client/ayon_core/host/dirmap.py
+++ b/client/ayon_core/host/dirmap.py
@@ -118,7 +118,7 @@ class HostDirmap(ABC):
             site, in that case configuration in Local Settings takes precedence
         """
 
-        dirmap_label = "{}-dirmap".format(self.host_name)
+        dirmap_label = "{}_dirmap".format(self.host_name)
         mapping_sett = self.project_settings[self.host_name].get(dirmap_label,
                                                                  {})
         local_mapping = self._get_local_sync_dirmap()

--- a/client/ayon_core/host/dirmap.py
+++ b/client/ayon_core/host/dirmap.py
@@ -117,10 +117,7 @@ class HostDirmap(ABC):
             It checks if Site Sync is enabled and user chose to use local
             site, in that case configuration in Local Settings takes precedence
         """
-
-        dirmap_label = "{}_dirmap".format(self.host_name)
-        mapping_sett = self.project_settings[self.host_name].get(dirmap_label,
-                                                                 {})
+        mapping_sett = self.project_settings[self.host_name].get("dirmap", {})
         local_mapping = self._get_local_sync_dirmap()
         mapping_enabled = mapping_sett.get("enabled") or bool(local_mapping)
         if not mapping_enabled:


### PR DESCRIPTION
## Changelog Description

Remove host name separator in dirmap settings, so that [Maya settings `maya_dirmap` or `maya-dirmap` is now `dirmap` inside that host's settings.](https://github.com/ynput/ayon-maya/blob/d0a8fc35662196ef3e468d3eca4e939be3071a91/server/settings/main.py#L54-L55)

## Additional info

Only other integration I can see that has dirmapping is [Nuke, which uses just `dirmap` without host prefix](https://github.com/ynput/ayon-nuke/blob/a1a0f14bff445dda1de083b47b8a0c143d774dbd/server/settings/main.py#L60-L63) - which I suppose would then be broken regardless anyway but I think [it uses its own way of remapping paths](https://github.com/ynput/ayon-nuke/blob/e401649b044c708d38f31d387e8e1955c4c289e4/client/ayon_nuke/api/pipeline.py#L171-L174). It may make more sense to remove the `host` specific prefix from the label because it's already looking in host specific settings anyway. (However, that'd also need a refactor in `ayon-maya` then? Plus it would then also suddenly pick up the Nuke one which may have other side effects?

Reported on [discord here](https://discord.com/channels/517362899170230292/563751989075378201/1318333164950650941)

Nuke and Maya seems to be the only repos relevant to `dirmap`.

Fixes https://github.com/ynput/ayon-maya/issues/102

## Testing notes:

1. Dirmap in Maya should work
2. Dirmap in Nuke (if relevant) should work
