### PR TITLE
Add substance designer as being part of the hosts in extract thumbnail

### DIFF
--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -35,6 +35,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         "resolve",
         "traypublisher",
         "substancepainter",
+        "substancedesigner",
         "nuke",
         "aftereffects",
         "unreal",


### PR DESCRIPTION
## Changelog Description
Supports to extract thumbnail for substance designer
Resolve https://github.com/ynput/ayon-substance-designer/issues/8

## Additional info
n/a

## Testing notes:
1. Build and install addon
2. Launch SD and create textures
3. Publish
