### PR TITLE
Add Silhouette host to defaults of version and outdated containers validators

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -1033,7 +1033,8 @@ DEFAULT_PUBLISH_VALUES = {
                     "maya",
                     "nuke",
                     "photoshop",
-                    "substancepainter"
+                    "substancepainter",
+                    "silhouette"
                 ],
                 "enabled": True,
                 "optional": False,
@@ -1053,7 +1054,8 @@ DEFAULT_PUBLISH_VALUES = {
                     "harmony",
                     "photoshop",
                     "aftereffects",
-                    "fusion"
+                    "fusion",
+                    "silhouette"
                 ],
                 "enabled": True,
                 "optional": True,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -1034,7 +1034,7 @@ DEFAULT_PUBLISH_VALUES = {
                     "nuke",
                     "photoshop",
                     "substancepainter",
-                    "silhouette"
+                    "silhouette",
                 ],
                 "enabled": True,
                 "optional": False,
@@ -1055,7 +1055,7 @@ DEFAULT_PUBLISH_VALUES = {
                     "photoshop",
                     "aftereffects",
                     "fusion",
-                    "silhouette"
+                    "silhouette",
                 ],
                 "enabled": True,
                 "optional": True,


### PR DESCRIPTION
## Changelog Description

Add Silhouette host to defaults of version and outdated containers validators

## Additional info

Relates to `ayon-silhouette`

## Testing notes:

1. Settings should be the new defaults.
