### PR TITLE
Workfiles: Workfile entities path mapping

### DIFF
--- a/client/ayon_core/host/interfaces/workfiles.py
+++ b/client/ayon_core/host/interfaces/workfiles.py
@@ -1072,10 +1072,13 @@ class IWorkfileHost:
             prepared_data=prepared_data,
         )
 
-        workfile_entities_by_path = {
-            workfile_entity["path"]: workfile_entity
-            for workfile_entity in list_workfiles_context.workfile_entities
-        }
+        workfile_entities_by_path = {}
+        for workfile_entity in list_workfiles_context.workfile_entities:
+            rootless_path = workfile_entity["path"]
+            path = os.path.normpath(
+                list_workfiles_context.anatomy.fill_root(rootless_path)
+            )
+            workfile_entities_by_path[path] = workfile_entity
 
         workdir_data = get_template_data(
             list_workfiles_context.project_entity,
@@ -1114,10 +1117,10 @@ class IWorkfileHost:
 
             rootless_path = f"{rootless_workdir}/{filename}"
             workfile_entity = workfile_entities_by_path.pop(
-                rootless_path, None
+                filepath, None
             )
             version = comment = None
-            if workfile_entity:
+            if workfile_entity is not None:
                 _data = workfile_entity["data"]
                 version = _data.get("version")
                 comment = _data.get("comment")
@@ -1137,7 +1140,7 @@ class IWorkfileHost:
             )
             items.append(item)
 
-        for workfile_entity in workfile_entities_by_path.values():
+        for filepath, workfile_entity in workfile_entities_by_path.items():
             # Workfile entity is not in the filesystem
             #   but it is in the database
             rootless_path = workfile_entity["path"]
@@ -1154,7 +1157,6 @@ class IWorkfileHost:
                 version = parsed_data.version
                 comment = parsed_data.comment
 
-            filepath = list_workfiles_context.anatomy.fill_root(rootless_path)
             available = os.path.exists(filepath)
             items.append(WorkfileInfo.new(
                 filepath,


### PR DESCRIPTION
## Changelog Description
Use filepath for mapping of workfiles entities instead of rootless path. Allow workfiles to be available if are not available in current workdir.

## Additional info
Rootless path on workfile entity might use different root that has the same value which would make the workfile not available. If workfile has workfile entity but does not lead to current workdir it can still be available.

## Testing notes:
1. Make sure you have 2 roots in a project and both roots have same value.
2. Create a workfile.
3. Change workdir template to use the other root.
4. Workfiles tools should be able to show the workfile.
