### PR TITLE
Chore: Avoid knowledge about render job id in metadata file

### DIFF
--- a/client/ayon_core/plugins/publish/collect_rendered_files.py
+++ b/client/ayon_core/plugins/publish/collect_rendered_files.py
@@ -93,8 +93,7 @@ class CollectRenderedFiles(pyblish.api.ContextPlugin):
 
         # now we can just add instances from json file and we are done
         any_staging_dir_persistent = False
-        for instance_data in data.get("instances"):
-
+        for instance_data in data["instances"]:
             self.log.debug("  - processing instance for {}".format(
                 instance_data.get("productName")))
             instance = self._context.create_instance(
@@ -105,6 +104,10 @@ class CollectRenderedFiles(pyblish.api.ContextPlugin):
             instance.data.update(instance_data)
 
             # stash render job id for later validation
+            instance.data["publishJobMetadata"] = data
+            # TODO remove 'render_job_id' here and rather use
+            #   'publishJobMetadata' where is needed.
+            #   - this is deadline specific
             instance.data["render_job_id"] = data.get("job", {}).get("_id")
             staging_dir_persistent = instance.data.get(
                 "stagingDir_persistent", False

--- a/client/ayon_core/plugins/publish/collect_rendered_files.py
+++ b/client/ayon_core/plugins/publish/collect_rendered_files.py
@@ -105,7 +105,7 @@ class CollectRenderedFiles(pyblish.api.ContextPlugin):
             instance.data.update(instance_data)
 
             # stash render job id for later validation
-            instance.data["render_job_id"] = data.get("job").get("_id")
+            instance.data["render_job_id"] = data.get("job", {}).get("_id")
             staging_dir_persistent = instance.data.get(
                 "stagingDir_persistent", False
             )


### PR DESCRIPTION
## Changelog Description
Plugin `CollectRenderedFiles` does not require `"job"` key to be filled in metadata file and is storing the metadata to instance.

## Additional info
The need to store "job._id" is to pass it for deadline for validation of finished render jobs, but ayon-core should not know that deadline does store that information to the metadata file, and also should not enforce the existence of `"job"` key. With this PR the requirement is avoided and also gives deadline other way how to receive id from instance, so it can be fully deprecated in future.

We can discuss if name of the key is ok and if there are better suggestions.

## Testing notes:
1. Validate code changes.
