### PR TITLE
Linked assets/folders in template builder

### DIFF
--- a/client/ayon_core/pipeline/load/plugins.py
+++ b/client/ayon_core/pipeline/load/plugins.py
@@ -373,7 +373,7 @@ def discover_loader_plugins(project_name=None):
     if not project_name:
         project_name = get_current_project_name()
     project_settings = get_project_settings(project_name)
-    plugins = discover(LoaderPlugin)
+    plugins = discover(LoaderPlugin, allow_duplicates=False)
     hooks = discover(LoaderHookPlugin)
     sorted_hooks = sorted(hooks, key=lambda hook: hook.order)
     for plugin in plugins:

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -301,7 +301,7 @@ class AbstractTemplateBuilder(ABC):
             self._loaders_by_name = get_loaders_by_name()
         return self._loaders_by_name
 
-    def get_linked_folder_entities(self, link_type: str = "template"):
+    def get_linked_folder_entities(self, link_type: str):
         project_name = self.project_name
         folder_entity = self.current_folder_entity
         if not folder_entity:
@@ -1466,7 +1466,6 @@ class PlaceholderLoadMixin(object):
             attribute_definitions.EnumDef(
                 "link_type",
                 label="Link Type",
-                default="template",
                 items=link_types_enum_item,
                 tooltip=(
                     "Link Type\n"

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -202,14 +202,6 @@ class AbstractTemplateBuilder(ABC):
         return self._current_folder_entity
 
     @property
-    def linked_folder_entities(self):
-        if self._linked_folder_entities is _NOT_SET:
-            self._linked_folder_entities = self._get_linked_folder_entities(
-                link_type="template"
-            )
-        return self._linked_folder_entities
-
-    @property
     def current_task_entity(self):
         if self._current_task_entity is _NOT_SET:
             task_entity = None
@@ -309,7 +301,7 @@ class AbstractTemplateBuilder(ABC):
             self._loaders_by_name = get_loaders_by_name()
         return self._loaders_by_name
 
-    def _get_linked_folder_entities(self, link_type: str = "template"):
+    def get_linked_folder_entities(self, link_type: str = "template"):
         project_name = self.project_name
         folder_entity = self.current_folder_entity
         if not folder_entity:
@@ -1642,6 +1634,8 @@ class PlaceholderLoadMixin(object):
             folder_ids = [current_folder_entity["id"]]
 
         elif builder_type == "linked_folders":
+            # link type from placeholder data or default to "template"
+            link_type = placeholder.data.get("link_type", "template")
             # Get all linked folders for the current folder
             if hasattr(self, "builder") and isinstance(
                     self.builder, AbstractTemplateBuilder):
@@ -1649,7 +1643,8 @@ class PlaceholderLoadMixin(object):
                 folder_ids = [
                     linked_folder_entity["id"]
                     for linked_folder_entity in (
-                        self.builder.linked_folder_entities)
+                        self.builder.get_linked_folder_entities(
+                            link_type=link_type))
                 ]
 
         if not folder_ids:

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1430,11 +1430,21 @@ class PlaceholderLoadMixin(object):
 
         link_types = ayon_api.get_link_types(self.builder.project_name)
 
-        link_types_enum_item = [
+        # Filter link types for folder to folder links
+        link_types_enum_items = [
             {"label": link_type["name"], "value": link_type["linkType"]}
             for link_type in link_types
-
+            if (
+                    link_type["inputType"] == "folder"
+                    and link_type["outputType"] == "folder"
+            )
         ]
+
+        if not link_types_enum_items:
+            link_types_enum_items.append(
+                {"label": "<No link types>", "value": None}
+            )
+
         build_type_label = "Folder Builder Type"
         build_type_help = (
             "Folder Builder Type\n"
@@ -1466,7 +1476,7 @@ class PlaceholderLoadMixin(object):
             attribute_definitions.EnumDef(
                 "link_type",
                 label="Link Type",
-                items=link_types_enum_item,
+                items=link_types_enum_items,
                 tooltip=(
                     "Link Type\n"
                     "\nDefines what type of link will be used to"

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -16,6 +16,7 @@ import re
 import collections
 import copy
 from abc import ABC, abstractmethod
+from typing import Optional
 
 import ayon_api
 from ayon_api import (

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -204,7 +204,9 @@ class AbstractTemplateBuilder(ABC):
     @property
     def linked_folder_entities(self):
         if self._linked_folder_entities is _NOT_SET:
-            self._linked_folder_entities = self._get_linked_folder_entities()
+            self._linked_folder_entities = self._get_linked_folder_entities(
+                link_type="template"
+            )
         return self._linked_folder_entities
 
     @property
@@ -307,14 +309,14 @@ class AbstractTemplateBuilder(ABC):
             self._loaders_by_name = get_loaders_by_name()
         return self._loaders_by_name
 
-    def _get_linked_folder_entities(self):
+    def _get_linked_folder_entities(self, link_type: str = "template"):
         project_name = self.project_name
         folder_entity = self.current_folder_entity
         if not folder_entity:
             return []
         links = get_folder_links(
             project_name,
-            folder_entity["id"], link_types=["template"], link_direction="in"
+            folder_entity["id"], link_types=[link_type], link_direction="in"
         )
         linked_folder_ids = {
             link["entityId"]
@@ -1433,6 +1435,14 @@ class PlaceholderLoadMixin(object):
             {"label": "Linked folders", "value": "linked_folders"},
             {"label": "All folders", "value": "all_folders"},
         ]
+
+        link_types = ayon_api.get_link_types(self.builder.project_name)
+
+        link_types_enum_item = [
+            {"label": link_type["name"], "value": link_type["linkType"]}
+            for link_type in link_types
+
+        ]
         build_type_label = "Folder Builder Type"
         build_type_help = (
             "Folder Builder Type\n"
@@ -1460,6 +1470,17 @@ class PlaceholderLoadMixin(object):
                 default=options.get("builder_type"),
                 items=builder_type_enum_items,
                 tooltip=build_type_help
+            ),
+            attribute_definitions.EnumDef(
+                "link_type",
+                label="Link Type",
+                default="template",
+                items=link_types_enum_item,
+                tooltip=(
+                    "Link Type\n"
+                    "\nDefines what type of link will be used to"
+                    " link the asset to the current folder."
+                )
             ),
             attribute_definitions.EnumDef(
                 "product_type",

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1627,7 +1627,8 @@ class PlaceholderLoadMixin(object):
                 # self.builder: AbstractTemplateBuilder
                 folder_ids = [
                     linked_folder_entity["id"]
-                    for linked_folder_entity in self.builder.linked_folder_entities  # noqa: E501
+                    for linked_folder_entity in (
+                        self.builder.linked_folder_entities)
                 ]
 
         if not folder_ids:

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -313,7 +313,8 @@ class AbstractTemplateBuilder(ABC):
         if not folder_entity:
             return []
         links = get_folder_links(
-            project_name, folder_entity["id"], link_direction="in"
+            project_name,
+            folder_entity["id"], link_types=["template"], link_direction="in"
         )
         linked_folder_ids = {
             link["entityId"]
@@ -1429,8 +1430,7 @@ class PlaceholderLoadMixin(object):
 
         builder_type_enum_items = [
             {"label": "Current folder", "value": "context_folder"},
-            # TODO implement linked folders
-            # {"label": "Linked folders", "value": "linked_folders"},
+            {"label": "Linked folders", "value": "linked_folders"},
             {"label": "All folders", "value": "all_folders"},
         ]
         build_type_label = "Folder Builder Type"
@@ -1607,10 +1607,7 @@ class PlaceholderLoadMixin(object):
 
         builder_type = placeholder.data["builder_type"]
         folder_ids = []
-        if builder_type == "context_folder":
-            folder_ids = [current_folder_entity["id"]]
-
-        elif builder_type == "all_folders":
+        if builder_type == "all_folders":
             folder_ids = {
                 folder_entity["id"]
                 for folder_entity in get_folders(
@@ -1619,6 +1616,19 @@ class PlaceholderLoadMixin(object):
                     fields={"id"}
                 )
             }
+
+        elif builder_type == "context_folder":
+            folder_ids = [current_folder_entity["id"]]
+
+        elif builder_type == "linked_folders":
+            # Get all linked folders for the current folder
+            if hasattr(self, "builder") and isinstance(
+                    self.builder, AbstractTemplateBuilder):
+                # self.builder: AbstractTemplateBuilder
+                folder_ids = [
+                    linked_folder_entity["id"]
+                    for linked_folder_entity in self.builder.linked_folder_entities  # noqa: E501
+                ]
 
         if not folder_ids:
             return []

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -301,7 +301,9 @@ class AbstractTemplateBuilder(ABC):
             self._loaders_by_name = get_loaders_by_name()
         return self._loaders_by_name
 
-    def get_linked_folder_entities(self, link_type: str):
+    def get_linked_folder_entities(self, link_type: Optional[str]):
+        if not link_type:
+            return []
         project_name = self.project_name
         folder_entity = self.current_folder_entity
         if not folder_entity:


### PR DESCRIPTION
## Changelog Description
Adding back linked assets/folder feature that was there in template builder back in OpenPype days. This is now working with template type links of AYON.

## Additional Notes
This should work nicely with https://github.com/ynput/ayon-ftrack/pull/227

## Testing notes:
1.links folders together using template links - for example link asset `foo` and asset `bar` to shot `sh010`
2. have some versions of model published in `foo` and `bar`
3. in DCC supporting template builder and loading models create template placeholder working on linked folders.

For example in Maya, you can create this placeholder:
<img width="533" height="548" alt="image" src="https://github.com/user-attachments/assets/37e6813f-7c0c-44d5-ab42-5da34fc57fe1" />

and if you run it in context of `sh010`, it will pull in representations of abc models from `foo` and `bar`.


> [!NOTE]
> To create links, use either API calls `ayon_api.create_link(project_name: str, link_type_name: str, input_id: str, input_type: str, output_id: str, output_type: str, link_name: Optional[str] = None)` - be sure to use `template` type for the links or you can use this PR to do it via frontend https://github.com/ynput/ayon-frontend/pull/1337