### PR TITLE
Workfiles: Browse and Save As button only enabled when in valid context

### DIFF
--- a/client/ayon_core/tools/workfiles/widgets/files_widget.py
+++ b/client/ayon_core/tools/workfiles/widgets/files_widget.py
@@ -266,9 +266,6 @@ class FilesWidget(QtWidgets.QWidget):
     def _on_workarea_path_changed(self, event):
         valid_path = event["path"] is not None
         self._workarea_btn_open.setEnabled(valid_path)
-        valid_task = self._selected_task_id is not None
-        self._workarea_btn_save.setEnabled(valid_task)
-        self._workarea_btn_browse.setEnabled(valid_task)
 
     # -------------------------------------------------------------
     # Published workfiles
@@ -283,8 +280,9 @@ class FilesWidget(QtWidgets.QWidget):
         self._published_btn_change_context.setEnabled(enabled)
 
     def _update_workarea_btns_state(self):
-        enabled = self._is_save_enabled
+        enabled = self._is_save_enabled and self._valid_selected_context
         self._workarea_btn_save.setEnabled(enabled)
+        self._workarea_btn_browse.setEnabled(self._valid_selected_context)
 
     def _on_published_repre_changed(self, event):
         self._valid_representation_id = event["representation_id"] is not None
@@ -299,6 +297,7 @@ class FilesWidget(QtWidgets.QWidget):
             and self._selected_task_id is not None
         )
         self._update_published_btns_state()
+        self._update_workarea_btns_state()
 
     def _on_published_save_clicked(self):
         result = self._exec_save_as_dialog()

--- a/client/ayon_core/tools/workfiles/widgets/files_widget.py
+++ b/client/ayon_core/tools/workfiles/widgets/files_widget.py
@@ -136,6 +136,8 @@ class FilesWidget(QtWidgets.QWidget):
 
         # Initial setup
         workarea_btn_open.setEnabled(False)
+        workarea_btn_browse.setEnabled(False)
+        workarea_btn_save.setEnabled(False)
         published_btn_copy_n_open.setEnabled(False)
         published_btn_change_context.setEnabled(False)
         published_btn_cancel.setVisible(False)
@@ -264,6 +266,9 @@ class FilesWidget(QtWidgets.QWidget):
     def _on_workarea_path_changed(self, event):
         valid_path = event["path"] is not None
         self._workarea_btn_open.setEnabled(valid_path)
+        valid_task = self._selected_task_id is not None
+        self._workarea_btn_save.setEnabled(valid_task)
+        self._workarea_btn_browse.setEnabled(valid_task)
 
     # -------------------------------------------------------------
     # Published workfiles


### PR DESCRIPTION
## Changelog Description

Only allow saving and browsing from a "task" context.

## Additional info

Fixes e.g. this error when clicking Save As before the Workfiles tool has fully initialized:

```
Traceback (most recent call last):
  File "C:\CODE\__YNPUT\ayon-core\client\ayon_core\tools\workfiles\widgets\files_widget.py", line 253, in _on_workarea_save_clicked
    result = self._exec_save_as_dialog()
  File "C:\CODE\__YNPUT\ayon-core\client\ayon_core\tools\workfiles\widgets\files_widget.py", line 175, in _exec_save_as_dialog
    dialog.update_context()
  File "C:\CODE\__YNPUT\ayon-core\client\ayon_core\tools\workfiles\widgets\save_as_dialog.py", line 254, in update_context
    self._extension_combobox.addItems(data["extensions"])
TypeError: 'PySide2.QtWidgets.QComboBox.addItems' called with wrong argument types:
  PySide2.QtWidgets.QComboBox.addItems(NoneType)
Supported signatures:
  PySide2.QtWidgets.QComboBox.addItems(typing.Sequence[str])
```
As reported e.g. [here](https://github.com/ynput/ayon-silhouette/pull/1#issuecomment-2589857545)

## Testing notes:

1. Workfiles tool should work as intended
2. Deselecting a folder or task should block "browse" and "save as" buttons
