### PR TITLE
Chore: Reverse product name key replacements

### DIFF
--- a/client/ayon_core/pipeline/create/product_name.py
+++ b/client/ayon_core/pipeline/create/product_name.py
@@ -52,15 +52,15 @@ def get_product_name_template(
         # TODO remove formatting keys replacement
         template = (
             matching_profile["template"]
-            .replace("{task[name]}", "{task}")
-            .replace("{Task[name]}", "{Task}")
-            .replace("{TASK[NAME]}", "{TASK}")
-            .replace("{product[type]}", "{family}")
-            .replace("{Product[type]}", "{Family}")
-            .replace("{PRODUCT[TYPE]}", "{FAMILY}")
-            .replace("{folder[name]}", "{asset}")
-            .replace("{Folder[name]}", "{Asset}")
-            .replace("{FOLDER[NAME]}", "{ASSET}")
+            .replace("{task}", "{task[name]}")
+            .replace("{Task}", "{Task[name]}")
+            .replace("{TASK}", "{TASK[NAME]}")
+            .replace("{family}", "{product[type]}")
+            .replace("{Family}", "{Product[type]}")
+            .replace("{FAMILY}", "{PRODUCT[TYPE]}")
+            .replace("{asset}", "{folder[name]}")
+            .replace("{Asset}", "{Folder[name]}")
+            .replace("{ASSET}", "{FOLDER[NAME]}")
         )
 
     # Make sure template is set (matching may have empty string)


### PR DESCRIPTION
## Changelog Description
Reverse keys conversion in product name template to use AYON keys first instead of OP.

## Additional info
We did replace AYON keys to OpenPype keys (probably since OpenPype > AYON conversion) which should have been replaced the other way around for a long time.

## Testing notes:
Product names should be filled correctly when `{task[name]}`, `{task[type]}`, `{task[short]}` or `{task}` are used in the templates.
1. Choose a host of your choice (I would recommend traypublisher).
2. Fill a product name template in `ayon+settings://core/tools/creator/product_name_profiles` to use one of the keys.
3. Try to create instance in the host.
4. Change to use different key, or combination of keys.
5. Again try to create instance in the host.

Resolves https://github.com/ynput/ayon-core/issues/1264