### PR TITLE
Add explicit_cleanup_dirs to cleanup.py

### DIFF
--- a/client/ayon_core/plugins/publish/cleanup.py
+++ b/client/ayon_core/plugins/publish/cleanup.py
@@ -84,6 +84,14 @@ class CleanUp(pyblish.api.InstancePlugin):
                 f"type is excluded from cleanup: {product_type}")
             return
 
+        explicit_cleanup_dirs = instance.data.get("explicit_cleanup_dirs", [])
+        for _dir in explicit_cleanup_dirs:
+            self.log.debug("Removing explicit cleanup dir {}".format(_dir))
+            try:
+                shutil.rmtree(_dir)
+            except Exception as err:
+                self.log.debug(f"Could not remove dir {_dir}: {err}")
+
         temp_root = tempfile.gettempdir()
         staging_dir = instance.data.get("stagingDir", None)
 


### PR DESCRIPTION
## Changelog Description
To allow gaffer to publish to multiple contexts in one go, I wanted to be able to specify explicit cleanup directories per-instance, otherwise all the context's paths-to-cleanup would be removed once the first of the publishes would go through. Plus I needed to clean up more folders than just the `stagingDir` so cleanup_farm.py does not do it for me (plus, it's a context plugin).

Part of RVX's _summer of pull requests_