### PR TITLE
Improves transcoding performance and memory usage

### DIFF
--- a/client/ayon_core/lib/transcoding.py
+++ b/client/ayon_core/lib/transcoding.py
@@ -6,6 +6,7 @@ import collections
 import tempfile
 import subprocess
 import platform
+import psutil
 from typing import Optional
 
 import xml.etree.ElementTree
@@ -1010,11 +1011,18 @@ def convert_colorspace(
     input_arg, channels_arg = get_oiio_input_and_channel_args(input_info)
 
     # Prepare subprocess arguments
+    # Use 50% of available memory for cache (in bytes)
+    available_memory = psutil.virtual_memory().available
+    cache_size = int(available_memory * 0.5)
+
+    # Prepare subprocess arguments
     oiio_cmd = get_oiio_tool_args(
         "oiiotool",
         # Don't add any additional attributes
         "--nosoftwareattrib",
-        "--colorconfig", config_path
+        "--threads", str(os.cpu_count()),
+        "--cache",  str(cache_size),
+        "--colorconfig", config_path,
     )
 
     oiio_cmd.extend([

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -9,6 +9,7 @@ jsonschema = "^2.6.0"
 pyblish-base = "^1.8.11"
 speedcopy = "^2.1"
 six = "^1.15"
+psutil = "^5.9.0"
 qtawesome = "0.7.3"
 
 [ayon.runtimeDependencies]


### PR DESCRIPTION
## Changelog Description
Configures OpenImageIO (OIIO) to use a percentage of available memory as a cache.
This improves transcoding performance by reducing disk I/O. Also, this change adds
the 'psutil' package as a dependency to gather system memory information. It also
enables multithreading in OIIO to further enhance performance.

## Additional info
I have noticed during batchdelivery testing that oiiotool is very slow. This had speeded up a bit - I am using our distributed oiiotool with following versions:
- OpenColorIO 2.1.1, color config: built-in
- Dependent libraries: FFMpeg 4.4.1 (Lavf58.76.100), gif_lib 5.2.1, jpeg-turbo 2.1.3/jp62, null 1.0, OpenEXR 2.5.0,
    libpng 1.6.37, libraw 0.19.0-Beta1, LIBTIFF Version 4.3.0, Webp 1.2.2
- OIIO 2.3.10 built for C++14/199711 sse2


## Testing notes:
1. just do some `ExtractOIIOTranscode` preset conversions
2. No difference apart of performance increase
