### PR TITLE
Disable vertical and horizontal scrollbars in report page and log ite…

### DIFF
--- a/client/ayon_core/tools/publisher/widgets/report_page.py
+++ b/client/ayon_core/tools/publisher/widgets/report_page.py
@@ -255,6 +255,9 @@ class PublishErrorInstanceList(QtWidgets.QListView):
         self.setObjectName("PublishErrorInstanceList")
 
         self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        # Disable vertical scrollbar to avoid nested scrollbars inside the
+        # main logs view. The view auto-sizes its height to the content.
+        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
 
     def minimumSizeHint(self):
@@ -1133,6 +1136,10 @@ class LogItemMessage(QtWidgets.QTextEdit):
         pal.setColor(QtGui.QPalette.Base, QtCore.Qt.transparent)
         self.setPalette(pal)
         self.setContentsMargins(0, 0, 0, 0)
+        # Disable inner scrollbars so only the main logs view scrolls.
+        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+
         viewport = self.viewport()
         viewport.setContentsMargins(0, 0, 0, 0)
 


### PR DESCRIPTION
The publish report can create extreme flickering due to nested scrollbars rendering it useless and providing a poor user experience even after a successful publish. This pull request fixes that issue in most cases.