### PR TITLE
Fixes issue with original directory lookup

### DIFF
--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -2,7 +2,6 @@ import os
 import logging
 import sys
 import copy
-from pprint import pformat
 
 import clique
 import pyblish.api

--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -2,6 +2,7 @@ import os
 import logging
 import sys
 import copy
+from pprint import pformat
 
 import clique
 import pyblish.api
@@ -612,6 +613,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
 
         is_udim = bool(repre.get("udim"))
 
+        self.log.debug(pformat(instance.data))
         # handle publish in place
         if "{originalDirname}" in template:
             # store as originalDirname only original value without project root
@@ -619,8 +621,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             # used for all represe
             # from temp to final
             original_directory = (
-                instance.data.get("originalDirname") or instance_stagingdir)
-
+                instance.data.get("originalDirname") or stagingdir)
             _rootless = self.get_rootless_path(anatomy, original_directory)
             if _rootless == original_directory:
                 raise KnownPublishError((

--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -613,7 +613,6 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
 
         is_udim = bool(repre.get("udim"))
 
-        self.log.debug(pformat(instance.data))
         # handle publish in place
         if "{originalDirname}" in template:
             # store as originalDirname only original value without project root


### PR DESCRIPTION
## Changelog Description
Fixes a bug where the instance staging directory was being incorrectly used
when looking up the original directory for publish in place workflows,
instead of the staging directory from representation.

Adds debug logging to inspect instance data during integration.

## Testing notes:
1. create publish category anatomy template (bellow is the item data)
2. go to `ayon+settings://core/tools/publish/template_name_profiles` and create profile pointing at the anatomy publish preset. Set it to any of product you prefer to be published.
3. Add testing data to your testing project root (at least at your desired project root folder)
4. publish from your dcc or traypublisher with the matching product and host filtering at the template preset.
5. See that your data were ingested without copying into a context publish folder. 

```{
  "name": "plates_in_place",
  "directory": "{originalDirname}",
  "file": "{originalBasename}<.{@frame}>.{ext}"
}
```