### PR TITLE
Launcher: Fix red dot for FORCE_NOT_OPEN_WORKFILE_ROLE to be drawn on wrong location if app is not on first row

### DIFF
--- a/client/ayon_core/tools/launcher/ui/actions_widget.py
+++ b/client/ayon_core/tools/launcher/ui/actions_widget.py
@@ -265,7 +265,7 @@ class ActionDelegate(QtWidgets.QStyledItemDelegate):
 
         if index.data(FORCE_NOT_OPEN_WORKFILE_ROLE):
             rect = QtCore.QRectF(
-                option.rect.x(), option.rect.height(), 5, 5)
+                option.rect.x(), option.rect.y() + option.rect.height(), 5, 5)
             painter.setPen(QtCore.Qt.NoPen)
             painter.setBrush(QtGui.QColor(200, 0, 0))
             painter.drawEllipse(rect)


### PR DESCRIPTION
## Changelog Description

In tray launcher, fix red dot for FORCE_NOT_OPEN_WORKFILE_ROLE to be drawn on wrong location if app is not on first row

## Additional info

In the launcher the "Skip open last workfile" red dot on the applications draws in the wrong location if the app is on the second line (e.g. not top row)

![image](https://github.com/user-attachments/assets/749a3133-e20a-43c5-9952-7813a782bd8e)

In this case the Maya is set to skip last workfile, even though the red dot is still drawn as if that app was at the top row.

This PR fixes it. Now it becomes:

![image](https://github.com/user-attachments/assets/d4b79306-44fe-4ca3-9c55-98a273dd252b)

## Testing notes:
1. Force disable/enable the open last workfile via right mouse click
2. Shrink width of the launcher so the app ends up on second row.
3. The drawn red dot should look ok.
