### PR TITLE
Allow setting the default USD Contribution enabled state per profile

### DIFF
--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -479,6 +479,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
             profile = {}
 
         # Define defaults
+        default_enabled = profile.get("contribution_enabled", True)
         default_contribution_layer = profile.get(
             "contribution_layer", None)
         default_apply_as_variant = profile.get(
@@ -513,7 +514,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                         "In both cases the USD data itself is free to have "
                         "references and sublayers of its own."
                     ),
-                    default=True),
+                    default=default_enabled),
             TextDef("contribution_target_product",
                     label="Target product",
                     tooltip=(

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -91,6 +91,15 @@ class CollectUSDLayerContributionsProfileModel(BaseSettingsModel):
             " creating from within that task type."
         ),
     )
+    contribution_enabled: bool = SettingsField(
+        True,
+        title="Contribution Enabled (default)",
+        description=(
+            "The default state for USD Contribution being marked enabled or"
+            " disabled for this profile."
+        ),
+        section="Instance attribute defaults",
+    )
     contribution_layer: str = SettingsField(
         "",
         title="Contribution Department Layer",
@@ -99,7 +108,6 @@ class CollectUSDLayerContributionsProfileModel(BaseSettingsModel):
             " matching this profile. The layer name should be in the"
             " 'Department Layer Orders' list to get a sensible order."
         ),
-        section="Instance attribute defaults",
     )
     contribution_apply_as_variant: bool = SettingsField(
         True,
@@ -1082,6 +1090,7 @@ DEFAULT_PUBLISH_VALUES = {
             {
                 "product_types": ["model"],
                 "task_types": [],
+                "contribution_enabled": True,
                 "contribution_layer": "model",
                 "contribution_apply_as_variant": True,
                 "contribution_target_product": "usdAsset"
@@ -1089,6 +1098,7 @@ DEFAULT_PUBLISH_VALUES = {
             {
                 "product_types": ["look"],
                 "task_types": [],
+                "contribution_enabled": True,
                 "contribution_layer": "look",
                 "contribution_apply_as_variant": True,
                 "contribution_target_product": "usdAsset"
@@ -1096,6 +1106,7 @@ DEFAULT_PUBLISH_VALUES = {
             {
                 "product_types": ["groom"],
                 "task_types": [],
+                "contribution_enabled": True,
                 "contribution_layer": "groom",
                 "contribution_apply_as_variant": True,
                 "contribution_target_product": "usdAsset"
@@ -1103,6 +1114,7 @@ DEFAULT_PUBLISH_VALUES = {
             {
                 "product_types": ["rig"],
                 "task_types": [],
+                "contribution_enabled": True,
                 "contribution_layer": "rig",
                 "contribution_apply_as_variant": True,
                 "contribution_target_product": "usdAsset"
@@ -1110,6 +1122,7 @@ DEFAULT_PUBLISH_VALUES = {
             {
                 "product_types": ["usd"],
                 "task_types": [],
+                "contribution_enabled": True,
                 "contribution_layer": "assembly",
                 "contribution_apply_as_variant": False,
                 "contribution_target_product": "usdShot"


### PR DESCRIPTION
## Changelog Description

Allow setting the default USD Contribution enabled state per profile in settings

## Additional info

Fix #1171 

## Testing notes:
1. Change default enabled state for an entry in settings: `ayon+settings://core/publish/CollectUSDLayerContributions/profiles`

![image](https://github.com/user-attachments/assets/9b65f19e-9141-4957-a358-b0e39955c9c2)

2. Default state in publisher UI should reflect the same:

![image](https://github.com/user-attachments/assets/cf34b391-6c41-4498-a367-713f0dd8dd15)
