### PR TITLE
Collect Versions Loaded in Scene: Use `ILoadHost.get_containers()`

### DIFF
--- a/client/ayon_core/plugins/publish/collect_scene_loaded_versions.py
+++ b/client/ayon_core/plugins/publish/collect_scene_loaded_versions.py
@@ -27,12 +27,13 @@ class CollectSceneLoadedVersions(pyblish.api.ContextPlugin):
     def process(self, context):
         host = registered_host()
         if host is None:
-            self.log.warn("No registered host.")
+            self.log.warning("No registered host.")
             return
 
         if not hasattr(host, "ls"):
             host_name = host.__name__
-            self.log.warn("Host %r doesn't have ls() implemented." % host_name)
+            self.log.warning(
+                f"Host {host_name} doesn't have ls() implemented.")
             return
 
         loaded_versions = []

--- a/client/ayon_core/plugins/publish/collect_scene_loaded_versions.py
+++ b/client/ayon_core/plugins/publish/collect_scene_loaded_versions.py
@@ -94,4 +94,5 @@ class CollectSceneLoadedVersions(pyblish.api.ContextPlugin):
             }
             loaded_versions.append(version)
 
+        self.log.debug(f"Collected {len(loaded_versions)} loaded versions.")
         context.data["loadedVersions"] = loaded_versions

--- a/client/ayon_core/plugins/publish/collect_scene_loaded_versions.py
+++ b/client/ayon_core/plugins/publish/collect_scene_loaded_versions.py
@@ -45,6 +45,11 @@ class CollectSceneLoadedVersions(pyblish.api.ContextPlugin):
                 f"loaded versions in scene.")
             return
 
+        if not containers:
+            # Opt out early if there are no containers
+            self.log.debug("No loaded containers found in scene.")
+            return
+
         repre_ids = {
             container["representation"]
             for container in containers


### PR DESCRIPTION
## Changelog Description

Collect Versions Loaded in Scene: Use `ILoadHost.get_containers()`

## Additional info

Fix #1379 

## Testing notes:

1. Collecting versions loaded in scene should work using the new `get_containers` method on the registered host if it is present.