### PR TITLE
Attribute definitions: Multiselection EnumDef allows empty items

### DIFF
--- a/client/ayon_core/lib/attribute_definitions.py
+++ b/client/ayon_core/lib/attribute_definitions.py
@@ -562,17 +562,18 @@ class EnumDef(AbstractAttrDef):
         multiselection: Optional[bool] = False,
         **kwargs
     ):
-        if not items:
-            raise ValueError((
-                "Empty 'items' value. {} must have"
+        if multiselection is None:
+            multiselection = False
+
+        if not items and not multiselection:
+            raise ValueError(
+                f"Empty 'items' value. {self.__class__.__name__} must have"
                 " defined values on initialization."
-            ).format(self.__class__.__name__))
+            )
 
         items = self.prepare_enum_items(items)
         item_values = [item["value"] for item in items]
         item_values_set = set(item_values)
-        if multiselection is None:
-            multiselection = False
 
         if multiselection:
             if default is None:

--- a/client/ayon_core/tools/attribute_defs/widgets.py
+++ b/client/ayon_core/tools/attribute_defs/widgets.py
@@ -2,7 +2,7 @@ import copy
 import typing
 from typing import Optional
 
-from qtpy import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore, QtGui
 
 from ayon_core.lib.attribute_definitions import (
     AbstractAttrDef,
@@ -655,6 +655,9 @@ class EnumAttrWidget(_BaseAttrDefWidget):
         for item in self.attr_def.items:
             input_widget.addItem(item["label"], item["value"])
 
+        if not self.attr_def.items:
+            self._add_empty_item(input_widget)
+
         idx = input_widget.findData(self.attr_def.default)
         if idx >= 0:
             input_widget.setCurrentIndex(idx)
@@ -670,6 +673,20 @@ class EnumAttrWidget(_BaseAttrDefWidget):
 
         input_widget.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         input_widget.customContextMenuRequested.connect(self._on_context_menu)
+
+    def _add_empty_item(self, input_widget):
+        model = input_widget.model()
+        if not isinstance(model, QtGui.QStandardItemModel):
+            return
+
+        root_item = model.invisibleRootItem()
+
+        empty_item = QtGui.QStandardItem()
+        empty_item.setData("< No items to select >", QtCore.Qt.DisplayRole)
+        empty_item.setData("", QtCore.Qt.UserRole)
+        empty_item.setFlags(QtCore.Qt.NoItemFlags)
+
+        root_item.appendRow(empty_item)
 
     def _on_context_menu(self, pos):
         menu = QtWidgets.QMenu(self)

--- a/client/ayon_core/tools/publisher/widgets/precreate_widget.py
+++ b/client/ayon_core/tools/publisher/widgets/precreate_widget.py
@@ -85,6 +85,8 @@ class AttributesWidget(QtWidgets.QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setHorizontalSpacing(INPUTS_LAYOUT_HSPACING)
         layout.setVerticalSpacing(INPUTS_LAYOUT_VSPACING)
+        layout.setColumnStretch(0, 0)
+        layout.setColumnStretch(1, 1)
 
         self._layout = layout
 


### PR DESCRIPTION
## Changelog Description
EnumDef does not require to have items.

## Additional info
It is valid option to have empty items for multiselection enumerator.

## Testing notes:
1. It is possible to create EnumDef with empty items (e.g. in pre-create attributes).
2. It shows correctly in UI.

```python
EnumDef(
    "some_key",
    [],
    multiselection=True,
)
```
Resolves https://github.com/ynput/ayon-core/issues/810