### PR TITLE
Fix [clip_media] reviewable.

### DIFF
--- a/client/ayon_core/plugins/publish/collect_otio_review.py
+++ b/client/ayon_core/plugins/publish/collect_otio_review.py
@@ -36,6 +36,16 @@ class CollectOtioReview(pyblish.api.InstancePlugin):
         # optionally get `reviewTrack`
         review_track_name = instance.data.get("reviewTrack")
 
+        # [clip_media] setting:
+        # Extract current clip source range as reviewable.
+        # Flag review content from otio_clip.
+        if not review_track_name and "review" in instance.data["families"]:
+            otio_review_clips = [otio_clip]
+
+        # skip if no review track available
+        elif not review_track_name:
+            return
+
         # generate range in parent
         otio_tl_range = otio_clip.range_in_parent()
 
@@ -43,13 +53,12 @@ class CollectOtioReview(pyblish.api.InstancePlugin):
         clip_frame_end = int(
             otio_tl_range.start_time.value + otio_tl_range.duration.value)
 
-        # skip if no review track available
-        if not review_track_name:
-            return
-
         # loop all tracks and match with name in `reviewTrack`
         for track in otio_timeline.tracks:
-            if review_track_name != track.name:
+            if (
+                review_track_name is None
+                or review_track_name != track.name
+            ):
                 continue
 
             # process correct track

--- a/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
+++ b/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
@@ -195,13 +195,6 @@ class CollectOtioSubsetResources(
                 repre = self._create_representation(
                     frame_start, frame_end, file=filename)
 
-            if (
-                not instance.data.get("otioReviewClips")
-                and "review" in instance.data["families"]
-            ):
-                review_repre = self._create_representation(
-                    frame_start, frame_end, collection=collection,
-                    delete=True, review=True)
 
         else:
             _trim = False
@@ -217,13 +210,6 @@ class CollectOtioSubsetResources(
             repre = self._create_representation(
                 frame_start, frame_end, file=filename, trim=_trim)
 
-            if (
-                not instance.data.get("otioReviewClips")
-                and "review" in instance.data["families"]
-            ):
-                review_repre = self._create_representation(
-                    frame_start, frame_end,
-                    file=filename, delete=True, review=True)
 
         instance.data["originalDirname"] = self.staging_dir
 
@@ -236,9 +222,6 @@ class CollectOtioSubsetResources(
 
             instance.data["representations"].append(repre)
 
-        # add review representation to instance data
-        if review_repre:
-            instance.data["representations"].append(review_repre)
 
         self.log.debug(instance.data)
 

--- a/client/ayon_core/plugins/publish/extract_otio_review.py
+++ b/client/ayon_core/plugins/publish/extract_otio_review.py
@@ -320,6 +320,9 @@ class ExtractOTIOReview(
         end = max(collection.indexes)
 
         files = [f for f in collection]
+        # single frame sequence
+        if len(files) == 1:
+            files = files[0] 
         ext = collection.format("{tail}")
         representation_data.update({
             "name": ext[1:],


### PR DESCRIPTION
## Changelog Description

While working on retimes, I realized I've over-engineered the logic to handle `[clip_media]` reviewable.
When selected the reviewable should be `otio_clip` original media source range + handles.

This change simplify the approach to make it leverage `collect_otio_review`, `extract_otio_review` and `extract_review`.

Changes:
* [X] Rework `[clip_media]` logic to make it go through `collect_otio_review`
* [X] Ensure single frame reviewables are properly handled by `extract_review` plugins

## Testing notes:
1. From Flame or Hiero publish shot clip with the `[clip_media]` reviewable enabled
2. Ensure reviewable is properly produce from clip source range (no retime applied) + handles
