### PR TITLE
Extract Thumbnail: Fix original intnetion of thumbnail created logging

### DIFF
--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -164,7 +164,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         instance.context.data["cleanupFullPaths"].append(dst_staging)
 
         oiio_supported = is_oiio_supported()
-        repre_thumb_created = False
+        thumbnail_created = False
         for repre in filtered_repres:
             # Reset for each iteration to handle cases where multiple
             # reviewable thumbnails are needed
@@ -241,6 +241,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
             if not repre_thumb_created:
                 continue
 
+            thumbnail_created = True
             if len(explicit_repres) > 1:
                 repre_name = "thumbnail_{}".format(repre["outputName"])
             else:
@@ -294,7 +295,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
                 # There is no need to create more then one thumbnail
                 break
 
-        if not repre_thumb_created:
+        if not thumbnail_created:
             self.log.warning("Thumbnail has not been created.")
 
     def _is_review_instance(self, instance):


### PR DESCRIPTION
## Changelog Description
Use out of loop variable to store information if thumbnail was created to log correctly if thumbnail was created.

## Additional info
This change was requested in https://github.com/ynput/ayon-core/pull/1242 but misunderstood.

## Testing notes:
1. The log "Thumbnail has not been created." is not logged if at least one thumbnail was created.
