### PR TITLE
Chore: Define logging config for AYON processes

### DIFF
--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -2,6 +2,7 @@
 """Package for handling AYON command line arguments."""
 import os
 import sys
+import logging
 import code
 import traceback
 from pathlib import Path
@@ -22,6 +23,9 @@ from ayon_core.lib.env_tools import (
     compute_env_variables_structure,
     merge_env_variables,
 )
+
+logging.basicConfig()
+log = logging.getLogger()
 
 
 @click.group(invoke_without_command=True)

--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -24,9 +24,6 @@ from ayon_core.lib.env_tools import (
     merge_env_variables,
 )
 
-logging.basicConfig()
-log = logging.getLogger()
-
 
 @click.group(invoke_without_command=True)
 @click.pass_context
@@ -310,6 +307,8 @@ def _add_addons(addons_manager):
 
 
 def main(*args, **kwargs):
+    logging.basicConfig()
+
     initialize_ayon_connection()
     python_path = os.getenv("PYTHONPATH", "")
     split_paths = python_path.split(os.pathsep)


### PR DESCRIPTION
## Changelog Description
Define default logging config for AYON processes.

## Additional info
CLI initializes logging config.

## Testing notes:
1. Logs should be visible in terminal.
