### PR TITLE
Chore: Fix Python 3.7 in loader tool

### DIFF
--- a/client/ayon_core/tools/loader/control.py
+++ b/client/ayon_core/tools/loader/control.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import uuid
 

--- a/client/ayon_core/tools/loader/models/actions.py
+++ b/client/ayon_core/tools/loader/models/actions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import traceback
 import inspect

--- a/client/ayon_core/tools/loader/models/products.py
+++ b/client/ayon_core/tools/loader/models/products.py
@@ -1,5 +1,6 @@
 """Products model for loader tools."""
 from __future__ import annotations
+
 import collections
 import contextlib
 from typing import TYPE_CHECKING, Iterable, Optional

--- a/client/ayon_core/tools/loader/models/selection.py
+++ b/client/ayon_core/tools/loader/models/selection.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class SelectionModel(object):
     """Model handling selection changes.
 

--- a/client/ayon_core/tools/loader/models/sitesync.py
+++ b/client/ayon_core/tools/loader/models/sitesync.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 
 from ayon_api import (

--- a/client/ayon_core/tools/loader/ui/_multicombobox.py
+++ b/client/ayon_core/tools/loader/ui/_multicombobox.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import typing
 from typing import List, Tuple, Optional, Iterable, Any
 

--- a/client/ayon_core/tools/loader/ui/products_delegates.py
+++ b/client/ayon_core/tools/loader/ui/products_delegates.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numbers
 import uuid
-from typing import Dict
 
 from qtpy import QtWidgets, QtCore, QtGui
 
@@ -249,7 +248,7 @@ class VersionDelegate(QtWidgets.QStyledItemDelegate):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._editor_by_id: Dict[str, VersionComboBox] = {}
+        self._editor_by_id: dict[str, VersionComboBox] = {}
         self._task_ids_filter = None
         self._statuses_filter = None
         self._version_tags_filter = None

--- a/client/ayon_core/tools/loader/ui/products_widget.py
+++ b/client/ayon_core/tools/loader/ui/products_widget.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import collections
 from typing import Optional
 

--- a/client/ayon_core/tools/loader/ui/search_bar.py
+++ b/client/ayon_core/tools/loader/ui/search_bar.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import uuid
 from dataclasses import dataclass

--- a/client/ayon_core/tools/loader/ui/window.py
+++ b/client/ayon_core/tools/loader/ui/window.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from qtpy import QtWidgets, QtCore, QtGui
 
 from ayon_core.resources import get_ayon_icon_filepath


### PR DESCRIPTION
## Changelog Description
Use `from __future__ import annotations` to fix `list[...]`, `dict[...]` etc. type-hints.

## Testing notes:
I don't have installed DCC with Python 3.7 so all changes are done based on reading code.
1. Launch a DCC that uses Python 3.7
2. Open loader tool.
3. It should be working.
