### PR TITLE
Fixes frame string formatting for transcoding

### DIFF
--- a/client/ayon_core/plugins/publish/extract_color_transcode.py
+++ b/client/ayon_core/plugins/publish/extract_color_transcode.py
@@ -283,7 +283,11 @@ class ExtractOIIOTranscode(publish.Extractor):
             if collection.holes().indexes:
                 return files_to_convert
 
-            frame_str = "{}-{}#".format(frames[0], frames[-1])
+            # Get the padding from the collection
+            # This is the number of digits used in the frame numbers
+            padding = collection.padding
+
+            frame_str = "{}-{}%0{}d".format(frames[0], frames[-1], padding)
             file_name = "{}{}{}".format(collection.head, frame_str,
                                         collection.tail)
 


### PR DESCRIPTION
## Changelog Description
Ensures the frame string used for transcoding includes the correct padding,
based on the collection's padding attribute. This resolves issues where
the output file sequence name was not correctly formatted, leading to
transcoding failures.

## Additional info
I had found out about the issue during batchdelivery tests

## Testing notes:
1. only able to test this on higher then 4padding image sequence
