### PR TITLE
Filter launcher paths from `PATH` passed to host

### DIFF
--- a/client/ayon_core/hooks/pre_remove_launcher_paths.py
+++ b/client/ayon_core/hooks/pre_remove_launcher_paths.py
@@ -1,0 +1,36 @@
+""""Pre launch hook to remove launcher paths from the system."""
+import os
+from ayon_applications import PreLaunchHook, LaunchTypes
+
+
+class PreRemoveLauncherPaths(PreLaunchHook):
+    """Remove launcher paths from the system.
+
+    This hook is used to remove launcher paths from the system before launching
+    an application. It is used to ensure that the application is launched with
+    the correct environment variables. Especially for Windows, where
+    paths in `PATH` are used to load DLLs. This is important to avoid
+    conflicts with other applications that may have the same DLLs in their
+    paths.
+    """
+
+    order = 1
+
+    platforms = {"linux", "windows", "darwin"}
+    launch_types = {LaunchTypes.local}
+
+    def execute(self):
+        # Remove launcher paths from the system
+        paths = []
+        try:
+            ayon_root = self.launch_context.env["AYON_ROOT"]
+        except KeyError:
+            self.log.warning("AYON_ROOT not found in environment variables.")
+            return
+
+        paths.extend(
+            path
+            for path in self.launch_context.env.get("PATH", "").split(os.pathsep)
+            if not path.startswith(ayon_root)
+        )
+        self.launch_context.env["PATH"] = os.pathsep.join(paths)


### PR DESCRIPTION
## Changelog Description
Filter `PATH` environment variable so paths pointing to launcher are not passed to the launched hosts by default. Fixing mov writer issue in Nuke 16.

## Additional info
Passing those paths with PySide6 libraries (and others) can cause serious issues especially on Windows where DLL resolution is using `PATH` so wrong libraries can be pulled into runtime.

## Testing notes:
Run any DCC with suitable Python console and run:

```python
import os

for p in os.getenv("PATH").split(os.pathsep):
    print(p)
```
should print paths and there shouldn't be any pointing to location of your launcher. Your launcher path can be determined by `AYON_ROOT` environment variable so technically:

```python
import os

for p in os.getenv("PATH").split(os.pathsep):
    if p.startswith(os.getenv("AYON_ROOT")):
		print("All work and no play makes Jack a dull boy")
```

shouldn't print anything.

**OR**

run Nuke 16 via AYON, create Write node and set format to `mov` - it shouldn't crash