### PR TITLE
Avoid database queries when collecting managed staging dir

### DIFF
--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -708,6 +708,7 @@ def get_instance_staging_dir(instance):
         project_settings=context.data["project_settings"],
         template_data=template_data,
         always_return_path=True,
+        username=context.data["user"],
     )
 
     staging_dir_path = staging_dir_info.directory

--- a/client/ayon_core/pipeline/staging_dir.py
+++ b/client/ayon_core/pipeline/staging_dir.py
@@ -130,6 +130,7 @@ def get_staging_dir_info(
     logger: Optional[logging.Logger] = None,
     prefix: Optional[str] = None,
     suffix: Optional[str] = None,
+    username: Optional[str] = None,
 ) -> Optional[StagingDir]:
     """Get staging dir info data.
 
@@ -183,7 +184,9 @@ def get_staging_dir_info(
 
     # making few queries to database
     ctx_data = get_template_data(
-        project_entity, folder_entity, task_entity, host_name
+        project_entity, folder_entity, task_entity, host_name,
+        settings=project_settings,
+        username=username
     )
 
     # add additional data

--- a/client/ayon_core/pipeline/template_data.py
+++ b/client/ayon_core/pipeline/template_data.py
@@ -4,7 +4,7 @@ from ayon_core.settings import get_studio_settings
 from ayon_core.lib.local_settings import get_ayon_username
 
 
-def get_general_template_data(settings=None):
+def get_general_template_data(settings=None, username=None):
     """General template data based on system settings or machine.
 
     Output contains formatting keys:
@@ -14,17 +14,22 @@ def get_general_template_data(settings=None):
 
     Args:
         settings (Dict[str, Any]): Studio or project settings.
+        username (Optional[str]): AYON Username.
     """
 
     if not settings:
         settings = get_studio_settings()
+
+    if username is None:
+        username = get_ayon_username()
+
     core_settings = settings["core"]
     return {
         "studio": {
             "name": core_settings["studio_name"],
             "code": core_settings["studio_code"]
         },
-        "user": get_ayon_username()
+        "user": username
     }
 
 
@@ -145,6 +150,7 @@ def get_template_data(
     task_entity=None,
     host_name=None,
     settings=None,
+    username=None
 ):
     """Prepare data for templates filling from entered documents and info.
 
@@ -167,12 +173,13 @@ def get_template_data(
         host_name (Optional[str]): Used to fill '{app}' key.
         settings (Union[Dict, None]): Prepared studio or project settings.
             They're queried if not passed (may be slower).
+        username (Optional[str]): AYON Username.
 
     Returns:
         Dict[str, Any]: Data prepared for filling workdir template.
     """
 
-    template_data = get_general_template_data(settings)
+    template_data = get_general_template_data(settings, username=username)
     template_data.update(get_project_template_data(project_entity))
     if folder_entity:
         template_data.update(get_folder_template_data(


### PR DESCRIPTION
## Changelog Description

Collect Managed Staging Dir runs over every instance - when many instances would be processed it'd usually make two connections for each of them, a project settings query because we weren't passing that along + a username query - both which are already collected in the publish context.

This change avoids the redundant query.

## Additional info

Publishing with and without custom staging dir should continue to work.

## Testing notes:

1. Publish from a few different integrations with and without custom staging dir should continue to work.
