### PR TITLE
String template: Fix index validation for list values

### DIFF
--- a/client/ayon_core/lib/path_templates.py
+++ b/client/ayon_core/lib/path_templates.py
@@ -587,8 +587,8 @@ class FormattingPart:
                 if sub_key < 0:
                     sub_key = len(value) + sub_key
 
-                invalid = 0 > sub_key < len(data)
-                if invalid:
+                valid = 0 <= sub_key < len(value)
+                if not valid:
                     used_keys.append(sub_key)
                     missing_key = True
                     break


### PR DESCRIPTION
## Changelog Description
List values are correctly resovled as have missing index/key.

## Additional info
The validation was not readable much and it was looking at length of input data instead of lenght of current value.

## Testing notes:
1. Use `<{folder[parents][100]}>` in anatomy template.
2. Run some process to try fill the template.
3. It should not crash because of `IndexError`.