### PR TITLE
Launcher tool: Check for all project filters

### DIFF
--- a/client/ayon_core/tools/utils/projects_widget.py
+++ b/client/ayon_core/tools/utils/projects_widget.py
@@ -351,13 +351,14 @@ class ProjectSortFilterProxy(QtCore.QSortFilterProxyModel):
             return True
 
         string_pattern = self.filterRegularExpression().pattern()
-        if string_pattern:
-            return string_pattern.lower() in project_name.lower()
+        if (
+            string_pattern
+            and string_pattern.lower() not in project_name.lower()
+        ):
+            return False
 
         # Current project keep always visible
-        default = super(ProjectSortFilterProxy, self).filterAcceptsRow(
-            source_row, source_parent
-        )
+        default = super().filterAcceptsRow(source_row, source_parent)
         if not default:
             return default
 

--- a/client/ayon_core/tools/utils/projects_widget.py
+++ b/client/ayon_core/tools/utils/projects_widget.py
@@ -350,21 +350,20 @@ class ProjectSortFilterProxy(QtCore.QSortFilterProxyModel):
         if project_name is None:
             return True
 
+        # Make sure current project is visible
+        if index.data(PROJECT_IS_CURRENT_ROLE):
+            return True
+
+        default = super().filterAcceptsRow(source_row, source_parent)
+        if not default:
+            return default
+
         string_pattern = self.filterRegularExpression().pattern()
         if (
             string_pattern
             and string_pattern.lower() not in project_name.lower()
         ):
             return False
-
-        # Current project keep always visible
-        default = super().filterAcceptsRow(source_row, source_parent)
-        if not default:
-            return default
-
-        # Make sure current project is visible
-        if index.data(PROJECT_IS_CURRENT_ROLE):
-            return True
 
         if (
             self._filter_inactive


### PR DESCRIPTION
## Changelog Description
Don't skip other validations when string regex is filled.

## Additional info
When string match is filled the other filters were skipped, which could reveal archived projects.

## Testing notes:
The best testing is using archived projects and using AYON launcher 1.1.1 -> That version of AYON launcher does not filter archived projects.
1. Make sure you have at least one archived project.
2. Open launcher tool.
3. Fill part of project name in text filter.
4. You should not see the archived project.
