### PR TITLE
Create: Add helper 'get_template_data' to create context

### DIFF
--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -483,7 +483,7 @@ class CreateContext:
 
     def get_template_data(
         self, folder_path: Optional[str], task_name: Optional[str]
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         """Prepare template data for given context.
 
         Method is using cached entities and settings to prepare template data.

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -29,6 +29,7 @@ from ayon_core.lib.events import QueuedEventSystem
 from ayon_core.lib.attribute_definitions import get_default_values
 from ayon_core.host import IPublishHost, IWorkfileHost
 from ayon_core.pipeline import Anatomy
+from ayon_core.pipeline.template_data import get_template_data
 from ayon_core.pipeline.plugin_discover import DiscoverResult
 
 from .exceptions import (
@@ -479,6 +480,36 @@ class CreateContext:
             self._current_project_settings = get_project_settings(
                 self.get_current_project_name())
         return self._current_project_settings
+
+    def get_template_data(
+        self, folder_path: Optional[str], task_name: Optional[str]
+    ) -> dict[str, Any]:
+        """Prepare template data for given context.
+
+        Method is using cached entities and settings to prepare template data.
+
+        Args:
+            folder_path (Optional[str]): Folder path.
+            task_name (Optional[str]): Task name.
+
+        Returns:
+            dict[str, Any]: Template data.
+
+        """
+        project_entity = self.get_current_project_entity()
+        folder_entity = task_entity = None
+        if folder_path:
+            folder_entity = self.get_folder_entity(folder_path)
+            if task_name and folder_entity:
+                task_entity = self.get_task_entity(folder_path, task_name)
+
+        return get_template_data(
+            project_entity,
+            folder_entity,
+            task_entity,
+            host_name=self.host_name,
+            settings=self.get_current_project_settings(),
+        )
 
     @property
     def context_has_changed(self):


### PR DESCRIPTION
## Changelog Description
Helper method to preare template data for passed folder path and task name.

## Additional info
It looks like it is common to prepare template data for given context which requires a lot of preparations inside create plugins, this should help to avoid that with single call.

## Testing notes:
1. The reason why this method was added makes sense.
2. The method does what should do.
