### PR TITLE
Add substance designer support

### DIFF
--- a/client/ayon_core/hooks/pre_add_last_workfile_arg.py
+++ b/client/ayon_core/hooks/pre_add_last_workfile_arg.py
@@ -26,6 +26,7 @@ class AddLastWorkfileToLaunchArgs(PreLaunchHook):
         "photoshop",
         "tvpaint",
         "substancepainter",
+        "substancedesigner",
         "aftereffects",
         "wrap",
         "openrv",

--- a/client/ayon_core/hooks/pre_ocio_hook.py
+++ b/client/ayon_core/hooks/pre_ocio_hook.py
@@ -10,6 +10,7 @@ class OCIOEnvHook(PreLaunchHook):
     order = 0
     hosts = {
         "substancepainter",
+        "substancedesigner",
         "fusion",
         "blender",
         "aftereffects",

--- a/client/ayon_core/pipeline/farm/pyblish_functions.py
+++ b/client/ayon_core/pipeline/farm/pyblish_functions.py
@@ -935,9 +935,7 @@ def _collect_expected_files_for_aov(files):
         ValueError: If there are multiple collections.
 
     """
-    print(f"files: {files}")
     cols, rem = clique.assemble(files)
-    print(cols)
     # we shouldn't have any reminders. And if we do, it should
     # be just one item for single frame renders.
     if not cols and rem:

--- a/client/ayon_core/pipeline/farm/pyblish_functions.py
+++ b/client/ayon_core/pipeline/farm/pyblish_functions.py
@@ -935,7 +935,9 @@ def _collect_expected_files_for_aov(files):
         ValueError: If there are multiple collections.
 
     """
+    print(f"files: {files}")
     cols, rem = clique.assemble(files)
+    print(cols)
     # we shouldn't have any reminders. And if we do, it should
     # be just one item for single frame renders.
     if not cols and rem:

--- a/client/ayon_core/plugins/publish/collect_resources_path.py
+++ b/client/ayon_core/plugins/publish/collect_resources_path.py
@@ -66,7 +66,8 @@ class CollectResourcesPath(pyblish.api.InstancePlugin):
                 "yeticacheUE",
                 "tycache",
                 "usd",
-                "oxrig"
+                "oxrig",
+                "sbsar",
                 ]
 
     def process(self, instance):


### PR DESCRIPTION
## Changelog Description
Add substance designer as being part of the hosts for OCIO and last workfile prelaunch hook.

## Additional info
Use together with the related application addon https://github.com/ynput/ayon-applications/pull/50 and initial integration

## Testing notes:
1. Build and install core addon
2. Last workfile can be launched as expected.
