### PR TITLE
Create: Auto-fill project entity in get product name if is not passed in

### DIFF
--- a/client/ayon_core/pipeline/create/creator_plugins.py
+++ b/client/ayon_core/pipeline/create/creator_plugins.py
@@ -562,6 +562,9 @@ class BaseCreator(ABC):
             instance
         )
 
+        if not project_entity:
+            project_entity = self.create_context.get_current_project_entity()
+
         return get_product_name(
             project_name,
             task_name,

--- a/client/ayon_core/pipeline/create/creator_plugins.py
+++ b/client/ayon_core/pipeline/create/creator_plugins.py
@@ -562,7 +562,8 @@ class BaseCreator(ABC):
             instance
         )
 
-        if not project_entity:
+        cur_project_name = self.create_context.get_current_project_name()
+        if not project_entity and project_name == cur_project_name:
             project_entity = self.create_context.get_current_project_entity()
 
         return get_product_name(


### PR DESCRIPTION
## Changelog Description
Auto fill project entity from current context if is not passed into the create plugin method.

## Additional info
There is low chance we will call this method from different than current project, but I've added check for the project name (just safety).

## Testing notes:
1. Product name calculation might be a little bit faster for creators which are calling the method on their own (e.g. auto-creators).
