### PR TITLE
Local settings: Capture 'ItemNotFoundException' error if possible

### DIFF
--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -124,6 +124,10 @@ def get_addons_resources_dir(addon_name: str, *args) -> str:
     return os.path.join(addons_resources_dir, addon_name, *args)
 
 
+class _FakeException(Exception):
+    """Placeholder exception used if real exception is not available."""
+
+
 class AYONSecureRegistry:
     """Store information using keyring.
 
@@ -195,7 +199,17 @@ class AYONSecureRegistry:
         """
         import keyring
 
-        value = keyring.get_password(self._name, name)
+        # Capture 'ItemNotFoundException' exception (on linux)
+        try:
+            from secretstorage.exceptions import ItemNotFoundException
+        except ImportError:
+            ItemNotFoundException = _FakeException
+
+        try:
+            value = keyring.get_password(self._name, name)
+        except ItemNotFoundException:
+            value = None
+
         if value is not None:
             return value
 


### PR DESCRIPTION
## Changelog Description
Try to catch `ItemNotFoundException` exception from `secretstorage` if is available.

## Additional info
Backend `secretstorage` backend does raise error if item is not available, breaking the logic we have implemented. It looks like the `secretstorage` is used if 

### Exception
<img width="1830" height="684" alt="image" src="https://github.com/user-attachments/assets/1b2321a3-8aa9-4423-92a1-3ec87082e1e4" />


## Testing notes:
Not sure how to test this.
