### PR TITLE
Fixes thumbnail creation logic

### DIFF
--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -163,9 +163,9 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         # Store new staging to cleanup paths
         instance.context.data["cleanupFullPaths"].append(dst_staging)
 
-        thumbnail_created = False
         oiio_supported = is_oiio_supported()
         for repre in filtered_repres:
+            thumbnail_created = False
             repre_files = repre["files"]
             src_staging = os.path.normpath(repre["stagingDir"])
             if not isinstance(repre_files, (list, tuple)):


### PR DESCRIPTION
## Changelog Description
Make sure multiple reviewable representations which are requiring own thumbnail are supported by integrator.

## Additional info
Moves the `thumbnail_created` flag initialization inside the loop.

This ensures that the flag is reset for each representation, preventing it from being incorrectly skipped if a previous representation failed to create a thumbnail.

## Testing notes:
1. Use nuke ideally for the case.
2. create multiple reviewable intermendiate presets here `ayon+settings://nuke/publish/ExtractReviewIntermediates/outputs`
3. this should not be blocked be integrate publishing plugin crash.
