### PR TITLE
Loader: Add submenu to group loaders in load context menu: 

### DIFF
--- a/client/ayon_core/tools/loader/ui/actions_utils.py
+++ b/client/ayon_core/tools/loader/ui/actions_utils.py
@@ -1,6 +1,9 @@
+import os
+import itertools
 import uuid
+from typing import List
 
-from qtpy import QtWidgets, QtGui
+from qtpy import QtWidgets, QtGui, QtCore
 import qtawesome
 
 from ayon_core.lib.attribute_definitions import AbstractAttrDef
@@ -10,12 +13,20 @@ from ayon_core.tools.utils.widgets import (
     OptionalAction,
     OptionDialog,
 )
+from ayon_core.tools.loader.models.actions import ActionItem
 from ayon_core.tools.utils import get_qt_icon
 
 
-def show_actions_menu(action_items, global_point, one_item_selected, parent):
+def show_actions_menu(
+        action_items: List[ActionItem],
+        global_point: QtCore.QPoint,
+        one_item_selected: bool,
+        parent: QtCore.QObject):
     selected_action_item = None
     selected_options = None
+
+    # Can be any of `never`, `multiples`, `always`
+    grouping_mode = os.getenv("AYON_LOADER_GROUP_MODE", "always")
 
     if not action_items:
         menu = QtWidgets.QMenu(parent)
@@ -27,30 +38,56 @@ def show_actions_menu(action_items, global_point, one_item_selected, parent):
     menu = OptionalMenu(parent)
 
     action_items_by_id = {}
-    for action_item in action_items:
-        item_id = uuid.uuid4().hex
-        action_items_by_id[item_id] = action_item
-        item_options = action_item.options
-        icon = get_qt_icon(action_item.icon)
-        use_option = bool(item_options)
-        action = OptionalAction(
-            action_item.label,
-            icon,
-            use_option,
-            menu
-        )
-        if use_option:
-            # Add option box tip
-            action.set_option_tip(item_options)
+    for key, group in itertools.groupby(
+            action_items, key=lambda x: x.identifier):
+        group_action_items: List[ActionItem] = list(group)
 
-        tip = action_item.tooltip
-        if tip:
-            action.setToolTip(tip)
-            action.setStatusTip(tip)
+        target_menu = menu
 
-        action.setData(item_id)
+        is_grouped = True
+        if grouping_mode == "never":
+            # Never group
+            is_grouped = False
+        if grouping_mode == "multiples":
+            # Only group if more than one action item from a loader
+            is_grouped = len(group_action_items) > 1
+        elif grouping_mode == "always":
+            # Always
+            is_grouped = True
 
-        menu.addAction(action)
+        if is_grouped:
+            # Attach to a submenu
+            label = group_action_items[0].label.rsplit(" (", 1)[0]
+            icon = get_qt_icon(group_action_items[0].icon)
+            target_menu = menu.addMenu(icon, label)
+
+        for action_item in group_action_items:
+            item_id = uuid.uuid4().hex
+            action_items_by_id[item_id] = action_item
+            item_options = action_item.options
+            icon = get_qt_icon(action_item.icon)
+            use_option = bool(item_options)
+            label = action_item.label
+            if is_grouped:
+                label = label.rsplit(" (", 1)[-1].rstrip(") ")
+            action = OptionalAction(
+                label,
+                icon,
+                use_option,
+                target_menu
+            )
+            if use_option:
+                # Add option box tip
+                action.set_option_tip(item_options)
+
+            tip = action_item.tooltip
+            if tip:
+                action.setToolTip(tip)
+                action.setStatusTip(tip)
+
+            action.setData(item_id)
+
+            target_menu.addAction(action)
 
     action = menu.exec_(global_point)
     if action is not None:
@@ -103,7 +140,7 @@ def _get_options(action, action_item, parent):
     return dialog.get_values()
 
 
-def _get_no_loader_action(menu, one_item_selected):
+def _get_no_loader_action(menu: QtWidgets.QMenu, one_item_selected: bool):
     """Creates dummy no loader option in 'menu'"""
 
     if one_item_selected:

--- a/client/ayon_core/tools/utils/widgets.py
+++ b/client/ayon_core/tools/utils/widgets.py
@@ -830,13 +830,15 @@ class OptionalMenu(QtWidgets.QMenu):
         """Add highlight to active action"""
         active = self.actionAt(event.pos())
         for action in self.actions():
-            action.set_highlight(action is active, event.globalPos())
+            if isinstance(action, OptionalAction):
+                action.set_highlight(action is active, event.globalPos())
         super(OptionalMenu, self).mouseMoveEvent(event)
 
     def leaveEvent(self, event):
         """Remove highlight from all actions"""
         for action in self.actions():
-            action.set_highlight(False)
+            if isinstance(action, OptionalAction):
+                action.set_highlight(False)
         super(OptionalMenu, self).leaveEvent(event)
 
 


### PR DESCRIPTION
## Changelog Description

Quick and dirty prototype to test whether grouping of loader actions is better UX or not

An env var `AYON_LOADER_GROUP_MODE` can be used to switch between `never`, `multiples`, `always`. The default is now "always". If an invalid value is set for the env var not from the aforementioned list it will silently use `always`

![image](https://github.com/user-attachments/assets/305e8823-b802-4b97-8cb0-2e49b30e1e47)

## Additional info

This is merely a draft prototype so one can test whether it actually improves the UX.

There are some issues:
- [ ] Submenu actions don't seem to get highlighting on mouse over
- [ ] The context menu on the individual representations bottom right in the loader UI are also always grouped, even though there should never appear 'duplicates' in that list.
- [ ] The "label" for the menu items is currently very hackily 'patched' from the action item by splitting of the last `" ("` which definitely isn't what we should do.

This may completely be superseded by way more thorough API overhaul: https://github.com/ynput/ayon-core/issues/1058

_This is not production ready ☝️ ; it's merely intended for cosmetically testing the change_

Intends to fix https://github.com/ynput/ayon-core/issues/1132

## Testing notes:

1. Play around and feedback on it cosmetically.
