### PR TITLE
Explicit cleanup for instances

### DIFF
--- a/client/ayon_core/pipeline/farm/pyblish_functions.py
+++ b/client/ayon_core/pipeline/farm/pyblish_functions.py
@@ -276,6 +276,10 @@ def create_skeleton_instance(
     persistent = instance.data.get("stagingDir_persistent") is True
     instance_skeleton_data["stagingDir_persistent"] = persistent
 
+    explicit_cleanup_paths = instance.data.get("cleanupFullPaths", [])
+    if len(explicit_cleanup_paths) > 0:
+        instance_skeleton_data["cleanupFullPaths"] = explicit_cleanup_paths
+
     return instance_skeleton_data
 
 

--- a/client/ayon_core/plugins/publish/cleanup_explicit.py
+++ b/client/ayon_core/plugins/publish/cleanup_explicit.py
@@ -28,6 +28,13 @@ class ExplicitCleanUp(pyblish.api.ContextPlugin):
         self._remove_full_paths(cleanup_full_paths)
         self._remove_empty_dirs(cleanup_empty_dirs)
 
+        for instance in context:
+            instance_cleanup_full_paths = instance.data.get("cleanupFullPaths")
+            instance_cleanup_empty_dirs = instance.data.get("cleanupEmptyDirs")
+
+            self._remove_full_paths(instance_cleanup_full_paths)
+            self._remove_empty_dirs(instance_cleanup_empty_dirs)
+
     def _remove_full_paths(self, full_paths):
         """Remove files and folders from disc.
 


### PR DESCRIPTION
When we render with Gaffer, to get an exr with the aov's as channels instead of their own separate exr files, we render the aovs separately (since that's what Gaffer does) and then combine them, this requires deletion of these temporary aov folders. The existing `explicit_cleanup.py` plugin operates on contexts only and that's not good enough since then we'd collect e.g. 4 aov folder paths to delete for the various render layers, and then the first publish job would just delete them all regardless of if they are finished enough. So I needed to have some explicit cleanup for instances. 

So I added this to the `explicit_cleanup.py` plugin. Maybe it would be better to have it's dedicated plugin. Or perhaps the clean-up-farm plugin which I am unsure about how is used. 

This then propagates the 'cleanupFullPaths' key on the instances on to the farm metadata json files.