### PR TITLE
Feature: Executable path expand user and standard env var

### DIFF
--- a/client/ayon_core/lib/vendor_bin_utils.py
+++ b/client/ayon_core/lib/vendor_bin_utils.py
@@ -67,6 +67,8 @@ def find_executable(executable):
         Union[str, None]: Full path to executable with extension which was
             found otherwise None.
     """
+    # Expand user and environment variables
+    executable = os.path.expandvars(os.path.expanduser(executable))
 
     # Skip if passed path is file
     if is_file_executable(executable):


### PR DESCRIPTION
## Changelog Description
Executable path expand user `~` and standard environment variables syntax `$ENV_VAR`.

## Additional info
Fix of #1091 

## Testing notes:
1. In `Applications` addon, add a `~` or `$ENV_VAR` (don't forget to set it at some point) to an executable path, like `~/path/to/executable` or `$HOME/path/to/executable` (Unix syntax)
