### PR TITLE
Fix all characters of report being printed to new lines

### DIFF
--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -1048,7 +1048,7 @@ def main_cli_publish(
 
     discover_result = publish_plugins_discover()
     publish_plugins = discover_result.plugins
-    print("\n".join(discover_result.get_report(only_errors=False)))
+    print(discover_result.get_report(only_errors=False))
 
     # Error exit as soon as any error occurs.
     error_format = ("Failed {plugin.__name__}: "


### PR DESCRIPTION
## Changelog Description

Fix all characters of report being printed to new lines

## Additional info

[Fix this change](https://github.com/ynput/ayon-core/commit/6dc0a0e698f624232e284ff1a6c7e130bd9ba592).

## Testing notes:

1. Publish job log on farm should look normal.
