### PR TITLE
Create context: Ignore failed initialization of create plugin

### DIFF
--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -755,11 +755,19 @@ class CreateContext:
                 ).format(creator_class.host_name, self.host_name))
                 continue
 
-            creator = creator_class(
-                project_settings,
-                self,
-                self.headless
-            )
+            # TODO report initialization error
+            try:
+                creator = creator_class(
+                    project_settings,
+                    self,
+                    self.headless
+                )
+            except Exception:
+                self.log.error(
+                    f"Failed to initialize plugin: {creator_class}",
+                    exc_info=True
+                )
+                continue
 
             if not creator.enabled:
                 disabled_creators[creator_identifier] = creator


### PR DESCRIPTION
## Changelog Description
Failed initialization of create plugin does not fail whole create context.

## Additional info
This is quick fix to avoid full crash of the publisher making it unusable. Created issue for better handling https://github.com/ynput/ayon-core/issues/1160.

## Testing notes:
1. If create plugin fails on initialization it should not cause fail of whole create context (and publisher UI).
