### PR TITLE
Add "blender" to hosts list for Validate File Saved

### DIFF
--- a/client/ayon_core/plugins/publish/validate_file_saved.py
+++ b/client/ayon_core/plugins/publish/validate_file_saved.py
@@ -37,7 +37,7 @@ class ValidateCurrentSaveFile(pyblish.api.ContextPlugin):
     label = "Validate File Saved"
     order = pyblish.api.ValidatorOrder - 0.1
     hosts = ["fusion", "houdini", "max", "maya", "nuke", "substancepainter",
-             "cinema4d", "silhouette", "gaffer"]
+             "cinema4d", "silhouette", "gaffer", "blender"]
     actions = [SaveByVersionUpAction, ShowWorkfilesAction]
 
     def process(self, context):


### PR DESCRIPTION
## Changelog Description

Trigger validation whether workfile is saved also in Blender
## Additional info

![image](https://github.com/user-attachments/assets/f23d518d-7d5c-4b8e-a0e3-7af09e88fb1f)

## Testing notes:

1. Validation should work in Blender.
