### PR TITLE
Fixes ffmpeg seek argument

### DIFF
--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -525,7 +525,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         # Build command args
         cmd_args = []
         if seek_position > 0.0:
-            cmd_args.extend(["--ss", str(seek_position)])
+            cmd_args.extend(["-ss", str(seek_position)])
 
         # Add generic ffmpeg commands
         cmd_args.extend([
@@ -536,9 +536,6 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
             "-frames:v", "1",
             output_thumb_file_path
         ])
-
-        # add output file path
-        cmd_args.append(output_thumb_file_path)
 
         # create ffmpeg command
         cmd = get_ffmpeg_tool_args(


### PR DESCRIPTION
## Changelog Description
Corrects the ffmpeg command-line argument for specifying the seek position. It changes from '--ss' to '-ss', which is the correct flag.

## Additional info
continuation of previous pr #1250

## Testing notes:
1. test it the same way as in #1250
