### PR TITLE
Launcher: Make project filter field case insensitive

### DIFF
--- a/client/ayon_core/tools/utils/projects_widget.py
+++ b/client/ayon_core/tools/utils/projects_widget.py
@@ -286,6 +286,7 @@ class ProjectSortFilterProxy(QtCore.QSortFilterProxyModel):
         self._sort_by_type = True
         # Disable case sensitivity
         self.setSortCaseSensitivity(QtCore.Qt.CaseInsensitive)
+        self.setFilterCaseSensitivity(QtCore.Qt.CaseInsensitive)
 
     def _type_sort(self, l_index, r_index):
         if not self._sort_by_type:


### PR DESCRIPTION
## Changelog Description

Launcher: Make project filter field case insensitive

## Additional info

![image](https://github.com/user-attachments/assets/1e92a93e-7e57-406d-9ff7-0ce747cba217)

## Testing notes:

1. Make filter text field for projects case insensitive
