### PR TITLE
Create context: Set publish attributes values

### DIFF
--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -2303,10 +2303,16 @@ class CreateContext:
                 for plugin_name, plugin_value in item_changes.pop(
                     "publish_attributes"
                 ).items():
+                    if plugin_value is None:
+                        current_publish[plugin_name] = None
+                        continue
                     plugin_changes = current_publish.setdefault(
                         plugin_name, {}
                     )
-                    plugin_changes.update(plugin_value)
+                    if plugin_changes is None:
+                        current_publish[plugin_name] = plugin_value
+                    else:
+                        plugin_changes.update(plugin_value)
 
             item_values.update(item_changes)
 

--- a/client/ayon_core/pipeline/create/structures.py
+++ b/client/ayon_core/pipeline/create/structures.py
@@ -304,6 +304,9 @@ class PublishAttributes:
         else:
             self._data[key] = value
 
+    def __delitem__(self, key):
+        self.pop(key)
+
     def __contains__(self, key):
         return key in self._data
 

--- a/client/ayon_core/pipeline/create/structures.py
+++ b/client/ayon_core/pipeline/create/structures.py
@@ -160,27 +160,14 @@ class AttributeValues:
         return self._attr_defs_by_key.get(key, default)
 
     def update(self, value):
-        changes = {}
-        for _key, _value in dict(value).items():
-            if _key in self._data and self._data.get(_key) == _value:
-                continue
-            self._data[_key] = _value
-            changes[_key] = _value
-
+        changes = self._update(value)
         if changes:
             self._parent.attribute_value_changed(self._key, changes)
 
     def pop(self, key, default=None):
-        has_key = key in self._data
-        value = self._data.pop(key, default)
-        # Remove attribute definition if is 'UnknownDef'
-        # - gives option to get rid of unknown values
-        attr_def = self._attr_defs_by_key.get(key)
-        if isinstance(attr_def, UnknownDef):
-            self._attr_defs_by_key.pop(key)
-            self._attr_defs.remove(attr_def)
-        elif has_key:
-            self._parent.attribute_value_changed(self._key, {key: None})
+        value, changes = self._pop(key, default)
+        if changes:
+            self._parent.attribute_value_changed(self._key, changes)
         return value
 
     def reset_values(self):
@@ -227,6 +214,29 @@ class AttributeValues:
         """
 
         return serialize_attr_defs(self._attr_defs)
+
+    def _update(self, value):
+        changes = {}
+        for key, value in dict(value).items():
+            if key in self._data and self._data.get(key) == value:
+                continue
+            self._data[key] = value
+            changes[key] = value
+        return changes
+
+    def _pop(self, key, default):
+        has_key = key in self._data
+        value = self._data.pop(key, default)
+        # Remove attribute definition if is 'UnknownDef'
+        # - gives option to get rid of unknown values
+        attr_def = self._attr_defs_by_key.get(key)
+        changes = {}
+        if isinstance(attr_def, UnknownDef):
+            self._attr_defs_by_key.pop(key)
+            self._attr_defs.remove(attr_def)
+        elif has_key:
+            changes[key] = None
+        return value, changes
 
 
 class CreatorAttributeValues(AttributeValues):

--- a/client/ayon_core/pipeline/create/structures.py
+++ b/client/ayon_core/pipeline/create/structures.py
@@ -290,6 +290,20 @@ class PublishAttributes:
     def __getitem__(self, key):
         return self._data[key]
 
+    def __setitem__(self, key, value):
+        """Set value for plugin.
+
+        Args:
+            key (str): Plugin name.
+            value (dict[str, Any]): Value to set.
+
+        """
+        current_value = self._data.get(key)
+        if isinstance(current_value, PublishAttributeValues):
+            current_value.set_value(value)
+        else:
+            self._data[key] = value
+
     def __contains__(self, key):
         return key in self._data
 

--- a/client/ayon_core/pipeline/create/structures.py
+++ b/client/ayon_core/pipeline/create/structures.py
@@ -170,6 +170,16 @@ class AttributeValues:
             self._parent.attribute_value_changed(self._key, changes)
         return value
 
+    def set_value(self, value):
+        pop_keys = set(value.keys()) - set(self._data.keys())
+        changes = self._update(value)
+        for key in pop_keys:
+            _, key_changes = self._pop(key, None)
+            changes.update(key_changes)
+
+        if changes:
+            self._parent.attribute_value_changed(self._key, changes)
+
     def reset_values(self):
         self._data = {}
 


### PR DESCRIPTION
## Changelog Description
It is possible to set publish plugin value if does not have attribute definitions defined yet.

## Additional info
The use-case is conversion of attribute values from old plugin name to new plugin name.

## Testing notes:
1. It is possible to set values for plugin which does not have set attribute definitions yet.

Source issue came up here: https://github.com/ynput/ayon-houdini/pull/245#discussion_r2024208074