### PR TITLE
Update ruff action and take the ruff version from pyproject

### DIFF
--- a/.github/workflows/pr_linting.yml
+++ b/.github/workflows/pr_linting.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
         with:
           changed-files: "true"
+          version-file: "pyproject.toml"


### PR DESCRIPTION
## Changelog Description
Update ruff CI action on GitHub and  make it use ruff version defined in the pyproject.toml file to match what is used for linting on the client side.

## Testing notes:
Linting on GH should still work, it should use the same version as defined in pyproject.toml (hard to test because the version isn't printed anywhere.
