### PR TITLE
Scene inventory tool: Update error more visible

### DIFF
--- a/client/ayon_core/tools/sceneinventory/view.py
+++ b/client/ayon_core/tools/sceneinventory/view.py
@@ -959,11 +959,13 @@ class SceneInventoryView(QtWidgets.QTreeView):
             remove_container(container)
         self.data_changed.emit()
 
-    def _show_version_error_dialog(self, version, item_ids):
+    def _show_version_error_dialog(self, version, item_ids, exception=None):
         """Shows QMessageBox when version switch doesn't work
 
         Args:
             version: str or int or None
+            item_ids (Iterable[str]): List of item ids to run the
+            exception (Exception, optional): Exception that occurred
         """
         if version == -1:
             version_str = "latest"
@@ -987,11 +989,14 @@ class SceneInventoryView(QtWidgets.QTreeView):
 
         dialog.addButton(QtWidgets.QMessageBox.Cancel)
 
+        exception = exception or "Unknown error"
+
         msg = (
-            "Version update to '{}' failed as representation doesn't exist."
+            "Version update to '{}' failed with the following error:\n"
+            "{}."
             "\n\nPlease update to version with a valid representation"
             " OR \n use 'Switch Folder' button to change folder."
-        ).format(version_str)
+        ).format(version_str, exception)
         dialog.setText(msg)
         dialog.exec_()
 
@@ -1105,10 +1110,10 @@ class SceneInventoryView(QtWidgets.QTreeView):
                 container = containers_by_id[item_id]
                 try:
                     update_container(container, item_version)
-                except AssertionError:
+                except Exception as e:
                     log.warning("Update failed", exc_info=True)
                     self._show_version_error_dialog(
-                        item_version, [item_id]
+                        item_version, [item_id], e
                     )
         finally:
             # Always update the scene inventory view, even if errors occurred

--- a/client/ayon_core/tools/sceneinventory/view.py
+++ b/client/ayon_core/tools/sceneinventory/view.py
@@ -989,8 +989,6 @@ class SceneInventoryView(QtWidgets.QTreeView):
 
         dialog.addButton(QtWidgets.QMessageBox.Cancel)
 
-        exception = exception or "Unknown error"
-
         msg = (
             "Version update to '{}' failed with the following error:\n"
             "{}."

--- a/client/ayon_core/tools/sceneinventory/view.py
+++ b/client/ayon_core/tools/sceneinventory/view.py
@@ -959,13 +959,13 @@ class SceneInventoryView(QtWidgets.QTreeView):
             remove_container(container)
         self.data_changed.emit()
 
-    def _show_version_error_dialog(self, version, item_ids, exception=None):
+    def _show_version_error_dialog(self, version, item_ids, exception):
         """Shows QMessageBox when version switch doesn't work
 
         Args:
             version: str or int or None
             item_ids (Iterable[str]): List of item ids to run the
-            exception (Exception, optional): Exception that occurred
+            exception (Exception): Exception that occurred
         """
         if version == -1:
             version_str = "latest"
@@ -1110,10 +1110,10 @@ class SceneInventoryView(QtWidgets.QTreeView):
                 container = containers_by_id[item_id]
                 try:
                     update_container(container, item_version)
-                except Exception as e:
+                except Exception as exc:
                     log.warning("Update failed", exc_info=True)
                     self._show_version_error_dialog(
-                        item_version, [item_id], e
+                        item_version, [item_id], exc
                     )
         finally:
             # Always update the scene inventory view, even if errors occurred


### PR DESCRIPTION
## Changelog Description
When there is an exception in the `_update_containers` function, only AssertionError was caught. This lead to silent error for the other exception type. This pull request aims at providing visual feedback on the error when the other types of exceptions are caught. 

## Additional info

![image](https://github.com/user-attachments/assets/780f9967-2e9c-4af2-aa33-0306ba3196fd)
[src](https://community.ynput.io/t/ayon-manager-silent-error/2586/3?u=bigroy)

## Testing notes:
1. Use a loader to load an asset into the scene
2. Modify the update code of the plugin to raise a test exception
3. Use the manager to update the asset in the scene
