### PR TITLE
Fix: add python 3.7 support to loader tool again

### DIFF
--- a/client/ayon_core/tools/loader/ui/product_types_combo.py
+++ b/client/ayon_core/tools/loader/ui/product_types_combo.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from qtpy import QtGui, QtCore
 
 from ._multicombobox import (


### PR DESCRIPTION
## Changelog Description
Reinstate support for python 3.7 in loader tool. Type annotation is using features unsupported in 3.7 so we need to add compatibility import.

## Testing notes:
Loader tool should open fine in python 3.7 based hosts
