### PR TITLE
Editorial: Added safe importing of opentimelineio

### DIFF
--- a/client/ayon_core/plugins/publish/collect_otio_frame_ranges.py
+++ b/client/ayon_core/plugins/publish/collect_otio_frame_ranges.py
@@ -8,13 +8,7 @@ This module contains a unified plugin that handles:
 
 from pprint import pformat
 
-import opentimelineio as otio
 import pyblish.api
-from ayon_core.pipeline.editorial import (
-    get_media_range_with_retimes,
-    otio_range_to_frame_range,
-    otio_range_with_handles,
-)
 
 
 def validate_otio_clip(instance, logger):
@@ -74,6 +68,8 @@ class CollectOtioRanges(pyblish.api.InstancePlugin):
         if not validate_otio_clip(instance, self.log):
             return
 
+        import opentimelineio as otio
+
         otio_clip = instance.data["otioClip"]
 
         # Collect timeline ranges if workfile start frame is available
@@ -100,6 +96,11 @@ class CollectOtioRanges(pyblish.api.InstancePlugin):
 
     def _collect_timeline_ranges(self, instance, otio_clip):
         """Collect basic timeline frame ranges."""
+        from ayon_core.pipeline.editorial import (
+            otio_range_to_frame_range,
+            otio_range_with_handles,
+        )
+
         workfile_start = instance.data["workfileFrameStart"]
 
         # Get timeline ranges
@@ -129,6 +130,8 @@ class CollectOtioRanges(pyblish.api.InstancePlugin):
 
     def _collect_source_ranges(self, instance, otio_clip):
         """Collect source media frame ranges."""
+        import opentimelineio as otio
+
         # Get source ranges
         otio_src_range = otio_clip.source_range
         otio_available_range = otio_clip.available_range()
@@ -178,6 +181,8 @@ class CollectOtioRanges(pyblish.api.InstancePlugin):
 
     def _collect_retimed_ranges(self, instance, otio_clip):
         """Handle retimed clip frame ranges."""
+        from ayon_core.pipeline.editorial import get_media_range_with_retimes
+
         retimed_attributes = get_media_range_with_retimes(otio_clip, 0, 0)
         self.log.debug(f"Retimed attributes: {retimed_attributes}")
 

--- a/client/ayon_core/plugins/publish/extract_otio_audio_tracks.py
+++ b/client/ayon_core/plugins/publish/extract_otio_audio_tracks.py
@@ -7,7 +7,6 @@ from ayon_core.lib import (
     get_ffmpeg_tool_args,
     run_subprocess
 )
-from ayon_core.pipeline import editorial
 
 
 class ExtractOtioAudioTracks(pyblish.api.ContextPlugin):
@@ -159,6 +158,7 @@ class ExtractOtioAudioTracks(pyblish.api.ContextPlugin):
         """
         # Not all hosts can import this module.
         import opentimelineio as otio
+        from ayon_core.pipeline.editorial import OTIO_EPSILON
 
         output = []
         # go trough all audio tracks

--- a/client/ayon_core/plugins/publish/extract_otio_review.py
+++ b/client/ayon_core/plugins/publish/extract_otio_review.py
@@ -25,7 +25,6 @@ from ayon_core.lib import (
 )
 from ayon_core.pipeline import (
     KnownPublishError,
-    editorial,
     publish,
 )
 
@@ -359,6 +358,7 @@ class ExtractOTIOReview(
         import opentimelineio as otio
         from ayon_core.pipeline.editorial import (
             trim_media_range,
+            OTIO_EPSILON,
         )
 
         def _round_to_frame(rational_time):
@@ -380,7 +380,7 @@ class ExtractOTIOReview(
         # Avoid rounding issue on media available range.
         if start.almost_equal(
             avl_start,
-            editorial.OTIO_EPSILON
+            OTIO_EPSILON
         ):
             avl_start = start
 


### PR DESCRIPTION
## Changelog Description
Don't import otio module if it is not necessary.

## Additional info
Moved imports that do need OTIO into the functions that do use them.

## Testing notes:
1. No crashed plugins because of missing `opentimelineio` in any DCC that does not have it (e.g. maya).
