### PR TITLE
Workfiles: Make sure workdir exists

### DIFF
--- a/client/ayon_core/host/interfaces/workfiles.py
+++ b/client/ayon_core/host/interfaces/workfiles.py
@@ -944,6 +944,8 @@ class IWorkfileHost:
         self._emit_workfile_save_event(event_data, after_save=False)
 
         workdir = os.path.dirname(filepath)
+        if not os.path.exists(workdir):
+            os.makedirs(workdir, exist_ok=True)
 
         # Set 'AYON_WORKDIR' environment variable
         os.environ["AYON_WORKDIR"] = workdir


### PR DESCRIPTION
## Changelog Description
Make sure the workdir exists before workfile is being saved.

## Additional info
The creation of workdir was lost in void.

## Testing notes:
1. Launch a DCC.
2. Make sure you don't have existing workdir for a task of your choice.
3. Using workfiles tool select the task and try to save workfile.
4. It should not fail.