### PR TITLE
Fix publish plugin discovery

### DIFF
--- a/client/ayon_core/lib/python_module_tools.py
+++ b/client/ayon_core/lib/python_module_tools.py
@@ -12,8 +12,8 @@ log = logging.getLogger(__name__)
 
 def import_filepath(
         filepath: str,
-        module_name: Optional[str]=None,
-        sys_module_name: Optional[str]=None) -> types.ModuleType:
+        module_name: Optional[str] = None,
+        sys_module_name: Optional[str] = None) -> types.ModuleType:
     """Import python file as python module.
 
     Args:

--- a/client/ayon_core/lib/python_module_tools.py
+++ b/client/ayon_core/lib/python_module_tools.py
@@ -28,6 +28,7 @@ def import_filepath(filepath, module_name=None):
     module_loader = importlib.machinery.SourceFileLoader(
         module_name, filepath
     )
+    sys.modules[module_name] = module
     module_loader.exec_module(module)
     return module
 
@@ -193,7 +194,7 @@ def is_func_signature_supported(func, *args, **kwargs):
     Notes:
         This does NOT check if the function would work with passed arguments
             only if they can be passed in. If function have *args, **kwargs
-            in paramaters, this will always return 'True'.
+            in parameters, this will always return 'True'.
 
     Example:
         >>> def my_function(my_number):

--- a/client/ayon_core/lib/python_module_tools.py
+++ b/client/ayon_core/lib/python_module_tools.py
@@ -1,6 +1,8 @@
+"""Tools for working with python modules and classes."""
 import os
 import sys
 import types
+from typing import Optional
 import importlib
 import inspect
 import logging
@@ -8,13 +10,22 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def import_filepath(filepath, module_name=None):
+def import_filepath(
+        filepath: str,
+        module_name: Optional[str]=None,
+        sys_module_name: Optional[str]=None) -> types.ModuleType:
     """Import python file as python module.
 
     Args:
         filepath (str): Path to python file.
         module_name (str): Name of loaded module. Only for Python 3. By default
             is filled with filename of filepath.
+        sys_module_name (str): Name of module in `sys.modules` where to store
+            loaded module. By default is None so module is not added to
+            `sys.modules`.
+
+    Todo (antirotor): We should add the module to the sys.modules always but
+        we need to be careful about it and test it properly.
 
     """
     if module_name is None:
@@ -28,7 +39,9 @@ def import_filepath(filepath, module_name=None):
     module_loader = importlib.machinery.SourceFileLoader(
         module_name, filepath
     )
-    sys.modules[module_name] = module
+    # only add to sys.modules if requested
+    if sys_module_name:
+        sys.modules[sys_module_name] = module
     module_loader.exec_module(module)
     return module
 
@@ -127,7 +140,8 @@ def classes_from_module(superclass, module):
     return classes
 
 
-def import_module_from_dirpath(dirpath, folder_name, dst_module_name=None):
+def import_module_from_dirpath(
+        dirpath, folder_name, dst_module_name=None):
     """Import passed directory as a python module.
 
     Imported module can be assigned as a child attribute of already loaded

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -360,7 +360,7 @@ def get_plugin_settings(plugin, project_settings, log, category=None):
     # Settings category determined from path
     # - usually path is './<category>/plugins/publish/<plugin file>'
     # - category can be host name of addon name ('maya', 'deadline', ...)
-    filepath = os.path.normpath(inspect.getfile(plugin.__class__))
+    filepath = os.path.normpath(inspect.getfile(plugin))
 
     split_path = filepath.rsplit(os.path.sep, 5)
     if len(split_path) < 4:

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -255,7 +255,8 @@ def publish_plugins_discover(
                 continue
 
             try:
-                module = import_filepath(abspath, mod_name)
+                module = import_filepath(
+                    abspath, mod_name, sys_module_name=mod_name)
 
             except Exception as err:  # noqa: BLE001
                 # we need broad exception to catch all possible errors.

--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -279,7 +279,7 @@ class PublishReportMaker:
             "name": plugin.__name__,
             "label": label,
             "order": plugin.order,
-            "filepath": inspect.getfile(plugin),
+            "filepath": inspect.getfile(plugin.__class__),
             "docstring": docstring,
             "plugin_type": plugin_type,
             "families": list(plugin.families),

--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -279,7 +279,7 @@ class PublishReportMaker:
             "name": plugin.__name__,
             "label": label,
             "order": plugin.order,
-            "filepath": inspect.getfile(plugin.__class__),
+            "filepath": inspect.getfile(plugin),
             "docstring": docstring,
             "plugin_type": plugin_type,
             "families": list(plugin.families),


### PR DESCRIPTION
## Changelog Description
When plugin is using type annotations and dataclasses, it crashed during discovery. This PR is fixing that (and possibly other type hint related issues). Closing #1199 

## Additional info
This PR can possibly affect how plugins are discovered so careful testing is needed.

## Testing notes:
Create plugin which is using dataclass and type annotations. Something like this:

```python
"""Test dataclass in publish plugin."""
from __future__ import annotations

from dataclasses import dataclass
from typing import ClassVar

import pyblish.api


@dataclass
class TestPublishData:
    """Test dataclass in publish plugin."""
    id: str
    name: str
    description: str
    version: str


class TestPublishPlugin(pyblish.api.ContextPlugin):
    """Test publish plugin."""
    label = "Test Publish Plugin"
    families: ClassVar[list[str]] = ["*"]

    def process(self, context: pyblish.api.Context) -> None:
        """Process the plugin."""
        _ = TestPublishData(
            id="test",
            name="Test",
            description="Test dataclass in publish plugin.",
            version="1.0.0"
        )
```

Make sure pyblish can see this.

Run publisher by your way of choice. Check *Crashed plugins* - it shouldn't be listed there, it should run as expected.

Also make sure other plugins are discovered as they used to be - in general, in *Crashed plugins* shouldn't be any new items except the usual suspects.

>[!WARNING]
> There are places using plain pyblish discovery function and there the problem will resurface again (farm publishing, web publisher, ...?). We need to 1) push the fix to pyblish, 2) move these things to ayon-core