### PR TITLE
Loader: Fix type hints support for older python versions

### DIFF
--- a/client/ayon_core/tools/loader/ui/product_types_combo.py
+++ b/client/ayon_core/tools/loader/ui/product_types_combo.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from qtpy import QtGui, QtCore
 
 from ._multicombobox import (


### PR DESCRIPTION
## Changelog Description
Fix support for older Python versions.

## Additional info

Avoids error:
```python
"C:\Users\User\AppData\Local\Ynput\AYON\addons\core_1.1.6\ayon_core\tools\loader\ui\product_types_combo.py", line 48, in ProductTypesQtModel
    def _get_standard_items(self) -> list[QtGui.QStandardItem]:
TypeError: 'type' object is not subscriptable
```

See reported privately [here.
](https://discord.com/channels/517362899170230292/1357555142928634108/1357787375136411878)

## Testing notes:

1. Loader should work in Nuke 13.2