### PR TITLE
Try extract thumbnail from available representations on instance

### DIFF
--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -372,15 +372,10 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         Returns:
             bool: whether the representation has the valid image content
         """
-        files = repre.get("files")
-        if not files:
-            return False
-
         # Get first file's extension
-        if isinstance(files, (list, tuple)):
-            first_file = files[0]
-        else:
-            first_file = files
+        first_file = repre["files"]
+        if isinstance(first_file, (list, tuple)):
+            first_file = first_file[0]
 
         ext = os.path.splitext(first_file)[1].lower()
 

--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -17,7 +17,7 @@ from ayon_core.lib import (
 )
 from ayon_core.lib.transcoding import convert_colorspace
 
-from ayon_core.lib.transcoding import VIDEO_EXTENSIONS
+from ayon_core.lib.transcoding import VIDEO_EXTENSIONS, IMAGE_EXTENSIONS
 
 
 class ExtractThumbnail(pyblish.api.InstancePlugin):
@@ -349,7 +349,8 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
                 continue
 
             if "review" not in tags:
-                continue
+                if not self._is_valid_media_repre(repre):
+                    continue
 
             if not repre.get("files"):
                 self.log.debug((
@@ -359,6 +360,21 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
 
             filtered_repres.append(repre)
         return filtered_repres
+
+    def _is_valid_media_repre(self, repre):
+        """Check if representation contains valid media files"""
+        files = repre.get("files")
+        if not files:
+            return False
+
+        # Get first file's extension
+        if isinstance(files, (list, tuple)):
+            first_file = files[0]
+        else:
+            first_file = files
+
+        ext = os.path.splitext(first_file)[1].lower()
+        return ext in IMAGE_EXTENSIONS
 
     def _create_thumbnail_oiio(
         self,

--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -365,6 +365,9 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         """Check if representation contains valid media files"""
         files = repre.get("files")
         if not files:
+            self.log.debug((
+                "Representation \"{}\" doesn't have files. Skipping"
+            ).format(repre["name"]))
             return False
 
         # Get first file's extension

--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -356,12 +356,9 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
                 continue
 
             has_review_tag = "review" in tags
-            if not has_review_tag and not self._is_valid_images_repre(repre):
-                continue
-
             if has_review_tag:
                 review_repres.append(repre)
-            else:
+            elif self._is_valid_images_repre(repre):
                 other_repres.append(repre)
 
         return review_repres + other_repres

--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -355,8 +355,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
                 ).format(repre["name"]))
                 continue
 
-            has_review_tag = "review" in tags
-            if has_review_tag:
+            if "review" in tags:
                 review_repres.append(repre)
             elif self._is_valid_images_repre(repre):
                 other_repres.append(repre)

--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -349,7 +349,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
                 continue
 
             if "review" not in tags:
-                if not self._is_valid_media_repre(repre):
+                if not self._is_valid_images_repre(repre):
                     continue
 
             if not repre.get("files"):
@@ -361,8 +361,8 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
             filtered_repres.append(repre)
         return filtered_repres
 
-    def _is_valid_media_repre(self, repre):
-        """Check if representation contains valid media files"""
+    def _is_valid_images_repre(self, repre):
+        """Check if representation contains valid image files"""
         files = repre.get("files")
         if not files:
             self.log.debug((

--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -362,7 +362,14 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         return filtered_repres
 
     def _is_valid_images_repre(self, repre):
-        """Check if representation contains valid image files"""
+        """Check if representation contains valid image files
+
+        Args:
+            repre (dict): representation
+
+        Returns:
+            bool: whether the representation has the valid image content
+        """
         files = repre.get("files")
         if not files:
             self.log.debug((


### PR DESCRIPTION
## Changelog Description
This PR is to make sure thumbnail would be exported when there is valid representation with image content files.
Resolve https://github.com/ynput/ayon-fusion/issues/16

## Additional info
Representations with `"review"` tag has privilege to be used before any other representation.

## Testing notes:
Test along with https://github.com/ynput/ayon-fusion/pull/43
1. Build this addon with the relevant fusion addon
2. Launch Fusion
3. Publish