### PR TITLE
Workfiles: Save next version re-use comment

### DIFF
--- a/client/ayon_core/pipeline/workfile/__init__.py
+++ b/client/ayon_core/pipeline/workfile/__init__.py
@@ -22,9 +22,11 @@ from .utils import (
     should_open_workfiles_tool_on_launch,
     MissingWorkdirError,
 
+    save_workfile_info,
     save_current_workfile_to,
     save_workfile_with_current_context,
-    save_workfile_info,
+    save_next_version,
+    copy_workfile_to_context,
     find_workfile_rootless_path,
 )
 
@@ -63,9 +65,11 @@ __all__ = (
     "should_open_workfiles_tool_on_launch",
     "MissingWorkdirError",
 
+    "save_workfile_info",
     "save_current_workfile_to",
     "save_workfile_with_current_context",
-    "save_workfile_info",
+    "save_next_version",
+    "copy_workfile_to_context",
 
     "BuildWorkfile",
 

--- a/client/ayon_core/pipeline/workfile/utils.py
+++ b/client/ayon_core/pipeline/workfile/utils.py
@@ -417,7 +417,9 @@ def save_next_version(
     Args:
         version (Optional[int]): Workfile version that will be used. Last
             version + 1 is used if is not passed in.
-        comment (optional[str]): Workfile comment.
+        comment (optional[str]): Workfile comment. Pass '""' to clear comment.
+            The last workfile comment is used if it is not passed in and
+            passed 'version' is 'None'.
         description (Optional[str]): Workfile description.
         prepared_data (Optional[SaveWorkfileOptionalData]): Prepared data
             for speed enhancements.
@@ -512,6 +514,9 @@ def save_next_version(
                 task_type=task_entity["taskType"],
                 product_type="workfile"
             )
+
+    if comment is None and last_workfile is not None:
+        comment = last_workfile.comment
 
     template_data["version"] = version
     template_data["comment"] = comment

--- a/client/ayon_core/pipeline/workfile/utils.py
+++ b/client/ayon_core/pipeline/workfile/utils.py
@@ -545,7 +545,7 @@ def save_next_version(
         elif last_workfile is not None:
             ext = os.path.splitext(last_workfile.filepath)[1]
         else:
-            ext = next(iter(workfile_extensions), None)
+            ext = next(iter(workfile_extensions))
         ext = ext.lstrip(".")
 
     if ext:

--- a/client/ayon_core/pipeline/workfile/utils.py
+++ b/client/ayon_core/pipeline/workfile/utils.py
@@ -541,11 +541,12 @@ def save_next_version(
     workfile_extensions = host.get_workfile_extensions()
     if workfile_extensions:
         if current_path:
-            ext = os.path.splitext(current_path)[1].lstrip(".")
+            ext = os.path.splitext(current_path)[1]
         elif last_workfile is not None:
-            ext = os.path.splitext(last_workfile.filepath)[1].lstrip(".")
+            ext = os.path.splitext(last_workfile.filepath)[1]
         else:
             ext = next(iter(workfile_extensions), None)
+        ext = ext.lstrip(".")
 
     if ext:
         template_data["ext"] = ext


### PR DESCRIPTION
## Changelog Description
Helper function `save_next_version` is re-using comment from current workfile (or last workfile if current is not set).

## Additional info
This behavior should cover most of function use-cases. It is still possible to pass `comment=""` to avoid that behavior. 

Also added helper functions to workfile's `__init__.py` for easier import.

## Testing notes:
1. Using `save_next_version` re-uses comment from current workfile.
