### PR TITLE
Workfiles tool: Allow copy of published workfile without task

### DIFF
--- a/client/ayon_core/tools/workfiles/widgets/files_widget.py
+++ b/client/ayon_core/tools/workfiles/widgets/files_widget.py
@@ -287,10 +287,11 @@ class FilesWidget(QtWidgets.QWidget):
     def _update_published_btns_state(self):
         enabled = (
             self._valid_representation_id
-            and self._valid_selected_context
             and self._is_save_enabled
         )
-        self._published_btn_copy_n_open.setEnabled(enabled)
+        self._published_btn_copy_n_open.setEnabled(
+            enabled and self._valid_selected_context
+        )
         self._published_btn_change_context.setEnabled(enabled)
 
     def _update_workarea_btns_state(self):


### PR DESCRIPTION
## Changelog Description
It is possible to copy published workfile without task.

## Additional info
It is very unlikely to happen but there might be workfiles without a task in that case workfiles tool does now allow to copy it using copy to context button.

## Testing notes:
1. Make sure you have published workfile without a task - e.g. from traypublisher or set `taskId` on the version using API.
2. Open workfiles tool in the DCC.
3. Select the published workfile version.
4. You should be able to copy it.

Resolves https://github.com/ynput/ayon-core/issues/1410