### PR TITLE
Burnin size can auto adjust by image height

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -692,6 +692,21 @@ class ExtractBurninOptionsModel(BaseSettingsModel):
         default_factory=MultiplatformPathModel,
         title="Font file path"
     )
+    relative_size: bool = SettingsField(
+        False,
+        title="Size relative to height",
+        description=(
+            "Enable recalculating Font size,"
+            " offset and padding relative to image height"
+        )
+    )
+    unit_height: int = SettingsField(
+        1080,
+        title="Relative Height",
+        description=(
+            "Unit height for relative size."
+        )
+    )
 
 
 class ExtractBurninDefFilter(BaseSettingsModel):
@@ -1311,6 +1326,8 @@ DEFAULT_PUBLISH_VALUES = {
             "x_offset": 5,
             "y_offset": 5,
             "bg_padding": 5,
+            "relative_size":  False,
+            "unit_height":  1080,
             "font_filepath": {
                 "windows": "",
                 "darwin": "",


### PR DESCRIPTION
## Changelog Description
This PR adds setting for Extract Burnin that allows auto adjusting the burnin size relative to image size height.

When creating full res and scaled down reviewables, it is hard to pick good burnin size. For example, good burnin size for UHD is unpleasantly big for 1080p.

## Testing notes:
1. Configure two extract review outputs with different output heights
2. Enable Size relative to height option in Extract Burnin settings
3. Check if Extracted reviewables burnin size matches (resize reviewables to the same size: fit height)
