### PR TITLE
Extractors extension lookups use `set[str]` instead of `list[str]`

### DIFF
--- a/client/ayon_core/plugins/publish/extract_color_transcode.py
+++ b/client/ayon_core/plugins/publish/extract_color_transcode.py
@@ -58,7 +58,7 @@ class ExtractOIIOTranscode(publish.Extractor):
     optional = True
 
     # Supported extensions
-    supported_exts = ["exr", "jpg", "jpeg", "png", "dpx"]
+    supported_exts = {"exr", "jpg", "jpeg", "png", "dpx"}
 
     # Configurable by Settings
     profiles = None

--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -135,11 +135,11 @@ class ExtractReview(pyblish.api.InstancePlugin):
     ]
 
     # Supported extensions
-    image_exts = ["exr", "jpg", "jpeg", "png", "dpx", "tga", "tiff", "tif"]
-    video_exts = ["mov", "mp4"]
-    supported_exts = image_exts + video_exts
+    image_exts = {"exr", "jpg", "jpeg", "png", "dpx", "tga", "tiff", "tif"}
+    video_exts = {"mov", "mp4"}
+    supported_exts = image_exts.union(video_exts)
 
-    alpha_exts = ["exr", "png", "dpx"]
+    alpha_exts = {"exr", "png", "dpx"}
 
     # Preset attributes
     profiles = []


### PR DESCRIPTION
## Changelog Description

Extractors extension lookups use `set[str]` instead of `list[str]`

## Additional info

Cosmetics and minor optimization mostly.

## Testing notes:

1. Publishing with review and OIIO transcode should still work
