### PR TITLE
Create: Use 'AYON_INSTANCE_ID' by default instead of 'AVALON_NSTANCE_ID'

### DIFF
--- a/client/ayon_core/pipeline/create/legacy_create.py
+++ b/client/ayon_core/pipeline/create/legacy_create.py
@@ -9,7 +9,7 @@ import os
 import logging
 import collections
 
-from ayon_core.pipeline.constants import AVALON_INSTANCE_ID
+from ayon_core.pipeline.constants import AYON_INSTANCE_ID
 
 from .product_name import get_product_name
 
@@ -34,7 +34,7 @@ class LegacyCreator:
         # Default data
         self.data = collections.OrderedDict()
         # TODO use 'AYON_INSTANCE_ID' when all hosts support it
-        self.data["id"] = AVALON_INSTANCE_ID
+        self.data["id"] = AYON_INSTANCE_ID
         self.data["productType"] = self.product_type
         self.data["folderPath"] = folder_path
         self.data["productName"] = name

--- a/client/ayon_core/pipeline/create/structures.py
+++ b/client/ayon_core/pipeline/create/structures.py
@@ -492,7 +492,7 @@ class CreatedInstance:
         item_id = data.get("id")
         # TODO use only 'AYON_INSTANCE_ID' when all hosts support it
         if item_id not in {AYON_INSTANCE_ID, AVALON_INSTANCE_ID}:
-            item_id = AVALON_INSTANCE_ID
+            item_id = AYON_INSTANCE_ID
         self._data["id"] = item_id
         self._data["productType"] = product_type
         self._data["productName"] = product_name


### PR DESCRIPTION
## Changelog Description
Use `AYON_INSTANCE_ID` constant by default for new instances instead of deprecated `AVALON_NSTANCE_ID`.

## Additional info
This might affect hosts that don't load `AYON_INSTANCE_ID` but still uses `AVALON_NSTANCE_ID`, hopefully there is none.

## Testing notes:
1. Create plugins in all hosts should be able to collect existing instances.
2. Create plugins in all hosts should be able to create new instances, that are then collected.

### Hosts
- [x] 3ds Max
- [x] After Effects
- [x] Blender
- [x] Cinema 4D
- [x] Celaction
- [x] Equalizer
- [x] Flame
- [x] Fusion
- [x] Harmony
- [x] Hiero
- [x] Houdini
- [x] Maya
- [x] Motion Builder
- [x] Mocha
- [x] OpenRV
- [x] Photoshop
- [x] Premiere
- [X] Resolve
- [x] Silhoutte
- [x] Substance Designer
- [x] Substance Painter
- [x] Speed Tree
- [x] TVPaint
- [x] TrayPublisher
- [x] Unreal
- [x] Webpublisher
- [x] Wrap
- [x] ZBrush