### PR TITLE
Lib: Local settings code refactor

### DIFF
--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -238,15 +238,11 @@ class ASettingRegistry(ABC):
     mechanism for storing common items must be implemented in abstract
     methods.
 
-    Attributes:
-        _name (str): Registry names.
-
     """
     def __init__(self, name: str) -> None:
         super().__init__()
 
         self._name = name
-        self._items = {}
 
     def set_item(self, name: str, value: str) -> None:
         """Set item to settings registry.
@@ -263,7 +259,6 @@ class ASettingRegistry(ABC):
         """Set item value to registry."""
 
     def __setitem__(self, name: str, value: str) -> None:
-        self._items[name] = value
         self._set_item(name, value)
 
     def get_item(self, name: str) -> str:
@@ -302,7 +297,6 @@ class ASettingRegistry(ABC):
         """Delete item from registry."""
 
     def __delitem__(self, name: str) -> None:
-        del self._items[name]
         self._delete_item(name)
 
 

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -141,6 +141,7 @@ class AYONSecureRegistry:
 
     Args:
         name(str): Name of registry used as identifier for data.
+
     """
     def __init__(self, name: str) -> None:
         try:

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -244,22 +244,30 @@ class ASettingRegistry(ABC):
     def __init__(self, name: str) -> None:
         self._name = name
 
-    def set_item(self, name: str, value: str) -> None:
-        """Set item to settings registry.
-
-        Args:
-            name (str): Name of the item.
-            value (str): Value of the item.
-
-        """
-        self._set_item(name, value)
+    @abstractmethod
+    def _get_item(self, name: str) -> Any:
+        """Get item value from registry."""
 
     @abstractmethod
     def _set_item(self, name: str, value: str) -> None:
         """Set item value to registry."""
 
+    @abstractmethod
+    def _delete_item(self, name: str) -> None:
+        """Delete item from registry."""
+
+    def __getitem__(self, name: str) -> Any:
+        return self._get_item(name)
+
     def __setitem__(self, name: str, value: str) -> None:
         self._set_item(name, value)
+
+    def __delitem__(self, name: str) -> None:
+        self._delete_item(name)
+
+    @property
+    def name(self) -> str:
+        return self._name
 
     def get_item(self, name: str) -> str:
         """Get item from settings registry.
@@ -276,12 +284,15 @@ class ASettingRegistry(ABC):
         """
         return self._get_item(name)
 
-    @abstractmethod
-    def _get_item(self, name: str) -> str:
-        """Get item value from registry."""
+    def set_item(self, name: str, value: str) -> None:
+        """Set item to settings registry.
 
-    def __getitem__(self, name: str) -> Any:
-        return self._get_item(name)
+        Args:
+            name (str): Name of the item.
+            value (str): Value of the item.
+
+        """
+        self._set_item(name, value)
 
     def delete_item(self, name: str) -> None:
         """Delete item from settings registry.
@@ -290,13 +301,6 @@ class ASettingRegistry(ABC):
             name (str): Name of the item.
 
         """
-        self._delete_item(name)
-
-    @abstractmethod
-    def _delete_item(self, name: str) -> None:
-        """Delete item from registry."""
-
-    def __delitem__(self, name: str) -> None:
         self._delete_item(name)
 
 

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -243,7 +243,7 @@ class ASettingRegistry(ABC):
 
     """
     def __init__(self, name: str) -> None:
-        super(ASettingRegistry, self).__init__()
+        super().__init__()
 
         self._name = name
         self._items = {}
@@ -313,7 +313,7 @@ class IniSettingRegistry(ASettingRegistry):
 
     """
     def __init__(self, name: str, path: str) -> None:
-        super(IniSettingRegistry, self).__init__(name)
+        super().__init__(name)
         # get registry file
         self._registry_file = os.path.join(path, "{}.ini".format(name))
         if not os.path.exists(self._registry_file):
@@ -361,7 +361,7 @@ class IniSettingRegistry(ASettingRegistry):
         """
         # this does the some, overridden just for different docstring.
         # we cast value to str as ini options values must be strings.
-        super(IniSettingRegistry, self).set_item(name, str(value))
+        super().set_item(name, str(value))
 
     def get_item(self, name: str) -> str:
         """Gets item from settings ini file.
@@ -379,7 +379,7 @@ class IniSettingRegistry(ASettingRegistry):
             RegistryItemNotFound: If value doesn't exist.
 
         """
-        return super(IniSettingRegistry, self).get_item(name)
+        return super().get_item(name)
 
     @lru_cache(maxsize=32)
     def get_item_from_section(self, section: str, name: str) -> str:
@@ -451,7 +451,7 @@ class JSONSettingRegistry(ASettingRegistry):
     """Class using json file as storage."""
 
     def __init__(self, name: str, path: str) -> None:
-        super(JSONSettingRegistry, self).__init__(name)
+        super().__init__(name)
         #: str: name of registry file
         self._registry_file = os.path.join(path, "{}.json".format(name))
         now = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
@@ -544,7 +544,7 @@ class AYONSettingsRegistry(JSONSettingRegistry):
         if not name:
             name = "AYON_settings"
         path = get_launcher_storage_dir()
-        super(AYONSettingsRegistry, self).__init__(name, path)
+        super().__init__(name, path)
 
 
 def get_local_site_id():

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -177,6 +177,7 @@ class AYONSecureRegistry:
         import keyring
 
         keyring.set_password(self._name, name, value)
+        self.get_item.cache_clear()
 
     @lru_cache(maxsize=32)
     def get_item(

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -242,8 +242,6 @@ class ASettingRegistry(ABC):
 
     """
     def __init__(self, name: str) -> None:
-        super().__init__()
-
         self._name = name
 
     def set_item(self, name: str, value: str) -> None:

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -18,7 +18,7 @@ _PLACEHOLDER = object()
 
 # TODO should use 'KeyError' or 'Exception' as base
 class RegistryItemNotFound(ValueError):
-    """Raised when the item is not found in keyring."""
+    """Raised when the item is not found in the keyring."""
 
 
 class _Cache:
@@ -37,10 +37,10 @@ def get_ayon_appdirs(*args: str) -> str:
 
     Deprecated:
         Use 'get_launcher_local_dir' or 'get_launcher_storage_dir' based on
-            use-case. Deprecation added 24/08/09 (0.4.4-dev.1).
+            a use-case. Deprecation added 24/08/09 (0.4.4-dev.1).
 
     Args:
-        *args (Iterable[str]): Subdirectories/files in local app data dir.
+        *args (Iterable[str]): Subdirectories/files in the local app data dir.
 
     Returns:
         str: Path to directory/file in local app data dir.
@@ -58,7 +58,7 @@ def get_ayon_appdirs(*args: str) -> str:
 
 
 def get_launcher_storage_dir(*subdirs: str) -> str:
-    """Get storage directory for launcher.
+    """Get a storage directory for launcher.
 
     Storage directory is used for storing shims, addons, dependencies, etc.
 
@@ -83,14 +83,14 @@ def get_launcher_storage_dir(*subdirs: str) -> str:
 
 
 def get_launcher_local_dir(*subdirs: str) -> str:
-    """Get local directory for launcher.
+    """Get a local directory for launcher.
 
-    Local directory is used for storing machine or user specific data.
+    Local directory is used for storing machine or user-specific data.
 
-    The location is user specific.
+    The location is user-specific.
 
     Note:
-        This function should be called at least once on bootstrap.
+        This function should be called at least once on the bootstrap.
 
     Args:
         *subdirs (str): Subdirectories relative to local dir.
@@ -107,7 +107,7 @@ def get_launcher_local_dir(*subdirs: str) -> str:
 
 
 def get_addons_resources_dir(addon_name: str, *args) -> str:
-    """Get directory for storing resources for addons.
+    """Get a directory for storing resources for addons.
 
     Some addons might need to store ad-hoc resources that are not part of
         addon client package (e.g. because of size). Studio might define
@@ -117,7 +117,7 @@ def get_addons_resources_dir(addon_name: str, *args) -> str:
 
     Args:
         addon_name (str): Addon name.
-        *args (str): Subfolders in resources directory.
+        *args (str): Subfolders in the resources directory.
 
     Returns:
         str: Path to resources directory.
@@ -140,7 +140,7 @@ class AYONSecureRegistry:
     identify which data were created by AYON.
 
     Args:
-        name(str): Name of registry used as identifier for data.
+        name(str): Name of registry used as the identifier for data.
 
     """
     def __init__(self, name: str) -> None:
@@ -162,9 +162,9 @@ class AYONSecureRegistry:
         self._name = f"AYON/{name}"
 
     def set_item(self, name: str, value: str) -> None:
-        """Set sensitive item into system's keyring.
+        """Set sensitive item into the system's keyring.
 
-        This uses `Keyring module`_ to save sensitive stuff into system's
+        This uses `Keyring module`_ to save sensitive stuff into the system's
         keyring.
 
         Args:
@@ -184,19 +184,20 @@ class AYONSecureRegistry:
     def get_item(
         self, name: str, default: Any = _PLACEHOLDER
     ) -> Optional[str]:
-        """Get value of sensitive item from system's keyring.
+        """Get value of sensitive item from the system's keyring.
 
         See also `Keyring module`_
 
         Args:
             name (str): Name of the item.
-            default (Any): Default value if item is not available.
+            default (Any): Default value if the item is not available.
 
         Returns:
             value (str): Value of the item.
 
         Raises:
-            RegistryItemNotFound: If item doesn't exist and default is not defined.
+            RegistryItemNotFound: If the item doesn't exist and default
+                is not defined.
 
         .. _Keyring module:
             https://github.com/jaraco/keyring
@@ -216,7 +217,7 @@ class AYONSecureRegistry:
         )
 
     def delete_item(self, name: str) -> None:
-        """Delete value stored in system's keyring.
+        """Delete value stored in the system's keyring.
 
         See also `Keyring module`_
 
@@ -446,7 +447,7 @@ class IniSettingRegistry(ASettingRegistry):
 
 
 class JSONSettingRegistry(ASettingRegistry):
-    """Class using json file as storage."""
+    """Class using a json file as storage."""
 
     def __init__(self, name: str, path: str) -> None:
         super().__init__(name)

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -536,12 +536,21 @@ class AYONSettingsRegistry(JSONSettingRegistry):
     """Class handling AYON general settings registry.
 
     Args:
-        name (Optional[str]): Name of the registry.
+        name (Optional[str]): Name of the registry. Using 'None' or not
+            passing name is deprecated.
 
     """
     def __init__(self, name: Optional[str] = None) -> None:
         if not name:
             name = "AYON_settings"
+            warnings.warn(
+                (
+                    "Used 'AYONSettingsRegistry' without 'name' argument."
+                    " The argument will be required in future versions."
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         path = get_launcher_storage_dir()
         super().__init__(name, path)
 

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -497,6 +497,7 @@ class JSONSettingRegistry(ASettingRegistry):
             cfg.truncate(0)
             cfg.seek(0)
             json.dump(data, cfg, indent=4)
+        self._get_item.cache_clear()
 
     def _delete_item(self, name: str) -> None:
         with open(self._registry_file, "r+") as cfg:
@@ -505,6 +506,7 @@ class JSONSettingRegistry(ASettingRegistry):
             cfg.truncate(0)
             cfg.seek(0)
             json.dump(data, cfg, indent=4)
+        self._get_item.cache_clear()
 
 
 class AYONSettingsRegistry(JSONSettingRegistry):

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -484,21 +484,6 @@ class JSONSettingRegistry(ASettingRegistry):
                 )
         return value
 
-    def get_item(self, name: str) -> Any:
-        """Get item value from registry json.
-
-        Args:
-            name (str): Name of the item.
-
-        Returns:
-            value of the item
-
-        Raises:
-            RegistryItemNotFound: If the item is not found in registry file.
-
-        """
-        return self._get_item(name)
-
     def _set_item(self, name: str, value: str) -> None:
         """Set item value to the registry.
 
@@ -513,18 +498,7 @@ class JSONSettingRegistry(ASettingRegistry):
             cfg.seek(0)
             json.dump(data, cfg, indent=4)
 
-    def set_item(self, name: str, value: Any) -> None:
-        """Set item and its value into json registry file.
-
-        Args:
-            name (str): name of the item.
-            value (Any): value of the item.
-
-        """
-        self._set_item(name, value)
-
     def _delete_item(self, name: str) -> None:
-        self._get_item.cache_clear()
         with open(self._registry_file, "r+") as cfg:
             data = json.load(cfg)
             del data["registry"][name]

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -467,8 +467,8 @@ class JSONSettingRegistry(ASettingRegistry):
                 json.dump(header, cfg, indent=4)
 
     @lru_cache(maxsize=32)
-    def _get_item(self, name: str) -> Any:
-        """Get item value from registry json.
+    def _get_item(self, name: str) -> str:
+        """Get item value from the registry.
 
         Note:
             See :meth:`ayon_core.lib.JSONSettingRegistry.get_item`
@@ -499,8 +499,8 @@ class JSONSettingRegistry(ASettingRegistry):
         """
         return self._get_item(name)
 
-    def _set_item(self, name: str, value: Any) -> None:
-        """Set item value to registry json.
+    def _set_item(self, name: str, value: str) -> None:
+        """Set item value to the registry.
 
         Note:
             See :meth:`ayon_core.lib.JSONSettingRegistry.set_item`

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -158,7 +158,7 @@ class AYONSecureRegistry:
             keyring.set_keyring(Windows.WinVaultKeyring())
 
         # Force "AYON" prefix
-        self._name = "/".join(("AYON", name))
+        self._name = f"AYON/{name}"
 
     def set_item(self, name: str, value: str) -> None:
         """Set sensitive item into system's keyring.
@@ -315,12 +315,12 @@ class IniSettingRegistry(ASettingRegistry):
     def __init__(self, name: str, path: str) -> None:
         super().__init__(name)
         # get registry file
-        self._registry_file = os.path.join(path, "{}.ini".format(name))
+        self._registry_file = os.path.join(path, f"{name}.ini")
         if not os.path.exists(self._registry_file):
             with open(self._registry_file, mode="w") as cfg:
                 print("# Settings registry", cfg)
                 now = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
-                print("# {}".format(now), cfg)
+                print(f"# {now}", cfg)
 
     def set_item_section(self, section: str, name: str, value: str) -> None:
         """Set item to specific section of ini registry.
@@ -452,8 +452,7 @@ class JSONSettingRegistry(ASettingRegistry):
 
     def __init__(self, name: str, path: str) -> None:
         super().__init__(name)
-        #: str: name of registry file
-        self._registry_file = os.path.join(path, "{}.json".format(name))
+        self._registry_file = os.path.join(path, f"{name}.json")
         now = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
         header = {
             "__metadata__": {"generated": now},

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -235,11 +235,7 @@ class AYONSecureRegistry:
 
 
 class ASettingRegistry(ABC):
-    """Abstract class defining structure of **SettingRegistry** class.
-
-    It is implementing methods to store secure items into keyring, otherwise
-    mechanism for storing common items must be implemented in abstract
-    methods.
+    """Abstract class to defining structure of registry class.
 
     """
     def __init__(self, name: str) -> None:

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -454,8 +454,10 @@ class JSONSettingRegistry(ASettingRegistry):
             "registry": {}
         }
 
-        if not os.path.exists(os.path.dirname(self._registry_file)):
-            os.makedirs(os.path.dirname(self._registry_file), exist_ok=True)
+        # Use 'os.path.dirname' in case someone uses slashes in 'name'
+        dirpath = os.path.dirname(self._registry_file)
+        if not os.path.exists(dirpath):
+            os.makedirs(dirpath, exist_ok=True)
         if not os.path.exists(self._registry_file):
             with open(self._registry_file, mode="w") as cfg:
                 json.dump(header, cfg, indent=4)


### PR DESCRIPTION
## Changelog Description
Quick maintanance PR for local settings.

## Additional info
- Use dedicated exception `RegistryItemNotFound` for missing registry item value instead of `ValueError`.
- `AYONSettingsRegistry` requires `name` argument -> dangerous for possible clashes if used by multiple places.
- Fix possible issue with registry caching if `set_item` is called (cache for `get_item` was not cleared).
- Removed python 2 compatibility of type hints and super calls.
- Use f-string if possible.

## Testing notes:
1. Validate code changes.
