### PR TITLE
Handles missing folder/task data safely

### DIFF
--- a/client/ayon_core/hooks/pre_global_host_data.py
+++ b/client/ayon_core/hooks/pre_global_host_data.py
@@ -32,8 +32,8 @@ class GlobalHostDataHook(PreLaunchHook):
             "app": app,
 
             "project_entity": self.data["project_entity"],
-            "folder_entity": self.data["folder_entity"],
-            "task_entity": self.data["task_entity"],
+            "folder_entity": self.data.get("folder_entity"),
+            "task_entity": self.data.get("task_entity"),
 
             "anatomy": self.data["anatomy"],
 


### PR DESCRIPTION
## Changelog Description
Ensures the global host data hook gracefully handles cases where 'folder_entity' or 'task_entity' keys are missing from the input data.

- Prevents potential errors when these keys are not present.
- Uses `.get()` to safely access the values, returning `None` if a key is missing.

## Testing notes:
1. prehook is possible to start even on context without task or folder
