### PR TITLE
Combobox: Move Select All, Deselect All and Swap menu entries to top

### DIFF
--- a/client/ayon_core/tools/loader/ui/_multicombobox.py
+++ b/client/ayon_core/tools/loader/ui/_multicombobox.py
@@ -254,7 +254,10 @@ class BaseQtModel(QtGui.QStandardItemModel):
             row = item.row()
             if row >= 0:
                 root_item.takeRow(row)
-        root_item.appendRows(items)
+
+        # Put items on top
+        for item in reversed(items):
+            root_item.insertRow(0, item)
 
     def _remove_items(self):
         root_item = self.invisibleRootItem()


### PR DESCRIPTION
## Changelog Description

Combobox: Move Select All, Deselect All and Swap menu entries to top

## Additional info

![image](https://github.com/user-attachments/assets/30d08646-5b91-4971-bb2b-257c89d18565)

I vaguely have a feeling that this is breaking some behavior somewhere though - because if you refresh the loader UI many times... and then pop-open the dropdown menu then suddenly it force auto scrolls to the bottom of the list. Which may hint this has unintended side effects.

## Testing notes:

1. Menu entries should now appear at top.
2. Menu should still open consistently without issues
3. Refreshing the menu should still work as intended.