### PR TITLE
Enhancing publisher card widget with folder and task name

### DIFF
--- a/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
@@ -211,7 +211,7 @@ class ContextCardWidget(CardWidget):
         icon_widget = PublishPixmapLabel(None, self)
         icon_widget.setObjectName("ProductTypeIconLabel")
 
-        label_widget = QtWidgets.QLabel(CONTEXT_LABEL, self)
+        label_widget = QtWidgets.QLabel(f"<span>{CONTEXT_LABEL}</span>", self)
 
         icon_layout = QtWidgets.QHBoxLayout()
         icon_layout.setContentsMargins(5, 5, 5, 5)


### PR DESCRIPTION
## Changelog Description
This PR adds a sub-label to the publisher card widget, containing the folder and the task name.
This is a very minimal implementation.

The image below shows the end result. The first card has the folder and the task name and the second one is an example for when a task is missing:

![image](https://github.com/user-attachments/assets/25d15867-12a0-49e6-87fe-027a9667df0f)


## Additional info
Having many cards with similar names can be very confusing, this PR facilitates more information in the widget to minimize this problem.

