### PR TITLE
Tools: Use task label if is set

### DIFF
--- a/client/ayon_core/tools/common_models/hierarchy.py
+++ b/client/ayon_core/tools/common_models/hierarchy.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
 import time
 import collections
 import contextlib
+import typing
 from abc import ABC, abstractmethod
 
 import ayon_api
 
 from ayon_core.lib import NestedCacheItem
+
+if typing.TYPE_CHECKING:
+    from typing import Union
 
 HIERARCHY_MODEL_SENDER = "hierarchy.model"
 
@@ -82,19 +88,26 @@ class TaskItem:
     Args:
         task_id (str): Task id.
         name (str): Name of task.
+        name (Union[str, None]): Task label.
         task_type (str): Type of task.
         parent_id (str): Parent folder id.
     """
 
     def __init__(
-        self, task_id, name, task_type, parent_id
+        self,
+        task_id: str,
+        name: str,
+        label: Union[str, None],
+        task_type: str,
+        parent_id: str,
     ):
         self.task_id = task_id
         self.name = name
+        self.label = label
         self.task_type = task_type
         self.parent_id = parent_id
 
-        self._label = None
+        self._full_label = None
 
     @property
     def id(self):
@@ -107,15 +120,16 @@ class TaskItem:
         return self.task_id
 
     @property
-    def label(self):
+    def full_label(self):
         """Label of task item for UI.
 
         Returns:
             str: Label of task item.
         """
 
-        if self._label is None:
-            self._label = "{} ({})".format(self.name, self.task_type)
+        if self._full_label is None:
+            label = self.label or self.name
+            self._full_label = f"{label} ({self.task_type})"
         return self._label
 
     def to_data(self):
@@ -128,6 +142,7 @@ class TaskItem:
         return {
             "task_id": self.task_id,
             "name": self.name,
+            "label": self.label,
             "parent_id": self.parent_id,
             "task_type": self.task_type,
         }
@@ -159,6 +174,7 @@ def _get_task_items_from_tasks(tasks):
         output.append(TaskItem(
             task["id"],
             task["name"],
+            task["label"],
             task["type"],
             folder_id
         ))
@@ -368,7 +384,7 @@ class HierarchyModel(object):
             sender (Union[str, None]): Who requested the task item.
 
         Returns:
-            Union[TaskItem, None]: Task item found by name and folder id.
+            Optional[TaskItem]: Task item found by name and folder id.
 
         """
         for task_item in self.get_task_items(project_name, folder_id, sender):

--- a/client/ayon_core/tools/common_models/hierarchy.py
+++ b/client/ayon_core/tools/common_models/hierarchy.py
@@ -130,7 +130,7 @@ class TaskItem:
         if self._full_label is None:
             label = self.label or self.name
             self._full_label = f"{label} ({self.task_type})"
-        return self._label
+        return self._full_label
 
     def to_data(self):
         """Converts task item to data.

--- a/client/ayon_core/tools/utils/tasks_widget.py
+++ b/client/ayon_core/tools/utils/tasks_widget.py
@@ -270,7 +270,7 @@ class TasksQtModel(QtGui.QStandardItemModel):
                 task_type_item_by_name,
                 task_type_icon_cache
             )
-            item.setData(task_item.label, QtCore.Qt.DisplayRole)
+            item.setData(task_item.full_label, QtCore.Qt.DisplayRole)
             item.setData(name, ITEM_NAME_ROLE)
             item.setData(task_item.id, ITEM_ID_ROLE)
             item.setData(task_item.task_type, TASK_TYPE_ROLE)


### PR DESCRIPTION
## Changelog Description
Use task label in UIs if is set on entity.

## Additional info
Before this PR only task name was shown in UIs and label was ignored.

## Testing notes:
1. Set label on task to something else from name.
2. Open UI showing tasks (e.g. launcher).
3. The task should show the label set on entity.

Resolves https://github.com/ynput/ayon-core/issues/1004