### PR TITLE
Fix Anatomy.format_all with unpadded int values.

### DIFF
--- a/client/ayon_core/lib/path_templates.py
+++ b/client/ayon_core/lib/path_templates.py
@@ -561,9 +561,6 @@ class FormattingPart:
 
         """
         key = self._template_base
-        if key in result.really_used_values:
-            result.add_output(result.really_used_values[key])
-            return result
 
         # ensure key is properly formed [({})] properly closed.
         if not self.validate_key_is_matched(key):


### PR DESCRIPTION
## Changelog Description
resolve #1059 

`Anatomy.format_all` is failing with unpadded int raises when attempting to convert `int` to `TemplatePartResult`

## Additional info
A work-around was to edit the problematic template with a padded int this is the proper code fix.
Fix discussed with @iLLiCiTiT 

## Testing notes:
1. Add the following template into your project `Anatomy`
![image](https://github.com/user-attachments/assets/297703d5-3544-4388-9ca9-0b956485d139)

```
default_test
{root[work]}/{project[name]}/OUT/DELIVERY/{yyyy_mm_dd}/{product[name]}/{@version}
{originalBasename}_{studio[name]}_{yyyy-mm-dd}_{version}.{ext}
```

2. Either run a publish to trigger `extract_burnins` or run the following
```python
from ayon_core.pipeline import Anatomy

anatomy = Anatomy("Dummy")
formatted = anatomy.format_all({"version": 5})
```

3. It failed before the fix, it should not fail anymore after.