### PR TITLE
Fixes: Uses correct fallback data key

### DIFF
--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -834,7 +834,7 @@ def _get_global_config_data(
 
     if not product_entities_by_name:
         # in case no product was found we need to use fallback
-        fallback_type = fallback_data["type"]
+        fallback_type = fallback_data["fallback_type"]
         return _get_config_path_from_profile_data(
             fallback_data, fallback_type, template_data
         )


### PR DESCRIPTION
## Changelog Description
The code now uses the correct key ("fallback_type") to access the
fallback type from the configuration data, ensuring the correct config
path is retrieved when no product is found.

## Additional info
Practically settings were not having "type" key, because that one was later renamed to `fallback_type`. This was some residual code.


## Testing notes:
1. only way to test this is with fallback config type
