### PR TITLE
Colorspace now allows empty file representation list

### DIFF
--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -1275,7 +1275,12 @@ def set_colorspace_data_to_representation(
     project_settings = context_data["project_settings"]
 
     # get one filename
-    filename = representation["files"][0] if representation["files"] else None
+    filename = representation["files"]
+    if isinstance(filename, list):
+        if filename:
+            filename = filename[0]
+        else:
+            filename = None
 
     # get matching colorspace from rules
     if colorspace is None:

--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -1275,9 +1275,7 @@ def set_colorspace_data_to_representation(
     project_settings = context_data["project_settings"]
 
     # get one filename
-    filename = representation["files"]
-    if isinstance(filename, list):
-        filename = filename[0]
+    filename = representation["files"][0] if representation["files"] else None
 
     # get matching colorspace from rules
     if colorspace is None:


### PR DESCRIPTION
## Changelog Description
Colorspace.py now check for empty file representation list.

## Testing notes:
1. In Nuke, make sure render work folder (staging dir) has no rendered frames
2. Try to publish on farm with existing frames
3. Publisher should stop on rendered frames validatior, not on colorspace error

Can fix [#97](https://github.com/ynput/ayon-nuke/issues/97)
Might also fix [#66](https://github.com/ynput/ayon-nuke/issues/66) 