### PR TITLE
Avoids OCIO env preparation without task entity

### DIFF
--- a/client/ayon_core/hooks/pre_ocio_hook.py
+++ b/client/ayon_core/hooks/pre_ocio_hook.py
@@ -29,6 +29,15 @@ class OCIOEnvHook(PreLaunchHook):
     def execute(self):
         """Hook entry method."""
 
+        task_entity = self.data.get("task_entity")
+
+        if not task_entity:
+            self.log.info(
+                "Skipping OCIO Environment preparation."
+                "Task Entity is not available."
+            )
+            return
+
         folder_entity = self.data["folder_entity"]
 
         template_data = get_template_data(


### PR DESCRIPTION
## Changelog Description
Skips OCIO environment preparation when the task entity is not available in the hook data.

This prevents potential errors or unexpected behavior when the hook is executed in contexts where task information is missing.


## Testing notes:
1. all should work as before but it is needed for https://github.com/ynput/ayon-review/pull/56
