### PR TITLE
Farm Publish: Do not register publish plug-in paths twice

### DIFF
--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -1022,12 +1022,6 @@ def main_cli_publish(
     if addons_manager is None:
         addons_manager = AddonsManager()
 
-    # TODO validate if this has to happen
-    # - it should happen during 'install_ayon_plugins'
-    publish_paths = addons_manager.collect_plugin_paths()["publish"]
-    for plugin_path in publish_paths:
-        pyblish.api.register_plugin_path(plugin_path)
-
     applications_addon = addons_manager.get_enabled_addon("applications")
     if applications_addon is not None:
         context = get_global_context()


### PR DESCRIPTION
## Changelog Description

Remove the additional registering of plug-in paths.

## Additional info

Saw this in a deadline log provided by @kalisp 

![image](https://github.com/user-attachments/assets/c60fcc1d-19c3-4623-88e1-a3c0de8326b0)

I think it was due to this logic.

## Testing notes:

1. Deadline publish jobs should still be running correctly with all relevant plug-ins.
