### PR TITLE
Resolve environment variables in dev bundle addon paths

### DIFF
--- a/client/ayon_core/addon/base.py
+++ b/client/ayon_core/addon/base.py
@@ -302,6 +302,9 @@ def _load_ayon_addons(log):
         milestone_version = MOVED_ADDON_MILESTONE_VERSIONS.get(addon_name)
         if use_dev_path:
             addon_dir = dev_addon_info["path"]
+            if addon_dir:
+                addon_dir.format(os.environ)
+
             if not addon_dir or not os.path.exists(addon_dir):
                 log.warning((
                     "Dev addon {} {} path does not exists. Path \"{}\""

--- a/client/ayon_core/addon/base.py
+++ b/client/ayon_core/addon/base.py
@@ -303,7 +303,9 @@ def _load_ayon_addons(log):
         if use_dev_path:
             addon_dir = dev_addon_info["path"]
             if addon_dir:
-                addon_dir = addon_dir.format(**os.environ)
+                addon_dir = os.path.expandvars(
+                    addon_dir.format_map(os.environ)
+                )
 
             if not addon_dir or not os.path.exists(addon_dir):
                 log.warning((

--- a/client/ayon_core/addon/base.py
+++ b/client/ayon_core/addon/base.py
@@ -303,7 +303,7 @@ def _load_ayon_addons(log):
         if use_dev_path:
             addon_dir = dev_addon_info["path"]
             if addon_dir:
-                addon_dir.format(os.environ)
+                addon_dir = addon_dir.format(**os.environ)
 
             if not addon_dir or not os.path.exists(addon_dir):
                 log.warning((


### PR DESCRIPTION
## Changelog Description
Add support of resolution of environment variables in dev bundle addon paths. You can use standard `{FOO_BAR}` format within the path. This can be used to set dev bundle to work on multiple platforms provided the environment variable is set there.

## Additional info
This also needs PR in `ayon-launcher` https://github.com/ynput/ayon-launcher/pull/253

## Testing notes:
1. In dev bundle, set path to addons like `{DEV_ADDONS}/ayon-core/client`
2. Set this environment variable so the path exist and can be resolved
3. Run AYON
