### PR TITLE
Implement upload retries for reviewables and add user-friendly timeout error; update validation help

### DIFF
--- a/client/ayon_core/plugins/publish/help/validate_publish_dir.xml
+++ b/client/ayon_core/plugins/publish/help/validate_publish_dir.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <root>
+<error id="upload_timeout">
+<title>Review upload timed out</title>
+<description>
+## Review upload failed after retries
+
+The connection to the AYON server timed out while uploading a reviewable file.
+
+### How to repair?
+
+1. Try publishing again. Intermittent network hiccups often resolve on retry.
+2. Ensure your network/VPN is stable and large uploads are allowed.
+3. If it keeps failing, try again later or contact your admin.
+
+<pre>File: {file}
+Error: {error}</pre>
+
+</description>
+</error>
 <error id="main">
 <title>Source directory not collected</title>
 <description>


### PR DESCRIPTION
While we don't use AYON reviews, its baked into the publishes so when I ran into numerous timeouts today, which almost always were fine the 2nd attempt to publish, I created this pull request.

## Changelog Description
- Adds exponential backoff retries (3) when uploading reviewable files to AYON.
- Raises a clear, user-facing validation error on repeated timeouts with actionable help text.
- Updates validation help docs to guide users when review uploads fail.

## Additional info
Retry policy: up to 3 attempts with backoff (2s, 4s, 8s). On exhaustion, raises PublishXmlValidationError with key="upload_timeout" and formatting data for file and error.

## Testing notes:
Honestly not sure if you do not have a way to simulate the timeout. The timeouts were common today so I was able to test.
