### PR TITLE
Addons: Plugin paths interface

### DIFF
--- a/client/ayon_core/addon/base.py
+++ b/client/ayon_core/addon/base.py
@@ -8,6 +8,7 @@ import inspect
 import logging
 import threading
 import collections
+import warnings
 from uuid import uuid4
 from abc import ABC, abstractmethod
 from typing import Optional
@@ -815,10 +816,26 @@ class AddonsManager:
 
         Unknown keys are logged out.
 
+        Deprecated:
+            Use targeted methods 'collect_launcher_action_paths',
+                'collect_create_plugin_paths', 'collect_load_plugin_paths',
+                'collect_publish_plugin_paths' and
+                 'collect_inventory_action_paths' to collect plugin paths.
+
         Returns:
             dict: Output is dictionary with keys "publish", "create", "load",
                 "actions" and "inventory" each containing list of paths.
+
         """
+        warnings.warn(
+            "Used deprecated method 'collect_plugin_paths'. Please use"
+            " targeted methods 'collect_launcher_action_paths',"
+            " 'collect_create_plugin_paths', 'collect_load_plugin_paths'"
+            " 'collect_publish_plugin_paths' and"
+            " 'collect_inventory_action_paths'",
+            DeprecationWarning,
+            stacklevel=2
+        )
         # Output structure
         output = {
             "publish": [],

--- a/client/ayon_core/addon/base.py
+++ b/client/ayon_core/addon/base.py
@@ -891,24 +891,28 @@ class AddonsManager:
             if not isinstance(addon, IPluginPaths):
                 continue
 
+            paths = None
             method = getattr(addon, method_name)
             try:
                 paths = method(*args, **kwargs)
             except Exception:
                 self.log.warning(
-                    (
-                        "Failed to get plugin paths from addon"
-                        " '{}' using '{}'."
-                    ).format(addon.__class__.__name__, method_name),
+                    "Failed to get plugin paths from addon"
+                    f" '{addon.name}' using '{method_name}'.",
                     exc_info=True
                 )
+
+            if not paths:
                 continue
 
-            if paths:
-                # Convert to list if value is not list
-                if not isinstance(paths, (list, tuple, set)):
-                    paths = [paths]
-                output.extend(paths)
+            if isinstance(paths, str):
+                paths = [paths]
+                self.log.warning(
+                    f"Addon '{addon.name}' returned invalid output type"
+                    f" from '{method_name}'."
+                    f" Got 'str' expected 'list[str]'."
+                )
+            output.extend(paths)
         return output
 
     def collect_launcher_action_paths(self):

--- a/client/ayon_core/addon/interfaces.py
+++ b/client/ayon_core/addon/interfaces.py
@@ -61,7 +61,8 @@ class IPluginPaths(AYONInterface):
         return {}
 
     def _get_plugin_paths_by_type(
-            self, plugin_type: str) -> list[str]:
+        self, plugin_type: str
+    ) -> list[str]:
         """Get plugin paths by type.
 
         Args:

--- a/client/ayon_core/addon/interfaces.py
+++ b/client/ayon_core/addon/interfaces.py
@@ -1,6 +1,7 @@
 """Addon interfaces for AYON."""
 from __future__ import annotations
 
+import warnings
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Callable, Optional, Type
 
@@ -39,14 +40,7 @@ class AYONInterface(metaclass=_AYONInterfaceMeta):
 
 
 class IPluginPaths(AYONInterface):
-    """Addon has plugin paths to return.
-
-    Expected result is dictionary with keys "publish", "create", "load",
-    "actions" or "inventory" and values as list or string.
-    {
-        "publish": ["path/to/publish_plugins"]
-    }
-    """
+    """Addon wants to register plugin paths."""
 
     def get_plugin_paths(self) -> dict[str, list[str]]:
         """Return plugin paths for addon.
@@ -87,6 +81,25 @@ class IPluginPaths(AYONInterface):
 
         if not isinstance(paths, (list, tuple, set)):
             paths = [paths]
+
+        new_function_name = "get_launcher_action_paths"
+        if plugin_type == "create":
+            new_function_name = "get_create_plugin_paths"
+        elif plugin_type == "load":
+            new_function_name = "get_load_plugin_paths"
+        elif plugin_type == "publish":
+            new_function_name = "get_publish_plugin_paths"
+        elif plugin_type == "inventory":
+            new_function_name = "get_inventory_action_paths"
+
+        warnings.warn(
+            f"Addon '{self.name}' returns '{plugin_type}' paths using"
+            " 'get_plugin_paths' method. Please implement"
+            f" '{new_function_name}' instead.",
+            DeprecationWarning,
+            stacklevel=2
+
+        )
         return paths
 
     def get_launcher_action_paths(self) -> list[str]:

--- a/client/ayon_core/addon/interfaces.py
+++ b/client/ayon_core/addon/interfaces.py
@@ -48,14 +48,23 @@ class IPluginPaths(AYONInterface):
     }
     """
 
-    @abstractmethod
     def get_plugin_paths(self) -> dict[str, list[str]]:
         """Return plugin paths for addon.
+
+        This method was abstract (required) in the past, so raise the required
+            'core' addon version when 'get_plugin_paths' is removed from
+            addon.
+
+        Deprecated:
+            Please implement specific methods 'get_create_plugin_paths',
+                'get_load_plugin_paths', 'get_inventory_action_paths' and
+                'get_publish_plugin_paths' to return plugin paths.
 
         Returns:
             dict[str, list[str]]: Plugin paths for addon.
 
         """
+        return {}
 
     def _get_plugin_paths_by_type(
             self, plugin_type: str) -> list[str]:

--- a/client/ayon_core/addon/interfaces.py
+++ b/client/ayon_core/addon/interfaces.py
@@ -99,7 +99,6 @@ class IPluginPaths(AYONInterface):
             f" '{new_function_name}' instead.",
             DeprecationWarning,
             stacklevel=2
-
         )
         return paths
 


### PR DESCRIPTION
## Changelog Description
First step to remove `get_plugin_paths` method from `IPluginPaths`.

## Additional info
The method was over the time expended to separate methods for each plugin type, now the specific methods do expect more arguments (usually host name) and the `get_plugin_paths` did become deprecated at that moment and also is complicating the readability with related `AddonsManager` method `collect_plugin_paths`.

First of all the method is not abstract anymore, so it is not required to be implemented. Added warning everytime the method is called and returns paths.

Added warning if the output of plugin path getters is string instead of list of strings.

## How to prepare addon for full deprecation
First of all keep `get_plugin_paths` to keep support with older core addon but return empty dictionary. Reimplement `get_create_plugin_paths`, `get_load_plugin_paths`, `get_inventory_action_paths` or `get_publish_plugin_paths` if you want to register paths for the plugin type.

Method `get_launcher_action_paths` is in grey zone now as webactions should be used instead, but some features can't be achieved with webactions at this moment, but is still available.

## Testing notes:
1. Validate the code and logic changes.
2. All plugins in your addons are registered and available.