### PR TITLE
Chore: Staging dir enhancements

### DIFF
--- a/client/ayon_core/pipeline/create/creator_plugins.py
+++ b/client/ayon_core/pipeline/create/creator_plugins.py
@@ -915,7 +915,7 @@ class Creator(BaseCreator):
 
         instance.transient_data.update({
             "stagingDir": staging_dir_path,
-            "stagingDir_persistent": staging_dir_info.persistent,
+            "stagingDir_persistent": staging_dir_info.is_persistent,
         })
 
         self.log.info(f"Applied staging dir to instance: {staging_dir_path}")

--- a/client/ayon_core/pipeline/create/creator_plugins.py
+++ b/client/ayon_core/pipeline/create/creator_plugins.py
@@ -15,7 +15,7 @@ from ayon_core.pipeline.plugin_discover import (
     deregister_plugin,
     deregister_plugin_path
 )
-from ayon_core.pipeline import get_staging_dir_info
+from ayon_core.pipeline.staging_dir import get_staging_dir_info, StagingDir
 
 from .constants import DEFAULT_VARIANT_VALUE
 from .product_name import get_product_name
@@ -833,7 +833,7 @@ class Creator(BaseCreator):
         """
         return self.pre_create_attr_defs
 
-    def get_staging_dir(self, instance):
+    def get_staging_dir(self, instance) -> Optional[StagingDir]:
         """Return the staging dir and persistence from instance.
 
         Args:

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -717,7 +717,7 @@ def get_instance_staging_dir(instance):
     instance.data.update({
         "stagingDir": staging_dir_path,
         "stagingDir_persistent": staging_dir_info.is_persistent,
-        "stagingDir_custom": staging_dir_info.is_custom
+        "stagingDir_is_custom": staging_dir_info.is_custom
     })
 
     return staging_dir_path

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -716,8 +716,8 @@ def get_instance_staging_dir(instance):
     os.makedirs(staging_dir_path, exist_ok=True)
     instance.data.update({
         "stagingDir": staging_dir_path,
-        "stagingDir_persistent": staging_dir_info.persistent,
-        "stagingDir_custom": staging_dir_info.custom
+        "stagingDir_persistent": staging_dir_info.is_persistent,
+        "stagingDir_custom": staging_dir_info.is_custom
     })
 
     return staging_dir_path

--- a/client/ayon_core/pipeline/staging_dir.py
+++ b/client/ayon_core/pipeline/staging_dir.py
@@ -161,11 +161,15 @@ def get_staging_dir_info(
         )
 
     if force_tmp_dir:
-        return get_temp_dir(
-            project_name=project_entity["name"],
-            anatomy=anatomy,
-            prefix=prefix,
-            suffix=suffix,
+        return StagingDir(
+            get_temp_dir(
+                project_name=project_entity["name"],
+                anatomy=anatomy,
+                prefix=prefix,
+                suffix=suffix,
+            ),
+            is_persistent=False,
+            is_custom=False
         )
 
     # making few queries to database

--- a/client/ayon_core/pipeline/staging_dir.py
+++ b/client/ayon_core/pipeline/staging_dir.py
@@ -1,3 +1,6 @@
+import logging
+import warnings
+from typing import Optional, Dict, Any
 from dataclasses import dataclass
 
 from ayon_core.lib import Logger, filter_profiles
@@ -16,16 +19,16 @@ class StagingDir:
 
 
 def get_staging_dir_config(
-    project_name,
-    task_type,
-    task_name,
-    product_type,
-    product_name,
-    host_name,
-    project_settings=None,
-    anatomy=None,
-    log=None,
-):
+    project_name: str,
+    task_type: Optional[str, None],
+    task_name: Optional[str, None],
+    product_type: str,
+    product_name: str,
+    host_name: str,
+    project_settings: Optional[Dict[str, Any]] = None,
+    anatomy: Optional[Anatomy] = None,
+    log: Optional[logging.Logger] = None,
+) -> Optional[Dict[str, Any]]:
     """Get matching staging dir profile.
 
     Args:
@@ -93,21 +96,21 @@ def get_staging_dir_config(
 
 
 def get_staging_dir_info(
-    project_entity,
-    folder_entity,
-    task_entity,
-    product_type,
-    product_name,
-    host_name,
-    anatomy=None,
-    project_settings=None,
-    template_data=None,
-    always_return_path=True,
-    force_tmp_dir=False,
-    logger=None,
-    prefix=None,
-    suffix=None,
-):
+    project_entity: Dict[str, Any],
+    folder_entity: Optional[Dict[str, Any]],
+    task_entity: Optional[Dict[str, Any]],
+    product_type: str,
+    product_name: str,
+    host_name: str,
+    anatomy: Optional[Anatomy] = None,
+    project_settings: Optional[Dict[str, Any]] = None,
+    template_data: Optional[Dict[str, Any]] = None,
+    always_return_path: bool = True,
+    force_tmp_dir: bool = False,
+    logger: Optional[logging.Logger] = None,
+    prefix: Optional[str] = None,
+    suffix: Optional[str] = None,
+) -> Optional[StagingDir]:
     """Get staging dir info data.
 
     If `force_temp` is set, staging dir will be created as tempdir.

--- a/client/ayon_core/pipeline/staging_dir.py
+++ b/client/ayon_core/pipeline/staging_dir.py
@@ -40,8 +40,8 @@ class StagingDir:
 
 def get_staging_dir_config(
     project_name: str,
-    task_type: Optional[str, None],
-    task_name: Optional[str, None],
+    task_type: Optional[str],
+    task_name: Optional[str],
     product_type: str,
     product_name: str,
     host_name: str,

--- a/client/ayon_core/pipeline/staging_dir.py
+++ b/client/ayon_core/pipeline/staging_dir.py
@@ -14,8 +14,28 @@ from .tempdir import get_temp_dir
 @dataclass
 class StagingDir:
     directory: str
-    persistent: bool
-    custom: bool  # Whether the staging dir is a custom staging dir
+    is_persistent: bool
+    # Whether the staging dir is a custom staging dir
+    is_custom: bool
+
+    def __setattr__(self, key, value):
+        if key == "persistent":
+            warnings.warn(
+                "'StagingDir.persistent' is deprecated."
+                " Use 'StagingDir.is_persistent' instead.",
+                DeprecationWarning
+            )
+            key = "is_persistent"
+        super().__setattr__(key, value)
+
+    @property
+    def persistent(self):
+        warnings.warn(
+            "'StagingDir.persistent' is deprecated."
+            " Use 'StagingDir.is_persistent' instead.",
+            DeprecationWarning
+        )
+        return self.is_persistent
 
 
 def get_staging_dir_config(
@@ -198,8 +218,8 @@ def get_staging_dir_info(
         dir_template = staging_dir_config["template"]["directory"]
         return StagingDir(
             dir_template.format_strict(ctx_data),
-            persistent=staging_dir_config["persistence"],
-            custom=True
+            is_persistent=staging_dir_config["persistence"],
+            is_custom=True
         )
 
     # no config found but force an output
@@ -211,8 +231,8 @@ def get_staging_dir_info(
                 prefix=prefix,
                 suffix=suffix,
             ),
-            persistent=False,
-            custom=False
+            is_persistent=False,
+            is_custom=False
         )
 
     return None

--- a/client/ayon_core/pipeline/staging_dir.py
+++ b/client/ayon_core/pipeline/staging_dir.py
@@ -76,7 +76,6 @@ def get_staging_dir_config(
 
     # get template from template name
     template_name = profile["template_name"]
-    _validate_template_name(project_name, template_name, anatomy)
 
     template = anatomy.get_template_item("staging", template_name)
 
@@ -91,19 +90,6 @@ def get_staging_dir_config(
     data_persistence = profile["custom_staging_dir_persistent"]
 
     return {"template": template, "persistence": data_persistence}
-
-
-def _validate_template_name(project_name, template_name, anatomy):
-    """Check that staging dir section with appropriate template exist.
-
-    Raises:
-        ValueError - if misconfigured template
-    """
-    if template_name not in anatomy.templates["staging"]:
-        raise ValueError(
-            f'Anatomy of project "{project_name}" does not have set'
-            f' "{template_name}" template key at Staging Dir category!'
-        )
 
 
 def get_staging_dir_info(


### PR DESCRIPTION
## Changelog Description
Added typehints. Function `get_staging_dir_info` returns `StagingDir` instead of string.
 Change bool attribute names to have `is_` prefix.

## Additional info
Also changed key `stagingDir_custom` to `stagingDir_is_custom`. I would like to use `stagingDirIsCustom` but there were opinions against that would not match existing `stagingDir_persistent` which cannot be changed because of backwards compatibility.

Attribute `is_persistent` has backwards compatibility to still support `persistent` even tho it is not used anywhere else. Key `stagingDir_persistent` cannot be changed at this moment, because it would break backwards compatibility. We could support both keys, but I have no idea how it is being used at other addons (e.g. if it is being changed?).

Function `get_staging_dir_info` could be maybe cleaned up a little, some of the arguments are not used anywhere.

## Testing notes:
1. Staging dir logic works as before.
