### PR TITLE
Support integrating a folder as files for a representation

### DIFF
--- a/client/ayon_core/lib/file_transaction.py
+++ b/client/ayon_core/lib/file_transaction.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import shutil
 import sys
 import errno
 
@@ -135,7 +136,10 @@ class FileTransaction:
 
             self._create_folder_for_file(dst)
 
-            if opts["mode"] == self.MODE_COPY:
+            if os.path.isdir(src):
+                self.log.debug(f"Copying directory ... {src} -> {dst}")
+                shutil.copytree(src, dst)
+            elif opts["mode"] == self.MODE_COPY:
                 self.log.debug("Copying file ... {} -> {}".format(src, dst))
                 copyfile(src, dst)
             elif opts["mode"] == self.MODE_HARDLINK:

--- a/client/ayon_core/tools/workfiles/control.py
+++ b/client/ayon_core/tools/workfiles/control.py
@@ -742,7 +742,11 @@ class BaseWorkfileController(
         # Save workfile
         dst_filepath = os.path.join(workdir, filename)
         if src_filepath:
-            shutil.copyfile(src_filepath, dst_filepath)
+            # Support published workfile representations that may be folders
+            if os.path.isdir(src_filepath):
+                shutil.copytree(src_filepath, dst_filepath)
+            else:
+                shutil.copyfile(src_filepath, dst_filepath)
             self._host_open_workfile(dst_filepath)
         else:
             self._host_save_workfile(dst_filepath)


### PR DESCRIPTION
## Changelog Description

Support integrating a folder as files for a representation

## Additional info

By allowing this, we can for example integrate BorisFX Silhouette workfiles (for which its project's are folders instead of files)

With these changes it is possible to integrate the workfile, register the representation, etc.

However, there may be follow up issues:

- [x] Integration works
- [x] Copy & Open from Published in Workfiles tool
- [x] Loader UI and tools works
- [ ] Site Sync (may need changes for this?)
- [ ] Push to library project (may need changes for this?)
- [ ] Delivery tool (may need changes for this?)

## Testing notes:

1. Publish and integrate folders as representations, e.g. a Workfile from Silhouette integration