### PR TITLE
Host tools: Validate host against correct interface for publisher tool

### DIFF
--- a/client/ayon_core/tools/utils/host_tools.py
+++ b/client/ayon_core/tools/utils/host_tools.py
@@ -7,7 +7,7 @@ import os
 
 import pyblish.api
 
-from ayon_core.host import ILoadHost
+from ayon_core.host import ILoadHost, IPublishHost
 from ayon_core.lib import Logger
 from ayon_core.pipeline import registered_host
 
@@ -236,7 +236,7 @@ class HostToolsHelper:
             from ayon_core.tools.publisher.window import PublisherWindow
 
             host = registered_host()
-            ILoadHost.validate_load_methods(host)
+            IPublishHost.validate_publish_methods(host)
 
             publisher_window = PublisherWindow(
                 controller=controller,


### PR DESCRIPTION
## Changelog Description
Publisher tool validates host agains `IPublishHost` interface instead of `ILoadHost`.

## Additional info
I guess the bug is there since beginning on Publisher tool, but all hosts that do use host tools to show publisher tool, also have implemented load interface. I found out the wrong validating with changes in traypublisher.

## Testing notes:
1. All hosts can open publisher.
