### PR TITLE
Allow merging of file sequence entries in files_widgets

### DIFF
--- a/client/ayon_core/tools/attribute_defs/files_widget.py
+++ b/client/ayon_core/tools/attribute_defs/files_widget.py
@@ -892,6 +892,28 @@ class FilesWidget(QtWidgets.QFrame):
             self._add_filepaths(new_items)
         self._remove_item_by_ids(item_ids)
 
+    def _on_merge_request(self):
+        if self._multivalue:
+            return
+
+        item_ids = self._files_view.get_selected_item_ids()
+        if not item_ids:
+            return
+
+        all_paths = []
+        for item_id in item_ids:
+            file_item = self._files_model.get_file_item_by_id(item_id)
+            if not file_item:
+                return
+
+            new_items = file_item.split_sequence()
+            for nitem in new_items:
+                all_paths.append(os.path.join(nitem.directory, nitem.filenames[0]))
+        unique_all_pahts = list(set(all_paths))
+        self._remove_item_by_ids(item_ids)
+        new_items = FileDefItem.from_value(unique_all_pahts, True)
+        self._add_filepaths(new_items)
+
     def _on_remove_requested(self):
         if self._multivalue:
             return
@@ -911,6 +933,9 @@ class FilesWidget(QtWidgets.QFrame):
                 split_action.triggered.connect(self._on_split_request)
                 menu.addAction(split_action)
 
+                merge_action = QtWidgets.QAction("Merge sequence", menu)
+                merge_action.triggered.connect(self._on_merge_request)
+                menu.addAction(merge_action)
             remove_action = QtWidgets.QAction("Remove", menu)
             remove_action.triggered.connect(self._on_remove_requested)
             menu.addAction(remove_action)


### PR DESCRIPTION
## Changelog Description
There came up the issue a while back that when very long sequences (6000 frames or longer) were dragged and dropped onto the file widgets QT would freak out and not handle it (behaving as if nothing was dropped). The fix was to add this merge function and drop 2 x 3000 frames and then combine them. Stupid? Yes. Did it work? Yes.

Part of RVX's _summer of pull requests_
