### PR TITLE
Tools: Remove usage of deprecated 'HighQualityAntialiasing' flag

### DIFF
--- a/client/ayon_core/tools/publisher/widgets/screenshot_widget.py
+++ b/client/ayon_core/tools/publisher/widgets/screenshot_widget.py
@@ -348,8 +348,6 @@ class ScreenMarquee(QtCore.QObject):
         #     QtGui.QPainter.Antialiasing
         #     | QtGui.QPainter.SmoothPixmapTransform
         # )
-        # if hasattr(QtGui.QPainter, "HighQualityAntialiasing"):
-        #     render_hints |= QtGui.QPainter.HighQualityAntialiasing
         # pix_painter.setRenderHints(render_hints)
         # for item in screen_pixes:
         #     (screen_pix, offset) = item

--- a/client/ayon_core/tools/publisher/widgets/thumbnail_widget.py
+++ b/client/ayon_core/tools/publisher/widgets/thumbnail_widget.py
@@ -135,8 +135,6 @@ class ThumbnailPainterWidget(QtWidgets.QWidget):
             QtGui.QPainter.Antialiasing
             | QtGui.QPainter.SmoothPixmapTransform
         )
-        if hasattr(QtGui.QPainter, "HighQualityAntialiasing"):
-            render_hints |= QtGui.QPainter.HighQualityAntialiasing
 
         pix_painter.setRenderHints(render_hints)
         pix_painter.drawPixmap(pos_x, pos_y, scaled_pix)
@@ -171,8 +169,6 @@ class ThumbnailPainterWidget(QtWidgets.QWidget):
                 QtGui.QPainter.Antialiasing
                 | QtGui.QPainter.SmoothPixmapTransform
             )
-            if hasattr(QtGui.QPainter, "HighQualityAntialiasing"):
-                render_hints |= QtGui.QPainter.HighQualityAntialiasing
             pix_painter.setRenderHints(render_hints)
 
             tiled_rect = QtCore.QRectF(
@@ -265,8 +261,6 @@ class ThumbnailPainterWidget(QtWidgets.QWidget):
             QtGui.QPainter.Antialiasing
             | QtGui.QPainter.SmoothPixmapTransform
         )
-        if hasattr(QtGui.QPainter, "HighQualityAntialiasing"):
-            render_hints |= QtGui.QPainter.HighQualityAntialiasing
 
         final_painter.setRenderHints(render_hints)
 

--- a/client/ayon_core/tools/utils/color_widgets/color_inputs.py
+++ b/client/ayon_core/tools/utils/color_widgets/color_inputs.py
@@ -65,7 +65,7 @@ class AlphaSlider(QtWidgets.QSlider):
 
         painter.fillRect(event.rect(), QtCore.Qt.transparent)
 
-        painter.setRenderHint(QtGui.QPainter.HighQualityAntialiasing)
+        painter.setRenderHint(QtGui.QPainter.Antialiasing)
 
         horizontal = self.orientation() == QtCore.Qt.Horizontal
 

--- a/client/ayon_core/tools/utils/color_widgets/color_triangle.py
+++ b/client/ayon_core/tools/utils/color_widgets/color_triangle.py
@@ -261,7 +261,7 @@ class QtColorTriangle(QtWidgets.QWidget):
         pix = self.bg_image.copy()
         pix_painter = QtGui.QPainter(pix)
 
-        pix_painter.setRenderHint(QtGui.QPainter.HighQualityAntialiasing)
+        pix_painter.setRenderHint(QtGui.QPainter.Antialiasing)
 
         trigon_path = QtGui.QPainterPath()
         trigon_path.moveTo(self.point_a)

--- a/client/ayon_core/tools/utils/lib.py
+++ b/client/ayon_core/tools/utils/lib.py
@@ -118,9 +118,6 @@ def paint_image_with_color(image, color):
         QtGui.QPainter.Antialiasing
         | QtGui.QPainter.SmoothPixmapTransform
     )
-    # Deprecated since 5.14
-    if hasattr(QtGui.QPainter, "HighQualityAntialiasing"):
-        render_hints |= QtGui.QPainter.HighQualityAntialiasing
     painter.setRenderHints(render_hints)
 
     painter.setClipRegion(alpha_region)

--- a/client/ayon_core/tools/utils/sliders.py
+++ b/client/ayon_core/tools/utils/sliders.py
@@ -58,7 +58,7 @@ class NiceSlider(QtWidgets.QSlider):
 
         painter.fillRect(event.rect(), QtCore.Qt.transparent)
 
-        painter.setRenderHint(QtGui.QPainter.HighQualityAntialiasing)
+        painter.setRenderHint(QtGui.QPainter.Antialiasing)
 
         horizontal = self.orientation() == QtCore.Qt.Horizontal
 

--- a/client/ayon_core/tools/utils/thumbnail_paint_widget.py
+++ b/client/ayon_core/tools/utils/thumbnail_paint_widget.py
@@ -205,8 +205,6 @@ class ThumbnailPainterWidget(QtWidgets.QWidget):
             QtGui.QPainter.Antialiasing
             | QtGui.QPainter.SmoothPixmapTransform
         )
-        if hasattr(QtGui.QPainter, "HighQualityAntialiasing"):
-            render_hints |= QtGui.QPainter.HighQualityAntialiasing
 
         pix_painter.setRenderHints(render_hints)
         pix_painter.drawPixmap(pos_x, pos_y, scaled_pix)
@@ -241,8 +239,6 @@ class ThumbnailPainterWidget(QtWidgets.QWidget):
                 QtGui.QPainter.Antialiasing
                 | QtGui.QPainter.SmoothPixmapTransform
             )
-            if hasattr(QtGui.QPainter, "HighQualityAntialiasing"):
-                render_hints |= QtGui.QPainter.HighQualityAntialiasing
             pix_painter.setRenderHints(render_hints)
 
             tiled_rect = QtCore.QRectF(
@@ -335,8 +331,6 @@ class ThumbnailPainterWidget(QtWidgets.QWidget):
             QtGui.QPainter.Antialiasing
             | QtGui.QPainter.SmoothPixmapTransform
         )
-        if hasattr(QtGui.QPainter, "HighQualityAntialiasing"):
-            render_hints |= QtGui.QPainter.HighQualityAntialiasing
 
         final_painter.setRenderHints(render_hints)
 

--- a/client/ayon_core/tools/utils/widgets.py
+++ b/client/ayon_core/tools/utils/widgets.py
@@ -624,8 +624,6 @@ class ClassicExpandBtnLabel(ExpandBtnLabel):
             QtGui.QPainter.Antialiasing
             | QtGui.QPainter.SmoothPixmapTransform
         )
-        if hasattr(QtGui.QPainter, "HighQualityAntialiasing"):
-            render_hints |= QtGui.QPainter.HighQualityAntialiasing
         painter.setRenderHints(render_hints)
         painter.drawPixmap(QtCore.QPoint(pos_x, pos_y), pixmap)
         painter.end()
@@ -788,8 +786,6 @@ class PixmapButtonPainter(QtWidgets.QWidget):
             QtGui.QPainter.Antialiasing
             | QtGui.QPainter.SmoothPixmapTransform
         )
-        if hasattr(QtGui.QPainter, "HighQualityAntialiasing"):
-            render_hints |= QtGui.QPainter.HighQualityAntialiasing
 
         painter.setRenderHints(render_hints)
         if self._cached_pixmap is None:


### PR DESCRIPTION
## Changelog Description
Don't use deprecated `HighQualityAntialiasing` flag removed in Qt5.

## Additional information
Deprecation information can be found [here](https://doc.qt.io/archives/qtforpython-5/PySide2/QtGui/QPainter.html#PySide2.QtGui.PySide2.QtGui.QPainter.RenderHint).

## Testing notes:
1. Nothing should change.
2. Validate code changes.