### PR TITLE
Collect Loaded Scene Versions: Enable for more hosts

### DIFF
--- a/client/ayon_core/plugins/publish/collect_scene_loaded_versions.py
+++ b/client/ayon_core/plugins/publish/collect_scene_loaded_versions.py
@@ -13,15 +13,23 @@ class CollectSceneLoadedVersions(pyblish.api.ContextPlugin):
         "aftereffects",
         "blender",
         "celaction",
+        "cinema4d",
+        "flame",
         "fusion",
         "harmony",
         "hiero",
         "houdini",
+        "max",
         "maya",
+        "motionbuilder",
         "nuke",
         "photoshop",
+        "silhouette",
+        "substancepainter",
+        "substancedesigner",
         "resolve",
-        "tvpaint"
+        "tvpaint",
+        "zbrush",
     ]
 
     def process(self, context):


### PR DESCRIPTION
## Changelog Description

Collect Loaded Scene Versions: Enable for more hosts

## Additional info

I'm not sure if the hosts filtering is still valid and should be maintained. Likely it's there solely to exclude e.g. apps like Tray Publisher? Anyway, this PR enables some more of the hosts that are available in AYON.

## Testing notes:

1. Publishing in the added DCCs should work with Collecting Loaded Version in Scene.

- [ ] Cinema4D
- [ ] Flame
- [ ] Max
- [ ] Motionbuilder
- [ ] Silhouette
- [ ] Substance Painter
- [ ] Substance Designer
- [ ] Zbrush
