### PR TITLE
Set the icon size in the stylesheet for *

### DIFF
--- a/client/ayon_core/style/style.css
+++ b/client/ayon_core/style/style.css
@@ -23,6 +23,9 @@ Enabled vs Disabled logic in most of stylesheets
     font-family: "Noto Sans";
     font-weight: 450;
     outline: none;
+
+    /* Fix icons in BorisFX Silhouette */
+    icon-size: 16px;
 }
 
 QWidget {


### PR DESCRIPTION
## Changelog Description

Set the icon size in the stylesheet to avoid too big clunky icons in BorisFX Silhouette.

The sizes appeared the same in Fusion and Maya with this added to the stylesheet (no changes there)

## Additional info

Might be worth testing some other integrations to see if icon sizes still look good.

Also, may be good to test on 4k High DPI scaling to see how it reacts with this. (It may need e.g. `em` instead of `px`?)

See [(internal) private discussion](https://discord.com/channels/517362899170230292/1326234257185574973/1326592358099324988)

## Testing notes:

1. Test whether workfiles, publisher, loader, etc. doesn't suddenly have odd button and icon sizes.
