### PR TITLE
Publisher: Publish description and detail respects new line characters

### DIFF
--- a/client/ayon_core/tools/publisher/widgets/report_page.py
+++ b/client/ayon_core/tools/publisher/widgets/report_page.py
@@ -1693,6 +1693,9 @@ class PublishFailWidget(QtWidgets.QWidget):
             description = error_item.description or description
             detail = error_item.detail or detail
 
+        description = description.replace("\n", "<br/>")
+        detail = detail.replace("\n", "<br/>")
+
         self._error_details_widget.set_detail(detail)
 
         if commonmark:


### PR DESCRIPTION
## Changelog Description
New line characters in publish error and details are showed correctly now.

## Additional info
The issue is that we do allow HTML tags, so we use `setHtml` method, which does not respect new line characters. On the other side, multiple plugins are raising errors with new line characters that should be ignored, so this might actually break more than fix.

## Testing notes:
1. When `PublishError` raises error with `\n` it is shown in UI.

Resolves https://github.com/ynput/ayon-core/issues/1062