### PR TITLE
AY-7063 Fix Version follow up from Workfile set by hosts.

### DIFF
--- a/client/ayon_core/pipeline/create/creator_plugins.py
+++ b/client/ayon_core/pipeline/create/creator_plugins.py
@@ -858,13 +858,24 @@ class Creator(BaseCreator):
             ["CollectAnatomyInstanceData"]
             ["follow_workfile_version"]
         )
+        follow_version_hosts = (
+            publish_settings
+            ["CollectSceneVersion"]
+            ["hosts"]
+        )
+
+        current_host = create_ctx.host.name
+        follow_workfile_version = (
+            follow_workfile_version and 
+            current_host in follow_version_hosts
+        )
 
         # Gather version number provided from the instance.
+        current_workfile = create_ctx.get_current_workfile_path()
         version = instance.get("version")
 
         # If follow workfile, gather version from workfile path.
-        if version is None and follow_workfile_version:
-            current_workfile = self.create_context.get_current_workfile_path()
+        if version is None and follow_workfile_version and current_workfile:
             workfile_version = get_version_from_path(current_workfile)
             version = int(workfile_version)
 

--- a/client/ayon_core/plugins/publish/collect_scene_version.py
+++ b/client/ayon_core/plugins/publish/collect_scene_version.py
@@ -46,6 +46,13 @@ class CollectSceneVersion(pyblish.api.ContextPlugin):
             self.log.debug("Skipping for headless publishing")
             return
 
+        if context.data["hostName"] not in self.hosts:
+            self.log.debug(
+                f"Host {context.data['hostName']} is"
+                " not setup for following version."
+            )
+            return
+
         if not context.data.get('currentFile'):
             self.log.error("Cannot get current workfile path. "
                            "Make sure your scene is saved.")


### PR DESCRIPTION
## Changelog Description

resolve: https://github.com/ynput/ayon-hiero/issues/19

Initial requests was to be able to "disable" the workfile-version-follow-up feature per host.
The setting to enable this feature is `ayon+settings://core/publish/CollectSceneVersion/hosts`.

I realized there already was a settings to  discriminate the workfile version collection per host: `ayon+settings://core/publish/CollectSceneVersion/hosts`

Changes:
* [X] Ensure that `ayon+settings://core/publish/CollectSceneVersion/hosts` is used in `collect_scene_version`
* [X] Report this in the `{version}` template computation for staging directory

## Testing notes:
1. Enable the version follow-up from `ayon+settings://core/publish/CollectSceneVersion/hosts`
2a. Ensure it follows workfile version if the host is part of `ayon+settings://core/publish/CollectSceneVersion/hosts`
2b. Ensure it does NOT follow workfile version otherwise

Tested in Hiero and Nuke (with/without staging directory).
