### PR TITLE
CI Update Bug Report: Change trigger event

### DIFF
--- a/.github/workflows/update_bug_report.yml
+++ b/.github/workflows/update_bug_report.yml
@@ -1,10 +1,11 @@
 name: 🐞 Update Bug Report
 
 on:
+  workflow_run:
+    workflows: ["🚀 Release Trigger"]
+    types:
+      - completed
   workflow_dispatch:
-  release:
-    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
-    types: [published]
 
 jobs:
   update-bug-report:


### PR DESCRIPTION
## Changelog Description
Trigger `Update Bug Report` CI action on `🚀 Release Trigger` action instead of on release.

## Additional info
The action does change `develop` branch which also happens during Relase trigger action which makes new release in the middle. That cause cross push to `develop` branch.

## Testing notes:
Look at the code changes.
