### PR TITLE
Reduce margins on Workfiles tool due to nested layouts

### DIFF
--- a/client/ayon_core/tools/workfiles/widgets/window.py
+++ b/client/ayon_core/tools/workfiles/widgets/window.py
@@ -113,6 +113,7 @@ class WorkfilesToolWindow(QtWidgets.QWidget):
 
         main_layout = QtWidgets.QHBoxLayout(self)
         main_layout.addWidget(pages_widget, 1)
+        main_layout.setContentsMargins(0, 0, 0, 0)
 
         overlay_messages_widget = MessageOverlayObject(self)
         overlay_invalid_host = InvalidHostOverlay(self)


### PR DESCRIPTION
## Changelog Description

Of all the AYON UIs, the workfiles tool was the only one that relatively had big margins around its full layout:

![image](https://github.com/user-attachments/assets/c8264276-b668-4e94-94de-5ca555f5cbd7)

This PR reduces that to:
![image](https://github.com/user-attachments/assets/8572604b-0ef5-4dd7-bcd8-65cdcb510d8d)

## Additional info

For comparison, some other tools:

Loader:
![image](https://github.com/user-attachments/assets/b901a79d-9b44-424a-9d36-de6a1a809e68)

Publisher:

![image](https://github.com/user-attachments/assets/a7455d20-2ef8-497b-8664-ac9bbc6dbb1d)

Scene Inventory:

![image](https://github.com/user-attachments/assets/6801eea7-a5cf-4804-b457-1789f7ff7bb4)

## Testing notes:

1. Workfiles tools should look better