### PR TITLE
Chore: Add env tool functions to ayon_core.lib

### DIFF
--- a/client/ayon_core/lib/__init__.py
+++ b/client/ayon_core/lib/__init__.py
@@ -50,8 +50,10 @@ from .attribute_definitions import (
 )
 
 from .env_tools import (
+    compute_env_variables_structure,
     env_value_to_bool,
     get_paths_from_environ,
+    merge_env_variables,
 )
 
 from .terminal import Terminal
@@ -166,8 +168,10 @@ __all__ = [
     "path_to_subprocess_arg",
     "CREATE_NO_WINDOW",
 
+    "compute_env_variables_structure",
     "env_value_to_bool",
     "get_paths_from_environ",
+    "merge_env_variables",
 
     "ToolNotFoundError",
     "find_executable",


### PR DESCRIPTION
## Changelog Description
Environment-related functions replacing functionality of `acre` added to `ayon_core.lib` init file, fixing import errors and fallback to acre in ayon-applications addon.

## Testing notes:
1. Test with ayon-applications addon 1.1.3
2. Resolving tokens in environent paths should work even without acre (remove acre from ayon-launcher dependencies, rebuild and run)
