### PR TITLE
Set running from console even for triggering from code

### DIFF
--- a/client/ayon_core/lib/ayon_info.py
+++ b/client/ayon_core/lib/ayon_info.py
@@ -77,7 +77,7 @@ def is_using_ayon_console():
     executable_filename = os.path.basename(executable_path)
     return (
         "ayon_console" in executable_filename
-        or "python.exe" in executable_filename
+        or "python" in executable_filename
     )
 
 

--- a/client/ayon_core/lib/ayon_info.py
+++ b/client/ayon_core/lib/ayon_info.py
@@ -75,7 +75,10 @@ def is_using_ayon_console():
         return True
     executable_path = os.environ["AYON_EXECUTABLE"]
     executable_filename = os.path.basename(executable_path)
-    return "ayon_console" in executable_filename
+    return (
+        "ayon_console" in executable_filename
+        or "python.exe" in executable_filename
+    )
 
 
 def is_headless_mode_enabled():


### PR DESCRIPTION
## Changelog Description
`is_using_ayon_console` is used to denote if AYON is running with support of console. Adobe products are using this check to produce console. This update resolves it to true even if AYON is started directly from code, eg. from IDE (via `python.exe`).


## Additional info
I personally run AYON from IDE the most and I always need to tweak this to show console in Adobe products. Its nothing major, just PITA. I always felt that it would make a sense that running from code would mean "is_using_ayon_console".
If this update would make sense, it would be much easier for me. 

