### PR TITLE
Scene Inventory: Restore saved painter

### DIFF
--- a/client/ayon_core/tools/sceneinventory/select_version_dialog.py
+++ b/client/ayon_core/tools/sceneinventory/select_version_dialog.py
@@ -127,6 +127,7 @@ class SelectVersionComboBox(QtWidgets.QComboBox):
             status_text_rect.setLeft(icon_rect.right() + 2)
 
         if status_text_rect.width() <= 0:
+            painter.restore()
             return
 
         if status_text_rect.width() < metrics.width(status_name):
@@ -144,6 +145,7 @@ class SelectVersionComboBox(QtWidgets.QComboBox):
             QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter,
             status_name
         )
+        painter.restore()
 
     def set_current_index(self, index):
         model = self._combo_view.model()


### PR DESCRIPTION
## Changelog Description
Make sure QPainter is cleaned up when done.

## Additional info
The painter has kept saved state at the end of painting which migh cause a warning in Qt (Happens in Silhouette).

## Testing notes:
1. No warning should be printed.
