### PR TITLE
Publish: Hash publish plugin dirpath before storing to sys modules

### DIFF
--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -5,6 +5,7 @@ import sys
 import inspect
 import copy
 import warnings
+import hashlib
 import xml.etree.ElementTree
 from typing import TYPE_CHECKING, Optional, Union, List
 
@@ -257,15 +258,18 @@ def publish_plugins_discover(
             filenames.append(os.path.basename(path))
             path = os.path.dirname(path)
 
+        dirpath_hash = hashlib.md5(path.encode("utf-8")).hexdigest()
         for filename in filenames:
             mod_name, mod_ext = os.path.splitext(filename)
             if mod_ext.lower() != ".py":
                 continue
 
             filepath = os.path.join(path, filename)
+            sys_module_name = f"{dirpath_hash}.{mod_name}"
             try:
                 module = import_filepath(
-                    filepath, mod_name, sys_module_name=mod_name
+                    filepath, mod_name, sys_module_name=sys_module_name
+                )
 
             except Exception as err:  # noqa: BLE001
                 # we need broad exception to catch all possible errors.

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -260,15 +260,15 @@ def publish_plugins_discover(
 
         dirpath_hash = hashlib.md5(path.encode("utf-8")).hexdigest()
         for filename in filenames:
-            mod_name, mod_ext = os.path.splitext(filename)
-            if mod_ext.lower() != ".py":
+            basename, ext = os.path.splitext(filename)
+            if ext.lower() != ".py":
                 continue
 
             filepath = os.path.join(path, filename)
-            sys_module_name = f"{dirpath_hash}.{mod_name}"
+            module_name = f"{dirpath_hash}.{basename}"
             try:
                 module = import_filepath(
-                    filepath, mod_name, sys_module_name=sys_module_name
+                    filepath, module_name, sys_module_name=module_name
                 )
 
             except Exception as err:  # noqa: BLE001


### PR DESCRIPTION
## Changelog Description
Hash dirpath to plugin before storing it to `sys.modules`.

## Additional info
The issue with current approach is that if there are 2 filenames across all addons then only one will have stored module in sys.modules and only one can retrieve it's path. Hashing dirpath we're making sure that on next discovery we replace the module of the file in `sys.modules` and at the same time is unique enough to avoid clashes with other addons.

## Testing notes:
1. Add 2 plugins `PluginA` and `PluginB` to different addons (or different folders in one addon) but their filename must be same (e.g. `test_plugin.py`).
2. Run `publish_plugins_discover`, find those plugin classes and try to get their paths.
3. The paths should correspond to their real paths.

```python
import inspect
from ayon_core.pipeline.publish import publish_plugins_discover


result = publish_plugins_discover()
for plugin in result.plugins:
    if plugin.__name__ in ("PluginA", "PluginB"):
        print(plugin.__name__, inspect.getfile(plugin))
```

If you're running the code from tray console, then you might need to pass paths to `publish_plugins_discover` because no publish paths are registered in tray.