### PR TITLE
Store in instance data whether the staging dir set is a custom one

### DIFF
--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -717,6 +717,7 @@ def get_instance_staging_dir(instance):
     instance.data.update({
         "stagingDir": staging_dir_path,
         "stagingDir_persistent": staging_dir_info.persistent,
+        "stagingDir_custom": staging_dir_info.custom
     })
 
     return staging_dir_path

--- a/client/ayon_core/pipeline/staging_dir.py
+++ b/client/ayon_core/pipeline/staging_dir.py
@@ -12,6 +12,7 @@ from .tempdir import get_temp_dir
 class StagingDir:
     directory: str
     persistent: bool
+    custom: bool  # Whether the staging dir is a custom staging dir
 
 
 def get_staging_dir_config(
@@ -204,7 +205,8 @@ def get_staging_dir_info(
         dir_template = staging_dir_config["template"]["directory"]
         return StagingDir(
             dir_template.format_strict(ctx_data),
-            staging_dir_config["persistence"],
+            persistent=staging_dir_config["persistence"],
+            custom=True
         )
 
     # no config found but force an output
@@ -216,7 +218,8 @@ def get_staging_dir_info(
                 prefix=prefix,
                 suffix=suffix,
             ),
-            False,
+            persistent=False,
+            custom=False
         )
 
     return None


### PR DESCRIPTION
## Changelog Description

Store in instance data whether the staging dir set is a custom one

## Additional info

Required to fix issue https://github.com/ynput/ayon-maya/issues/194#issuecomment-2556797055 using PR https://github.com/ynput/ayon-maya/pull/204

I did wonder a bit as well whether it may have been nicer to begin with to actually store the `StagingDir` class instance on the `instance.data` instead of the individual separate keys like we're doing now. But also felt that if we do want to - it may be better refactoring that separately.

## Testing notes:

1. Test with https://github.com/ynput/ayon-maya/pull/204
2. Submitting renders should work as intended with both custom staging dir set and when disabled.