### PR TITLE
Utils widgets: Ceil height of 'ExpandingTextEdit'

### DIFF
--- a/client/ayon_core/tools/utils/widgets.py
+++ b/client/ayon_core/tools/utils/widgets.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from typing import Optional, List, Set, Any
 
 from qtpy import QtWidgets, QtCore, QtGui
@@ -413,8 +414,8 @@ class ExpandingTextEdit(QtWidgets.QTextEdit):
         return margins.top() + document.size().height() + margins.bottom()
 
     def sizeHint(self):
-        width = super(ExpandingTextEdit, self).sizeHint().width()
-        return QtCore.QSize(width, self.heightForWidth(width))
+        width = super().sizeHint().width()
+        return QtCore.QSize(width, math.ceil(self.heightForWidth(width)))
 
 
 class BaseClickableFrame(QtWidgets.QFrame):

--- a/client/ayon_core/tools/utils/widgets.py
+++ b/client/ayon_core/tools/utils/widgets.py
@@ -411,11 +411,13 @@ class ExpandingTextEdit(QtWidgets.QTextEdit):
         document = self.document().clone()
         document.setTextWidth(document_width)
 
-        return margins.top() + document.size().height() + margins.bottom()
+        return math.ceil(
+            margins.top() + document.size().height() + margins.bottom()
+        )
 
     def sizeHint(self):
         width = super().sizeHint().width()
-        return QtCore.QSize(width, math.ceil(self.heightForWidth(width)))
+        return QtCore.QSize(width, self.heightForWidth(width))
 
 
 class BaseClickableFrame(QtWidgets.QFrame):


### PR DESCRIPTION
## Changelog Description
Ceil height of `ExpandingTextEdit` as it returns float that might be e.g. `0.1` which might cause issues in `QSize`.

## Additional info
Type `float` is "invalid" type for `QSize` in some PySide releases, and I think it might fix issue with fast changes of the height in publisher report.

## Testing notes:
There is not much to test.