### PR TITLE
Chore: Function to get addons resources directory

### DIFF
--- a/client/ayon_core/lib/__init__.py
+++ b/client/ayon_core/lib/__init__.py
@@ -9,6 +9,7 @@ from .local_settings import (
     AYONSettingsRegistry,
     get_launcher_local_dir,
     get_launcher_storage_dir,
+    get_addons_resources_dir,
     get_local_site_id,
     get_ayon_username,
 )
@@ -142,6 +143,7 @@ __all__ = [
     "AYONSettingsRegistry",
     "get_launcher_local_dir",
     "get_launcher_storage_dir",
+    "get_addons_resources_dir",
     "get_local_site_id",
     "get_ayon_username",
 

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -96,6 +96,30 @@ def get_launcher_local_dir(*subdirs: str) -> str:
     return os.path.join(storage_dir, *subdirs)
 
 
+def get_addons_resources_dir(addon_name: str, *args) -> str:
+    """Get directory for storing resources for addons.
+
+    Some addons might need to store ad-hoc resources that are not part of
+        addon client package (e.g. because of size). Studio might define
+        dedicated directory to store them with 'AYON_ADDONS_RESOURCES_DIR'
+        environment variable. By default, is used 'addons_resources' in
+        launcher storage (might be shared across platforms).
+
+    Args:
+        addon_name (str): Addon name.
+        *args (str): Subfolders in resources directory.
+
+    Returns:
+        str: Path to resources directory.
+
+    """
+    addons_resources_dir = os.getenv("AYON_ADDONS_RESOURCES_DIR")
+    if not addons_resources_dir:
+        addons_resources_dir = get_launcher_storage_dir("addons_resources")
+
+    return os.path.join(addons_resources_dir, addon_name, *args)
+
+
 class AYONSecureRegistry:
     """Store information using keyring.
 


### PR DESCRIPTION
## Changelog Description
Added new dedicated function `get_addons_resources_dir` where addons resources should be stored, if addon has any.

## Additional info
Addons resources might be ad-hoc files, the best example would be ffmpeg or oiio from 3rd part addon.

## Testing notes:
1. Validate the function name, logic and docstring.
