### PR TITLE
Chore: Add deprecations

### DIFF
--- a/client/ayon_core/pipeline/context_tools.py
+++ b/client/ayon_core/pipeline/context_tools.py
@@ -69,7 +69,7 @@ def _get_addons_manager():
 
 
 def register_root(path):
-    """Register currently active root"""
+    """DEPRECATED Register currently active root."""
     log.info("Registering root: %s" % path)
     _registered_root["_"] = path
 
@@ -88,8 +88,14 @@ def registered_root():
 
     Returns:
         dict[str, str]: Root paths.
-    """
 
+    """
+    warnings.warn(
+        "Used deprecated function 'registered_root'. Please use 'Anatomy'"
+        " to get roots.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _registered_root["_"]
 
 

--- a/client/ayon_core/pipeline/context_tools.py
+++ b/client/ayon_core/pipeline/context_tools.py
@@ -183,7 +183,7 @@ def install_ayon_plugins(project_name=None, host_name=None):
     register_inventory_action_path(INVENTORY_PATH)
 
     if host_name is None:
-        host_name = os.environ.get("AYON_HOST_NAME")
+        host_name = get_current_host_name()
 
     addons_manager = _get_addons_manager()
     publish_plugin_dirs = addons_manager.collect_publish_plugin_paths(

--- a/client/ayon_core/pipeline/context_tools.py
+++ b/client/ayon_core/pipeline/context_tools.py
@@ -99,13 +99,18 @@ def registered_root():
     return _registered_root["_"]
 
 
-def install_host(host):
+def install_host(host: HostBase) -> None:
     """Install `host` into the running Python session.
 
     Args:
         host (HostBase): A host interface object.
 
     """
+    if not isinstance(host, HostBase):
+        log.error(
+            f"Host must be a subclass of 'HostBase', got '{type(host)}'."
+        )
+
     global _is_installed
 
     _is_installed = True

--- a/client/ayon_core/pipeline/context_tools.py
+++ b/client/ayon_core/pipeline/context_tools.py
@@ -360,6 +360,24 @@ def get_current_task_name():
     return get_global_context()["task_name"]
 
 
+def get_current_project_settings() -> dict[str, Any]:
+    """Project settings for the current context project.
+
+    Returns:
+        dict[str, Any]: Project settings for the current context project.
+
+    Raises:
+        ValueError: If current project is not set.
+
+    """
+    project_name = get_current_project_name()
+    if not project_name:
+        raise ValueError(
+            "Current project is not set. Can't get project settings."
+        )
+    return get_project_settings(project_name)
+
+
 def get_current_project_entity(fields=None):
     """Helper function to get project document based on global Session.
 

--- a/client/ayon_core/pipeline/context_tools.py
+++ b/client/ayon_core/pipeline/context_tools.py
@@ -1,5 +1,6 @@
 """Core pipeline functionality"""
 from __future__ import annotations
+
 import os
 import logging
 import platform
@@ -575,6 +576,7 @@ def change_current_context(
                 " It is not necessary to pass it in anymore."
             ),
             DeprecationWarning,
+            stacklevel=2,
         )
 
     host = registered_host()
@@ -603,6 +605,16 @@ def get_process_id():
 
 
 def version_up_current_workfile():
-    """Function to increment and save workfile"""
+    """DEPRECATED Function to increment and save workfile.
+
+    Please use 'save_next_version' from 'ayon_core.pipeline.workfile' instead.
+
+    """
+    warnings.warn(
+        "Used deprecated 'version_up_current_workfile' please use"
+        " 'save_next_version' from 'ayon_core.pipeline.workfile' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     from ayon_core.pipeline.workfile import save_next_version
     save_next_version()

--- a/client/ayon_core/pipeline/load/utils.py
+++ b/client/ayon_core/pipeline/load/utils.py
@@ -720,11 +720,13 @@ def get_representation_path(representation, root=None):
         str: fullpath of the representation
 
     """
-
     if root is None:
-        from ayon_core.pipeline import registered_root
+        from ayon_core.pipeline import get_current_project_name, Anatomy
 
-        root = registered_root()
+        anatomy = Anatomy(get_current_project_name())
+        return get_representation_path_with_anatomy(
+            representation, anatomy
+        )
 
     def path_from_representation():
         try:
@@ -772,7 +774,7 @@ def get_representation_path(representation, root=None):
 
         dir_path, file_name = os.path.split(path)
         if not os.path.exists(dir_path):
-            return
+            return None
 
         base_name, ext = os.path.splitext(file_name)
         file_name_items = None
@@ -782,7 +784,7 @@ def get_representation_path(representation, root=None):
             file_name_items = base_name.split("%")
 
         if not file_name_items:
-            return
+            return None
 
         filename_start = file_name_items[0]
 

--- a/client/ayon_core/settings/lib.py
+++ b/client/ayon_core/settings/lib.py
@@ -4,6 +4,7 @@ import logging
 import collections
 import copy
 import time
+import warnings
 
 import ayon_api
 
@@ -175,17 +176,22 @@ def get_project_environments(project_name, project_settings=None):
 
 
 def get_current_project_settings():
-    """Project settings for current context project.
+    """DEPRECATE Project settings for current context project.
 
-    Project name should be stored in environment variable `AYON_PROJECT_NAME`.
-    This function should be used only in host context where environment
-    variable must be set and should not happen that any part of process will
-    change the value of the environment variable.
+    Function requires access to pipeline context which is in
+        'ayon_core.pipeline'.
+
+    Returns:
+        dict[str, Any]: Project settings for current context project.
+
     """
-    project_name = os.environ.get("AYON_PROJECT_NAME")
-    if not project_name:
-        raise ValueError(
-            "Missing context project in environment"
-            " variable `AYON_PROJECT_NAME`."
-        )
-    return get_project_settings(project_name)
+    warnings.warn(
+        "Used deprecated function 'get_current_project_settings' in"
+        " 'ayon_core.settings'. The function was moved to"
+        " 'ayon_core.pipeline.context_tools'.",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    from ayon_core.pipeline.context_tools import get_current_project_settings
+
+    return get_current_project_settings()


### PR DESCRIPTION
## Changelog Description
Mark few functions as deprecated. Some of them are considered as deprecated for a long time, some are new.

## Additional info
Function `get_current_project_settings` was moved to `ayon_core.pipeline.context_tools` -> requires access to current project name.
Marked registered root as deprecated, it is considered as deprecated for few years now. With that `get_representation_path` is now using current project anatomy to fill the path, making it slower.
Added host type validation to make sure we don't have some forgotten host without conversion to `HostBase`.
Marked `version_up_current_workfile` as deprecated with `save_next_version` helper function as replacement.

## Testing notes:
1. Validate code changes made here.
