### PR TITLE
Chore: Use platformdirs instead of appdirs

### DIFF
--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from abc import ABC, abstractmethod
 from functools import lru_cache
 
-import appdirs
+import platformdirs
 import ayon_api
 
 _PLACEHOLDER = object()
@@ -17,7 +17,7 @@ _PLACEHOLDER = object()
 
 def _get_ayon_appdirs(*args):
     return os.path.join(
-        appdirs.user_data_dir("AYON", "Ynput"),
+        platformdirs.user_data_dir("AYON", "Ynput"),
         *args
     )
 


### PR DESCRIPTION
## Changelog Description
Replace usage of `appdirs` with `platformdirs`.

## Additional info
Moduly `appdirs` is deprecated and `platformdirs` is it's successor.

## Testing notes:
1. Hopefully nothing really changes.
