### PR TITLE
`DiscoverResult.get_report`: Report the actual class name for plugins list

### DIFF
--- a/client/ayon_core/pipeline/plugin_discover.py
+++ b/client/ayon_core/pipeline/plugin_discover.py
@@ -51,7 +51,7 @@ class DiscoverResult:
                     "*** Discovered {} plugins".format(len(self.plugins))
                 )
                 for cls in self.plugins:
-                    lines.append("- {}".format(cls.__class__.__name__))
+                    lines.append("- {}".format(cls.__name__))
 
             # Plugin that were defined to be ignored
             if self.ignored_plugins or full_report:


### PR DESCRIPTION
## Changelog Description

Report the actual class name for plugins list

## Additional info

Before:
```
*** Discovered 78 plugins
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- MetaPlugin
- MetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- MetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- MetaPlugin
- ExplicitMetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- ExplicitMetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- ExplicitMetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- ExplicitMetaPlugin
- ExplicitMetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- MetaPlugin
- ExplicitMetaPlugin
- MetaPlugin
- MetaPlugin
- ExplicitMetaPlugin
- MetaPlugin
- ExplicitMetaPlugin
- MetaPlugin
- ExplicitMetaPlugin
```

After:
```
*** Discovered 78 plugins
- CollectAddons
- CollectCleanupKeys
- CollectCurrentContext
- CollectCurrentShellFile
- CollectDateTimeData
- CollectFromCreateContext
- CollectHostName
- CollectMachineName
- CollectShellWorkspace
- CollectAppName
- CollectTime
- CollectSettings
- CollectCoreJobEnvVars
- CollectApplicationsJobEnvVars
- CollectAnatomyObject
- CollectRenderedFiles
- CollectContextEntities
- CollectExplicitResolution
- CollectOtioRanges
- CollectCurrentDate
- CollectCurrentUser
- CollectCurrentWorkingDirectory
- RepairUnicodeStrings
- CollectAYONServerToFarmJob
- CollectDeadlineJobEnvVars
- CollectEnvironmentFileToDelete
- CollectCurrentAYONUser
- CollectAnatomyContextData
- CollectDefaultDeadlineServer
- CollectDeadlineServerFromInstance
- CollectContextLabel
- CollectDeadlineUserCredentials
- CollectUSDLayerContributions
- CollectJobInfo
- CollectAnatomyInstanceData
- CollectResourcesPath
- CollectSourceForSource
- CollectFarmTarget
- CollectInputRepresentationsToVersions
- CollectManagedStagingDir
- ValidateUSDDependencies
- ValidateFolderEntities
- ValidateFileSequences
- ValidateProductUniqueness
- ValidateVersion
- ValidateDeadlineConnection
- ValidateDeadlineJobInfo
- ValidateDeadlinePools
- ValidateExpectedFiles
- ValidatePublishDir
- ValidateResources
- CollectComment
- ExtractHierarchyToAYON
- ExtractThumbnailFromSource
- ExtractScanlineExr
- ExtractOIIOTranscode
- ExtractReview
- ExtractBurnin
- ExtractReviewSlate
- ExtractUSDLayerContribution
- ExtractUSDAssetContribution
- ExtractColorspaceData
- ExtractSlateData
- ExtractThumbnail
- AttachReviewables
- IntegrateProductGroup
- PreIntegrateThumbnails
- IntegrateResourcesPath
- IntegrateAsset
- IntegrateTraits
- IntegrateThumbnailsAYON
- IntegrateHeroVersion
- IntegrateAYONReview
- IntegrateInputLinksAYON
- ProcessSubmittedJobOnFarm
- IntegrateVersionAttributes
- CleanUp
- ExplicitCleanUp
```

## Testing notes:

1. Publish log on farm should actually list the found plug-in names.
