### PR TITLE
Escape & on Windows in shell using ^& in `run_subprocess`

### DIFF
--- a/client/ayon_core/lib/execute.py
+++ b/client/ayon_core/lib/execute.py
@@ -108,31 +108,29 @@ def run_subprocess(*args, **kwargs):
             | getattr(subprocess, "CREATE_NO_WINDOW", 0)
         )
 
-    # Escape parentheses for bash
+    # Escape special characters in certain shells
     if (
         kwargs.get("shell") is True
         and len(args) == 1
         and isinstance(args[0], str)
-        and os.getenv("SHELL") in ("/bin/bash", "/bin/sh")
     ):
-        new_arg = (
-            args[0]
-            .replace("(", "\\(")
-            .replace(")", "\\)")
-        )
-        args = (new_arg, )
+        # Escape parentheses for bash
+        if os.getenv("SHELL") in ("/bin/bash", "/bin/sh"):
+            new_arg = (
+                args[0]
+                .replace("(", "\\(")
+                .replace(")", "\\)")
+            )
+            args = (new_arg,)
+        # Escape & on Windows in shell with `cmd.exe` using ^&
+        elif (
+            platform.system().lower() == "windows"
+            and os.getenv("COMSPEC").endswith("cmd.exe")
+        ):
+            new_arg = args[0].replace("&", "^&")
+            args = (new_arg, )
 
-    # Escape & on Windows in shell using ^&
-    if (
-        kwargs.get("shell") is True
-        and len(args) == 1
-        and isinstance(args[0], str)
-        and platform.system().lower() == "windows"
-    ):
-        new_arg = args[0].replace("&", "^&")
-        args = (new_arg, )
-
-    # Get environents from kwarg or use current process environments if were
+    # Get environments from kwarg or use current process environments if were
     # not passed.
     env = kwargs.get("env") or os.environ
     # Make sure environment contains only strings

--- a/client/ayon_core/lib/execute.py
+++ b/client/ayon_core/lib/execute.py
@@ -122,6 +122,16 @@ def run_subprocess(*args, **kwargs):
         )
         args = (new_arg, )
 
+    # Escape & on Windows in shell using ^&
+    if (
+        kwargs.get("shell") is True
+        and len(args) == 1
+        and isinstance(args[0], str)
+        and platform.system().lower() == "windows"
+    ):
+        new_arg = args[0].replace("&", "^&")
+        args = (new_arg, )
+
     # Get environents from kwarg or use current process environments if were
     # not passed.
     env = kwargs.get("env") or os.environ


### PR DESCRIPTION
## Changelog Description

Escape & on Windows in shell using ^& in `run_subprocess`

## Additional info

Fix https://github.com/ynput/ayon-maya/issues/231

I'm not sure if in Windows you can override the default shell somehow - if so, then the escaping may need to check for that edge case if the other shell may not use `&` as a special character.

## Testing notes:

1. Follow publishing steps of https://github.com/ynput/ayon-maya/issues/231
2. Regular publishing should continue to work
