### PR TITLE
Add support for `optional_tooltip` attribute on `OptionalPyblishPluginMixin`

### DIFF
--- a/client/ayon_core/pipeline/publish/publish_plugins.py
+++ b/client/ayon_core/pipeline/publish/publish_plugins.py
@@ -304,8 +304,11 @@ class OptionalPyblishPluginMixin(AYONPyblishPluginMixin):
         active = getattr(cls, "active", True)
         # Return boolean stored under 'active' key with label of the class name
         label = cls.label or cls.__name__
+        # Allow exposing tooltip from class with `optional_tooltip` attribute
+        tooltip = getattr(cls, "optional_tooltip", None)
+
         return [
-            BoolDef("active", default=active, label=label)
+            BoolDef("active", default=active, label=label, tooltip=tooltip)
         ]
 
     def is_active(self, data):

--- a/client/ayon_core/pipeline/publish/publish_plugins.py
+++ b/client/ayon_core/pipeline/publish/publish_plugins.py
@@ -292,6 +292,9 @@ class OptionalPyblishPluginMixin(AYONPyblishPluginMixin):
     ```
     """
 
+    # Allow exposing tooltip from class with `optional_tooltip` attribute
+    optional_tooltip: Optional[str] = None
+
     @classmethod
     def get_attribute_defs(cls):
         """Attribute definitions based on plugin's optional attribute."""
@@ -304,11 +307,12 @@ class OptionalPyblishPluginMixin(AYONPyblishPluginMixin):
         active = getattr(cls, "active", True)
         # Return boolean stored under 'active' key with label of the class name
         label = cls.label or cls.__name__
-        # Allow exposing tooltip from class with `optional_tooltip` attribute
-        tooltip = getattr(cls, "optional_tooltip", None)
 
         return [
-            BoolDef("active", default=active, label=label, tooltip=tooltip)
+            BoolDef("active",
+                    default=active,
+                    label=label,
+                    tooltip=cls.optional_tooltip)
         ]
 
     def is_active(self, data):

--- a/client/ayon_core/pipeline/publish/publish_plugins.py
+++ b/client/ayon_core/pipeline/publish/publish_plugins.py
@@ -309,10 +309,12 @@ class OptionalPyblishPluginMixin(AYONPyblishPluginMixin):
         label = cls.label or cls.__name__
 
         return [
-            BoolDef("active",
-                    default=active,
-                    label=label,
-                    tooltip=cls.optional_tooltip)
+            BoolDef(
+                "active",
+                default=active,
+                label=label,
+                tooltip=cls.optional_tooltip,
+            )
         ]
 
     def is_active(self, data):


### PR DESCRIPTION
## Changelog Description

When `optional_tooltip: str` attribute is found on the publish plugin that inherits from `OptionalPyblishPluginMixin` and the plug-in is optional, then this tooltip will be added to the checkbox in the publisher UI.

## Additional info

Not sure if there's a nicer way - but there were just cases where I figured having some tooltip could be nice to clarify specific optional toggles.

Would it be nice to have `optional_tooltip: Optional[str] = None` attribute default on `OptionalPyblishPluginMixin`? For better auto-complete?

## Testing notes:

1. Add `optional_tooltip` string attribute to optional plug-in that inherits from `OptionalPyblishPluginMixin`
2. The tooltip should show on the attribute definition for the checkbox.