### PR TITLE
Staging Dir persistence log, change to debug level

### DIFF
--- a/client/ayon_core/plugins/publish/collect_managed_staging_dir.py
+++ b/client/ayon_core/plugins/publish/collect_managed_staging_dir.py
@@ -32,16 +32,16 @@ class CollectManagedStagingDir(pyblish.api.InstancePlugin):
     label = "Collect Managed Staging Directory"
     order = pyblish.api.CollectorOrder + 0.4990
 
-    def process(self, instance):
+    def process(self, instance: pyblish.api.Instance):
         """ Collect the staging data and stores it to the instance.
 
         Args:
             instance (object): The instance to inspect.
         """
         staging_dir_path = get_instance_staging_dir(instance)
-        persistance = instance.data.get("stagingDir_persistent", False)
+        persistence: bool = instance.data.get("stagingDir_persistent", False)
 
-        self.log.info((
+        self.log.debug(
             f"Instance staging dir was set to `{staging_dir_path}` "
-            f"and persistence is set to `{persistance}`"
-        ))
+            f"and persistence is set to `{persistence}`"
+        )


### PR DESCRIPTION
## Changelog Description

Change staging dir persistence state to debug log instead of info to avoid clutter for the artist (artist doesn't care)

## Additional info

Avoid this clutter in the artist report logs:
![image](https://github.com/user-attachments/assets/a648cdab-f9e6-4400-b7a5-cc015cee52a3)

+ Some code cosmetics/type hints/typos

## Testing notes:

1. Publish artist report should look nicer