### PR TITLE
UI: Nice checkbox uses odd sizes

### DIFF
--- a/client/ayon_core/tools/utils/nice_checkbox.py
+++ b/client/ayon_core/tools/utils/nice_checkbox.py
@@ -383,7 +383,7 @@ class NiceCheckbox(QtWidgets.QFrame):
         else:
             radius = floor(checkbox_rect.width() * 0.5)
 
-        painter.setPen(QtCore.Qt.transparent)
+        painter.setPen(QtCore.Qt.NoPen)
         painter.setBrush(bg_color)
         painter.drawRoundedRect(checkbox_rect, radius, radius)
 

--- a/client/ayon_core/tools/utils/nice_checkbox.py
+++ b/client/ayon_core/tools/utils/nice_checkbox.py
@@ -328,6 +328,9 @@ class NiceCheckbox(QtWidgets.QFrame):
         if frame_rect.width() < 0 or frame_rect.height() < 0:
             return
 
+        frame_rect.setLeft(frame_rect.x() + (frame_rect.width() % 2))
+        frame_rect.setTop(frame_rect.y() + (frame_rect.height() % 2))
+
         painter = QtGui.QPainter(self)
 
         painter.setRenderHint(QtGui.QPainter.Antialiasing)
@@ -364,11 +367,16 @@ class NiceCheckbox(QtWidgets.QFrame):
             margin_size_c = 0
 
         checkbox_rect = QtCore.QRect(
-            frame_rect.x() + margin_size_c,
-            frame_rect.y() + margin_size_c,
-            frame_rect.width() - (margin_size_c * 2),
-            frame_rect.height() - (margin_size_c * 2)
+            frame_rect.x(),
+            frame_rect.y(),
+            frame_rect.width(),
+            frame_rect.height()
         )
+        if margin_size_c:
+            checkbox_rect.adjust(
+                margin_size_c, margin_size_c,
+                -margin_size_c, -margin_size_c
+            )
 
         if checkbox_rect.width() > checkbox_rect.height():
             radius = floor(checkbox_rect.height() * 0.5)


### PR DESCRIPTION
## Changelog Description
NiceCheckbox does use odd sizes for frame to paint to avoid cropped paint.

## Additional information
It looks like it dependends where is the checkbox painted and how much space it gets, which might be based on UI scaling too. 

## Screenshots
### Before
![2025-02-11_17-14](https://github.com/user-attachments/assets/d026f5eb-4d2b-468c-b069-25a68ee38c29)

### After
![2025-02-11_17-14_1](https://github.com/user-attachments/assets/72fbce85-4ede-46b9-9df2-bb0403d74bf5)

## Testing notes:
Requires to be able to achieve the issue on machine which might be tricky. It works ok on my 100% scaling monitor and changes on 150% scaling monitor on my work laptop, but also doesn't work on different machine with 100% scaling, so hard to tell how to replicate.
1. The checkbox is not cropped.
