### PR TITLE
🏛️Product base types: Support in the integrator

### DIFF
--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -106,7 +106,8 @@ def get_publish_template_name(
     task_type,
     project_settings=None,
     hero=False,
-    logger=None
+    logger=None,
+    product_base_type: Optional[str] = None
 ):
     """Get template name which should be used for passed context.
 
@@ -126,6 +127,8 @@ def get_publish_template_name(
         hero (bool): Template is for hero version publishing.
         logger (logging.Logger): Custom logger used for 'filter_profiles'
             function.
+        product_base_type (Optional[str]): Product type for which should
+            be found template.
 
     Returns:
         str: Template name which should be used for integration.
@@ -135,6 +138,7 @@ def get_publish_template_name(
     filter_criteria = {
         "hosts": host_name,
         "product_types": product_type,
+        "product_base_types": product_base_type,
         "task_names": task_name,
         "task_types": task_type,
     }

--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -368,6 +368,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         folder_entity = instance.data["folderEntity"]
         product_name = instance.data["productName"]
         product_type = instance.data["productType"]
+        product_base_type = instance.data.get("productBaseType")
+
         self.log.debug("Product: {}".format(product_name))
 
         # Get existing product if it exists
@@ -401,7 +403,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             folder_entity["id"],
             data=data,
             attribs=attributes,
-            entity_id=product_id
+            entity_id=product_id,
+            product_base_type=product_base_type
         )
 
         if existing_product_entity is None:
@@ -917,6 +920,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         host_name = context.data["hostName"]
         anatomy_data = instance.data["anatomyData"]
         product_type = instance.data["productType"]
+        product_base_type = instance.data.get("productBaseType")
         task_info = anatomy_data.get("task") or {}
 
         return get_publish_template_name(
@@ -926,7 +930,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             task_name=task_info.get("name"),
             task_type=task_info.get("type"),
             project_settings=context.data["project_settings"],
-            logger=self.log
+            logger=self.log,
+            product_base_type=product_base_type
         )
 
     def get_rootless_path(self, anatomy, path):


### PR DESCRIPTION
## Changelog Description
Integrate `product base type` into AYON on publishing.

## Additional info
If instance has `product base type` defined, integrate it.

> [!NOTE]
> This requires https://github.com/ynput/ayon-python-api/pull/255 and definitely https://github.com/ynput/ayon-backend/pull/575

For more information about **product base types** and testing see description here https://github.com/ynput/ayon-core/issues/1297

