### PR TITLE
Integrate Input Links: Do not use deprecated `Logger.warn`, use `Logger.warning` instead

### DIFF
--- a/client/ayon_core/plugins/publish/integrate_inputlinks.py
+++ b/client/ayon_core/plugins/publish/integrate_inputlinks.py
@@ -105,7 +105,7 @@ class IntegrateInputLinksAYON(pyblish.api.ContextPlugin):
                 created links by its type
         """
         if workfile_instance is None:
-            self.log.warn("No workfile in this publish session.")
+            self.log.warning("No workfile in this publish session.")
             return
 
         workfile_version_id = workfile_instance.data["versionEntity"]["id"]


### PR DESCRIPTION
## Changelog Description

Integrate Input Links: Do not use deprecated `Logger.warn`, use `Logger.warning` instead

## Additional info

This may avoid a deprecation warning like:
```
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

## Testing notes:

1. Check code change.
