### PR TITLE
Report stagingDir_is_custom to apply_staging_dir

### DIFF
--- a/client/ayon_core/pipeline/create/creator_plugins.py
+++ b/client/ayon_core/pipeline/create/creator_plugins.py
@@ -916,6 +916,7 @@ class Creator(BaseCreator):
         instance.transient_data.update({
             "stagingDir": staging_dir_path,
             "stagingDir_persistent": staging_dir_info.is_persistent,
+            "stagingDir_is_custom": staging_dir_info.is_custom,
         })
 
         self.log.info(f"Applied staging dir to instance: {staging_dir_path}")


### PR DESCRIPTION
## Changelog Description
Following https://github.com/ynput/ayon-core/pull/1069 and testing https://github.com/ynput/ayon-nuke/pull/52, I realized `apply_staging_dir` was missing `stagingDir_is_custom`.

## Testing notes:
The following ensure Nuke product can be published with custom staging directories.

1. Enable custom staging directory with some profiles ayon+settings://core/tools/publish/custom_staging_dir_profiles (make it persistent so you can troubleshoot)
2. Create a template matching the staging directory under ayon+anatomy://Dummy/templates/staging
e.g. {root[work]}/{project[name]}/{hierarchy}/{folder[name]}/temp_render_only/{product[type]}/{product[name]}
3. Open Nuke and create+publish some products
4. Ensure that the staging directory is working is properly redirected to the relevant template for the associated products/task
