### PR TITLE
Fix remap with image sequence wrongly detected as legacy.

### DIFF
--- a/tests/client/ayon_core/pipeline/editorial/resources/img_seq_24_to_23.976_no_legacy.json
+++ b/tests/client/ayon_core/pipeline/editorial/resources/img_seq_24_to_23.976_no_legacy.json
@@ -1,0 +1,51 @@
+{
+    "OTIO_SCHEMA": "Clip.2",
+    "metadata": {},
+    "name": "",
+    "source_range": {
+        "OTIO_SCHEMA": "TimeRange.1",
+        "duration": {
+            "OTIO_SCHEMA": "RationalTime.1",
+            "rate": 23.976,
+            "value": 108.0
+        },
+        "start_time": {
+            "OTIO_SCHEMA": "RationalTime.1",
+            "rate": 23.976,
+            "value": 883159.0
+        }
+    },
+    "effects": [],
+    "markers": [],
+    "enabled": true,
+    "media_references": {
+        "DEFAULT_MEDIA": {
+            "OTIO_SCHEMA": "ImageSequenceReference.1",
+            "metadata": {},
+            "name": "",
+            "available_range": {
+                "OTIO_SCHEMA": "TimeRange.1",
+                "duration": {
+                    "OTIO_SCHEMA": "RationalTime.1",
+                    "rate": 24.0,
+                    "value": 755.0
+                },
+                "start_time": {
+                    "OTIO_SCHEMA": "RationalTime.1",
+                    "rate": 24.0,
+                    "value": 883750.0
+                }
+            },
+            "available_image_bounds": null,
+            "target_url_base": "/mnt/jobs/yahoo_theDog_1132/IN/FOOTAGE/SCANS_LINEAR/Panasonic Rec 709 to ACESCG/Panasonic P2 /A001_S001_S001_T004/",
+            "name_prefix": "A001_S001_S001_T004.",
+            "name_suffix": ".exr",
+            "start_frame": 883750,
+            "frame_step": 1,
+            "rate": 1.0,
+            "frame_zero_padding": 0,
+            "missing_frame_policy": "error"
+        }
+    },
+    "active_media_reference_key": "DEFAULT_MEDIA"
+}

--- a/tests/client/ayon_core/pipeline/editorial/test_media_range_with_retimes.py
+++ b/tests/client/ayon_core/pipeline/editorial/test_media_range_with_retimes.py
@@ -187,3 +187,29 @@ def test_img_sequence_conform_to_23_976fps():
         handle_start=0,
         handle_end=8,
     )
+
+
+def test_img_sequence_conform_from_24_to_23_976fps():
+    """
+    Img sequence clip
+    available files = 883750-884504 24fps
+    source_range =  883159-883267 23.976fps
+
+    This test ensures such entries do not trigger
+    the legacy Hiero export compatibility.
+    """
+    expected_data = {
+        'mediaIn': 884043,
+        'mediaOut': 884150,
+        'handleStart': 0,
+        'handleEnd': 0,
+        'speed': 1.0
+    }
+
+    _check_expected_retimed_values(
+        "img_seq_24_to_23.976_no_legacy.json",
+        expected_data,
+        handle_start=0,
+        handle_end=0,
+    )
+


### PR DESCRIPTION
## Changelog Description

We had to put in place a legacy backward-compatible mechanism when we updated our OTIO exporter so that previous relative OTIO range get properly handled. Unfortunately it appears that some clips are wrongly detected as "legacy-exporter" when they should not.
This fixes this issue.

## Additional info
Original error logs reported by the client: [publish-report-250107-17-45.json](https://github.com/user-attachments/files/18351318/publish-report-250107-17-45.json)

This specific use-case has been added as an automated test.

## Testing notes:
1. Run the automated tests
`.\tools\manage.ps1 run pytest .\tests\`
