### PR TITLE
OCIO: Use "max" for host group to get the correct ocio environment variable

### DIFF
--- a/client/ayon_core/hooks/pre_ocio_hook.py
+++ b/client/ayon_core/hooks/pre_ocio_hook.py
@@ -14,7 +14,7 @@ class OCIOEnvHook(PreLaunchHook):
         "fusion",
         "blender",
         "aftereffects",
-        "3dsmax",
+        "max",
         "houdini",
         "maya",
         "nuke",


### PR DESCRIPTION
## Changelog Description
This PR is to edit "max" instead of "3dsmax" in host group so that the OCIO-related environment variable being colllected.
This fixes the ocio misconfiguring issue in 3dsmax.

<img width="1413" height="703" alt="image" src="https://github.com/user-attachments/assets/d8691f55-5c73-461e-ae04-0b3c49d24498" />


## Additional info
n/a

## Testing notes:
1. Build Core Addon with this PR
2. Launch 3dsMax
3. The error shown in the screenshot should be gone
