### PR TITLE
Hacky version freezing

### DIFF
--- a/client/ayon_core/pipeline/load/utils.py
+++ b/client/ayon_core/pipeline/load/utils.py
@@ -1089,7 +1089,8 @@ def filter_containers(containers, project_name):
             continue
 
         version_id = repre_entity["versionId"]
-        if version_id in outdated_version_ids:
+        version_freeze = container.get("version_freeze", False)
+        if version_id in outdated_version_ids and not version_freeze:
             outdated_containers.append(container)
 
         elif version_id not in verisons_by_id:

--- a/client/ayon_core/tools/sceneinventory/models/containers.py
+++ b/client/ayon_core/tools/sceneinventory/models/containers.py
@@ -95,7 +95,8 @@ class ContainerItem:
         namespace,
         object_name,
         item_id,
-        project_name
+        project_name,
+        version_freeze,
     ):
         self.representation_id = representation_id
         self.loader_name = loader_name
@@ -103,6 +104,7 @@ class ContainerItem:
         self.namespace = namespace
         self.item_id = item_id
         self.project_name = project_name
+        self.version_freeze = version_freeze
 
     @classmethod
     def from_container_data(cls, current_project_name, container):
@@ -114,6 +116,9 @@ class ContainerItem:
             item_id=uuid.uuid4().hex,
             project_name=container.get(
                 "project_name", current_project_name
+            ),
+            version_freeze=container.get(
+                "version_freeze", False
             )
         )
 

--- a/client/ayon_core/tools/sceneinventory/view.py
+++ b/client/ayon_core/tools/sceneinventory/view.py
@@ -1123,6 +1123,8 @@ class SceneInventoryView(QtWidgets.QTreeView):
         If at least one item is specified this will always try to refresh
         the inventory even if errors occurred on any of the items.
 
+        This will skip items that have 'version_freeze' set to True.
+
         Arguments:
             item_ids (Iterable[str]): Items to update
             version (Union[int, HeroVersion]): Version to set to.
@@ -1131,8 +1133,18 @@ class SceneInventoryView(QtWidgets.QTreeView):
                 and HeroTypeVersion instances set the hero version.
 
         """
-        versions = [version for _ in range(len(item_ids))]
-        self._update_containers(item_ids, versions)
+        non_frozen_item_ids = []
+        containers_by_id = self._controller.get_containers_by_item_ids(
+            item_ids
+        )
+        for item_id in item_ids:
+            container = containers_by_id[item_id]
+            if container.get("version_freeze", False):
+                continue
+            else:
+                non_frozen_item_ids.append(item_id)
+        versions = [version for _ in range(len(non_frozen_item_ids))]
+        self._update_containers(non_frozen_item_ids, versions)
 
     def _update_containers_to_approved_versions(
         self, approved_version_by_item_id


### PR DESCRIPTION
## Changelog Description
This allows us to pin loaded versions in a scene; so that they don't change even if 'update all' is pressed. This requires a loader plugin that sets the 'version_freeze' data on the containers themselves - currently those live in their respective addons (nuke, gaffer). 

As a plus, I'm just hijacking the 'count' column from the inventory, since I wanted to test this out quickly, so this would need it's own column if it were to be a proper thing.

So this is more for discussion rather than anything else.

## Example loader plugin (the nuke one)
```python
class ToggleVersionFreeze(InventoryAction):

    label = "Toggle version freeze"
    icon = "snowflake-o"
    color = "#d8d8d8"

    def process(self, containers):

        for container in containers:
            node = container["node"]

            if "avalon:version_freeze" in node.knobs().keys():
                value = not node["avalon:version_freeze"].getValue()
            else:
                value = True
            data = {("avalon:version_freeze", "version_freeze"): value}
            for knob in create_knobs(data, None):
                if knob.name() in node.knobs().keys():
                    node[knob.name()].setValue(knob.value())
                else:
                    node.addKnob(knob)

            h = host_tools.get_tool_by_name("sceneinventory")
            h.refresh()
```

Part of RVX's _summer of pull requests_
