### PR TITLE
add optional `aov` key to render template profile name

### DIFF
--- a/server/settings/tools.py
+++ b/server/settings/tools.py
@@ -414,7 +414,7 @@ DEFAULT_TOOLS_VALUES = {
                 "hosts": [],
                 "task_types": [],
                 "tasks": [],
-                "template": "{product[type]}{Task[name]}{Variant}"
+                "template": "{product[type]}{Task[name]}{Variant}<_{Aov}>"
             },
             {
                 "product_types": [


### PR DESCRIPTION
## Changelog Description
resolve #1245 

## Testing notes:
1. keep default settings value
2. setup scene with AOV
3. render product names should be unique.