### PR TITLE
Detect rounding issues in media available_range when extracting (OTIO).

### DIFF
--- a/client/ayon_core/pipeline/editorial.py
+++ b/client/ayon_core/pipeline/editorial.py
@@ -7,6 +7,10 @@ import opentimelineio as otio
 from opentimelineio import opentime as _ot
 
 
+# https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/1822
+OTIO_EPSILON = 1e-9
+
+
 def otio_range_to_frame_range(otio_range):
     start = _ot.to_frames(
         otio_range.start_time, otio_range.start_time.rate)

--- a/client/ayon_core/plugins/publish/extract_otio_audio_tracks.py
+++ b/client/ayon_core/plugins/publish/extract_otio_audio_tracks.py
@@ -7,6 +7,7 @@ from ayon_core.lib import (
     get_ffmpeg_tool_args,
     run_subprocess
 )
+from ayon_core.pipeline import editorial
 
 
 class ExtractOtioAudioTracks(pyblish.api.ContextPlugin):
@@ -172,6 +173,14 @@ class ExtractOtioAudioTracks(pyblish.api.ContextPlugin):
                     clip_start = otio_clip.source_range.start_time
                     fps = clip_start.rate
                     conformed_av_start = media_av_start.rescaled_to(fps)
+
+                    # Avoid rounding issue on media available range.
+                    if clip_start.almost_equal(
+                        conformed_av_start,
+                        editorial.OTIO_EPSILON
+                    ):
+                        conformed_av_start = clip_start
+
                     # ffmpeg ignores embedded tc
                     start = clip_start - conformed_av_start
                     duration = otio_clip.source_range.duration

--- a/client/ayon_core/plugins/publish/extract_otio_review.py
+++ b/client/ayon_core/plugins/publish/extract_otio_review.py
@@ -23,7 +23,11 @@ from ayon_core.lib import (
     get_ffmpeg_tool_args,
     run_subprocess,
 )
-from ayon_core.pipeline import publish
+from ayon_core.pipeline import (
+    KnownPublishError,
+    editorial,
+    publish,
+)
 
 
 class ExtractOTIOReview(
@@ -97,8 +101,11 @@ class ExtractOTIOReview(
 
         # skip instance if no reviewable data available
         if (
-            not isinstance(otio_review_clips[0], otio.schema.Clip)
-            and len(otio_review_clips) == 1
+            len(otio_review_clips) == 1
+            and (
+                not isinstance(otio_review_clips[0], otio.schema.Clip)
+                or otio_review_clips[0].media_reference.is_missing_reference
+            )
         ):
             self.log.warning(
                 "Instance `{}` has nothing to process".format(instance))
@@ -248,7 +255,7 @@ class ExtractOTIOReview(
 
                 # Single video way.
                 # Extraction via FFmpeg.
-                else:
+                elif hasattr(media_ref, "target_url"):
                     path = media_ref.target_url
                     # Set extract range from 0 (FFmpeg ignores
                     #   embedded timecode).
@@ -370,6 +377,13 @@ class ExtractOTIOReview(
 
         avl_start = avl_range.start_time
 
+        # Avoid rounding issue on media available range.
+        if start.almost_equal(
+            avl_start,
+            editorial.OTIO_EPSILON
+        ):
+            avl_start = start
+
         # An additional gap is required before the available
         # range to conform source start point and head handles.
         if start < avl_start:
@@ -388,6 +402,14 @@ class ExtractOTIOReview(
         # (media duration is shorter then clip requirement).
         end_point = start + duration
         avl_end_point = avl_range.end_time_exclusive()
+
+        # Avoid rounding issue on media available range.
+        if end_point.almost_equal(
+            avl_end_point,
+            editorial.OTIO_EPSILON
+        ):
+            avl_end_point = end_point
+
         if end_point > avl_end_point:
             gap_duration = end_point - avl_end_point
             duration -= gap_duration
@@ -444,7 +466,7 @@ class ExtractOTIOReview(
         command = get_ffmpeg_tool_args("ffmpeg")
 
         input_extension = None
-        if sequence:
+        if sequence is not None:
             input_dir, collection, sequence_fps = sequence
             in_frame_start = min(collection.indexes)
 
@@ -478,7 +500,7 @@ class ExtractOTIOReview(
                 "-i", input_path
             ])
 
-        elif video:
+        elif video is not None:
             video_path, otio_range = video
             frame_start = otio_range.start_time.value
             input_fps = otio_range.start_time.rate
@@ -496,7 +518,7 @@ class ExtractOTIOReview(
                 "-i", video_path
             ])
 
-        elif gap:
+        elif gap is not None:
             sec_duration = frames_to_seconds(gap, self.actual_fps)
 
             # form command for rendering gap files
@@ -509,6 +531,9 @@ class ExtractOTIOReview(
                 ),
                 "-tune", "stillimage"
             ])
+
+        else:
+            raise KnownPublishError("Sequence, video or gap is required.")
 
         if video or sequence:
             command.extend([


### PR DESCRIPTION
## Changelog Description
Client came up with a timeline in Resolve with precision mismatches in media source range vs available ranges.
This was produced by native Resolve OTIO exporter but this precision mismatch was technically mistaken with gaps in our extractor.

when extracting review
````
[out#0/image2 @ 0000017d98a3fe00] Output file does not contain any stream
Error opening output file C:\Users\AppData\Local\Temp\ay_tmp_up3gcc67\shots_sh0320_sh0320.%02d.png.
Error opening output files: Invalid argument
````

when extracting audio
```
Invalid duration for option ss: -1.8947806286936004e-14
Error parsing options for input file P:\path\editorial\Locked\publish\review\review_Animatic_Main\v001\individualShots\shot__V1-0028.mp4.
Error opening input files: Invalid argument
```


## Additional info
Rounding issues with `otio.schema.RationalTime` is a known and reported issue:
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/1822

## Testing notes:
Quite hard to reproduce this round issue, but confirmed with the Client issues is fixed on its end.
So I'd say publishing plate/shot/audio should still work as before.