### PR TITLE
Update default order to match values in `CollectUSDLayerContributions`

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -1008,8 +1008,8 @@ DEFAULT_PUBLISH_VALUES = {
             {"name": "model", "order": 100},
             {"name": "assembly", "order": 150},
             {"name": "groom", "order": 175},
-            {"name": "look", "order": 300},
-            {"name": "rig", "order": 100},
+            {"name": "look", "order": 200},
+            {"name": "rig", "order": 300},
             # Shot layers
             {"name": "layout", "order": 200},
             {"name": "animation", "order": 300},


### PR DESCRIPTION
## Changelog Description
resolve #1081 
New default values follow: 
https://github.com/ynput/ayon-core/blob/a141237650951354005000c77e50e250198f35af/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py#L275-L276


## Testing notes:
1. everything should work as before, I've only updated the default values in settings.
