### PR TITLE
Loader: Product type icons

### DIFF
--- a/client/ayon_core/tools/common_models/__init__.py
+++ b/client/ayon_core/tools/common_models/__init__.py
@@ -10,6 +10,7 @@ from .projects import (
     PROJECTS_MODEL_SENDER,
     FolderTypeItem,
     TaskTypeItem,
+    ProductTypeIconMapping,
 )
 from .hierarchy import (
     FolderItem,
@@ -34,6 +35,7 @@ __all__ = (
     "PROJECTS_MODEL_SENDER",
     "FolderTypeItem",
     "TaskTypeItem",
+    "ProductTypeIconMapping",
 
     "FolderItem",
     "TaskItem",

--- a/client/ayon_core/tools/common_models/projects.py
+++ b/client/ayon_core/tools/common_models/projects.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 from abc import ABC, abstractmethod
-from typing import Dict, Any
+from typing import Any, Optional
 from dataclasses import dataclass
 
 import ayon_api
@@ -51,7 +51,7 @@ class StatusItem:
         self.icon: str = icon
         self.state: str = state
 
-    def to_data(self) -> Dict[str, Any]:
+    def to_data(self) -> dict[str, Any]:
         return {
             "name": self.name,
             "color": self.color,
@@ -218,6 +218,54 @@ class ProjectItem:
         return cls(**data)
 
 
+class ProductTypeIconMapping:
+    def __init__(
+        self,
+        default: Optional[dict[str, str]] = None,
+        definitions: Optional[list[dict[str, str]]] = None,
+    ):
+        self._default = default or {}
+        self._definitions = definitions or []
+
+        self._default_def = None
+        self._definitions_by_name = None
+
+    def get_icon(
+        self,
+        product_base_type: Optional[str] = None,
+        product_type: Optional[str] = None,
+    ) -> dict[str, str]:
+        defs = self._get_defs_by_name()
+        icon = defs.get(product_type)
+        if icon is None:
+            icon = defs.get(product_base_type)
+            if icon is None:
+                icon = self._get_default_def()
+        return icon.copy()
+
+    def _get_default_def(self) -> dict[str, str]:
+        if self._default_def is None:
+            self._default_def = {
+                "type": "material-symbols",
+                "name": self._default.get("icon", "deployed_code"),
+                "color": self._default.get("color", "#cccccc"),
+            }
+
+        return self._default_def
+
+    def _get_defs_by_name(self) -> dict[str, dict[str, str]]:
+        if self._definitions_by_name is None:
+            self._definitions_by_name = {
+                product_base_type_def["name"]: {
+                    "type": "material-symbols",
+                    "name": product_base_type_def.get("icon", "deployed_code"),
+                    "color": product_base_type_def.get("color", "#cccccc"),
+                }
+                for product_base_type_def in self._definitions
+            }
+        return self._definitions_by_name
+
+
 def _get_project_items_from_entitiy(
     projects: list[dict[str, Any]]
 ) -> list[ProjectItem]:
@@ -242,6 +290,9 @@ class ProjectsModel(object):
         self._projects_by_name = NestedCacheItem(
             levels=1, default_factory=list
         )
+        self._product_type_icons_mapping = NestedCacheItem(
+            levels=1, default_factory=ProductTypeIconMapping
+        )
         self._project_statuses_cache = {}
         self._folder_types_cache = {}
         self._task_types_cache = {}
@@ -255,6 +306,7 @@ class ProjectsModel(object):
         self._task_types_cache = {}
         self._projects_cache.reset()
         self._projects_by_name.reset()
+        self._product_type_icons_mapping.reset()
 
     def refresh(self):
         """Refresh project items.
@@ -389,6 +441,27 @@ class ProjectsModel(object):
             self._task_types_cache,
             self._task_type_items_getter,
         )
+
+    def get_product_type_icons_mapping(
+        self, project_name: Optional[str]
+    ) -> ProductTypeIconMapping:
+        cache = self._product_type_icons_mapping[project_name]
+        if cache.is_valid:
+            return cache.get_data()
+
+        project_entity = self.get_project_entity(project_name)
+        icons_mapping = ProductTypeIconMapping()
+        if project_entity:
+            product_base_types = (
+                project_entity["config"].get("productBaseTypes", {})
+            )
+            icons_mapping = ProductTypeIconMapping(
+                product_base_types.get("default"),
+                product_base_types.get("definitions")
+            )
+
+        cache.update_data(icons_mapping)
+        return icons_mapping
 
     def _get_project_items(
         self, project_name, sender, item_type, cache_obj, getter

--- a/client/ayon_core/tools/loader/abstract.py
+++ b/client/ayon_core/tools/loader/abstract.py
@@ -9,7 +9,11 @@ from ayon_core.lib.attribute_definitions import (
     deserialize_attr_defs,
     serialize_attr_defs,
 )
-from ayon_core.tools.common_models import TaskItem, TagItem
+from ayon_core.tools.common_models import (
+    TaskItem,
+    TagItem,
+    ProductTypeIconMapping,
+)
 
 
 class ProductTypeItem:
@@ -492,8 +496,8 @@ class BackendLoaderController(_BaseLoaderController):
             topic (str): Event topic name.
             data (Optional[dict[str, Any]]): Event data.
             source (Optional[str]): Event source.
-        """
 
+        """
         pass
 
     @abstractmethod
@@ -502,14 +506,20 @@ class BackendLoaderController(_BaseLoaderController):
 
         Returns:
             set[str]: Set of loaded product ids.
-        """
 
+        """
         pass
 
     @abstractmethod
-    def get_project_entity(
+    def get_product_type_icons_mapping(
         self, project_name: Optional[str]
-    ) -> Optional[dict[str, Any]]:
+    ) -> ProductTypeIconMapping:
+        """Product type icons mapping.
+
+        Returns:
+            ProductTypeIconMapping: Product type icons mapping.
+
+        """
         pass
 
 

--- a/client/ayon_core/tools/loader/abstract.py
+++ b/client/ayon_core/tools/loader/abstract.py
@@ -78,7 +78,6 @@ class ProductItem:
         product_type (str): Product type.
         product_name (str): Product name.
         product_icon (dict[str, Any]): Product icon definition.
-        product_type_icon (dict[str, Any]): Product type icon definition.
         product_in_scene (bool): Is product in scene (only when used in DCC).
         group_name (str): Group name.
         folder_id (str): Folder id.
@@ -93,8 +92,6 @@ class ProductItem:
         product_base_type: str,
         product_name: str,
         product_icon: dict[str, Any],
-        product_type_icon: dict[str, Any],
-        product_base_type_icon: dict[str, Any],
         group_name: str,
         folder_id: str,
         folder_label: str,
@@ -106,8 +103,6 @@ class ProductItem:
         self.product_base_type = product_base_type
         self.product_name = product_name
         self.product_icon = product_icon
-        self.product_type_icon = product_type_icon
-        self.product_base_type_icon = product_base_type_icon
         self.product_in_scene = product_in_scene
         self.group_name = group_name
         self.folder_id = folder_id
@@ -121,8 +116,6 @@ class ProductItem:
             "product_base_type": self.product_base_type,
             "product_name": self.product_name,
             "product_icon": self.product_icon,
-            "product_type_icon": self.product_type_icon,
-            "product_base_type_icon": self.product_base_type_icon,
             "product_in_scene": self.product_in_scene,
             "group_name": self.group_name,
             "folder_id": self.folder_id,

--- a/client/ayon_core/tools/loader/abstract.py
+++ b/client/ayon_core/tools/loader/abstract.py
@@ -513,6 +513,12 @@ class BackendLoaderController(_BaseLoaderController):
 
         pass
 
+    @abstractmethod
+    def get_project_entity(
+        self, project_name: Optional[str]
+    ) -> Optional[dict[str, Any]]:
+        pass
+
 
 class FrontendLoaderController(_BaseLoaderController):
     @abstractmethod

--- a/client/ayon_core/tools/loader/control.py
+++ b/client/ayon_core/tools/loader/control.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from typing import Optional, Any
 
 import ayon_api
 
@@ -187,6 +188,11 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
     # Entity model wrappers
     def get_project_items(self, sender=None):
         return self._projects_model.get_project_items(sender)
+
+    def get_project_entity(
+        self, project_name: Optional[str]
+    ) -> Optional[dict[str, Any]]:
+        return self._projects_model.get_project_entity(project_name)
 
     def get_folder_type_items(self, project_name, sender=None):
         return self._projects_model.get_folder_type_items(

--- a/client/ayon_core/tools/loader/control.py
+++ b/client/ayon_core/tools/loader/control.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Optional, Any
+from typing import Optional
 
 import ayon_api
 

--- a/client/ayon_core/tools/loader/control.py
+++ b/client/ayon_core/tools/loader/control.py
@@ -17,6 +17,7 @@ from ayon_core.tools.common_models import (
     HierarchyModel,
     ThumbnailsModel,
     TagItem,
+    ProductTypeIconMapping,
 )
 
 from .abstract import (
@@ -189,11 +190,6 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
     def get_project_items(self, sender=None):
         return self._projects_model.get_project_items(sender)
 
-    def get_project_entity(
-        self, project_name: Optional[str]
-    ) -> Optional[dict[str, Any]]:
-        return self._projects_model.get_project_entity(project_name)
-
     def get_folder_type_items(self, project_name, sender=None):
         return self._projects_model.get_folder_type_items(
             project_name, sender
@@ -202,6 +198,13 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
     def get_project_status_items(self, project_name, sender=None):
         return self._projects_model.get_project_status_items(
             project_name, sender
+        )
+
+    def get_product_type_icons_mapping(
+        self, project_name: Optional[str]
+    ) -> ProductTypeIconMapping:
+        return self._projects_model.get_product_type_icons_mapping(
+            project_name
         )
 
     def get_folder_items(self, project_name, sender=None):

--- a/client/ayon_core/tools/loader/models/products.py
+++ b/client/ayon_core/tools/loader/models/products.py
@@ -58,7 +58,7 @@ class ProductBaseTypeIconMapping:
         if self._default_def is None:
             self._default_def = {
                 "type": "material-symbols",
-                "name": self._default.get("icon", "inventory_2"),
+                "name": self._default.get("icon", "deployed_code"),
                 "color": self._default.get("color", "#cccccc"),
             }
 
@@ -69,7 +69,7 @@ class ProductBaseTypeIconMapping:
             self._definitions_by_name = {
                 product_base_type_def["name"]: {
                     "type": "material-symbols",
-                    "name": product_base_type_def.get("icon", "inventory_2"),
+                    "name": product_base_type_def.get("icon", "deployed_code"),
                     "color": product_base_type_def.get("color", "#cccccc"),
                 }
                 for product_base_type_def in self._definitions

--- a/client/ayon_core/tools/loader/ui/products_model.py
+++ b/client/ayon_core/tools/loader/ui/products_model.py
@@ -17,7 +17,6 @@ PRODUCT_ID_ROLE = QtCore.Qt.UserRole + 6
 PRODUCT_NAME_ROLE = QtCore.Qt.UserRole + 7
 PRODUCT_TYPE_ROLE = QtCore.Qt.UserRole + 8
 PRODUCT_BASE_TYPE_ROLE = QtCore.Qt.UserRole + 9
-PRODUCT_TYPE_ICON_ROLE = QtCore.Qt.UserRole + 10
 PRODUCT_IN_SCENE_ROLE = QtCore.Qt.UserRole + 11
 VERSION_ID_ROLE = QtCore.Qt.UserRole + 12
 VERSION_HERO_ROLE = QtCore.Qt.UserRole + 13
@@ -228,10 +227,7 @@ class ProductsModel(QtGui.QStandardItemModel):
             return super().data(index, role)
 
         if role == QtCore.Qt.DecorationRole:
-            if col == 1:
-                role = PRODUCT_TYPE_ICON_ROLE
-            else:
-                return None
+            return None
 
         if (
             role == VERSION_NAME_EDIT_ROLE
@@ -455,7 +451,6 @@ class ProductsModel(QtGui.QStandardItemModel):
             model_item = QtGui.QStandardItem(product_item.product_name)
             model_item.setEditable(False)
             icon = get_qt_icon(product_item.product_icon)
-            product_type_icon = get_qt_icon(product_item.product_type_icon)
             model_item.setColumnCount(self.columnCount())
             model_item.setData(icon, QtCore.Qt.DecorationRole)
             model_item.setData(product_id, PRODUCT_ID_ROLE)
@@ -464,7 +459,6 @@ class ProductsModel(QtGui.QStandardItemModel):
                 product_item.product_base_type, PRODUCT_BASE_TYPE_ROLE
             )
             model_item.setData(product_item.product_type, PRODUCT_TYPE_ROLE)
-            model_item.setData(product_type_icon, PRODUCT_TYPE_ICON_ROLE)
             model_item.setData(product_item.folder_id, FOLDER_ID_ROLE)
 
             self._product_items_by_id[product_id] = product_item

--- a/client/ayon_core/tools/sceneinventory/control.py
+++ b/client/ayon_core/tools/sceneinventory/control.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import ayon_api
 
 from ayon_core.lib.events import QueuedEventSystem
@@ -6,7 +8,11 @@ from ayon_core.pipeline import (
     registered_host,
     get_current_context,
 )
-from ayon_core.tools.common_models import HierarchyModel, ProjectsModel
+from ayon_core.tools.common_models import (
+    HierarchyModel,
+    ProjectsModel,
+    ProductTypeIconMapping,
+)
 
 from .models import SiteSyncModel, ContainersModel
 
@@ -91,6 +97,13 @@ class SceneInventoryController:
             project_name = self.get_current_project_name()
         return self._projects_model.get_project_status_items(
             project_name, None
+        )
+
+    def get_product_type_icons_mapping(
+        self, project_name: Optional[str]
+    ) -> ProductTypeIconMapping:
+        return self._projects_model.get_product_type_icons_mapping(
+            project_name
         )
 
     # Containers methods

--- a/client/ayon_core/tools/sceneinventory/model.py
+++ b/client/ayon_core/tools/sceneinventory/model.py
@@ -214,9 +214,6 @@ class InventoryModel(QtGui.QStandardItemModel):
         group_icon = qtawesome.icon(
             "fa.object-group", color=self._default_icon_color
         )
-        product_type_icon = qtawesome.icon(
-            "fa.folder", color="#0091B2"
-        )
         group_item_font = QtGui.QFont()
         group_item_font.setBold(True)
 
@@ -303,7 +300,7 @@ class InventoryModel(QtGui.QStandardItemModel):
                 remote_site_progress = "{}%".format(
                     max(progress["remote_site"], 0) * 100
                 )
-
+                product_type_icon = get_qt_icon(repre_info.product_type_icon)
                 group_item = QtGui.QStandardItem()
                 group_item.setColumnCount(root_item.columnCount())
                 group_item.setData(group_name, QtCore.Qt.DisplayRole)

--- a/client/ayon_core/tools/sceneinventory/models/containers.py
+++ b/client/ayon_core/tools/sceneinventory/models/containers.py
@@ -126,6 +126,7 @@ class RepresentationInfo:
         product_id,
         product_name,
         product_type,
+        product_type_icon,
         product_group,
         version_id,
         representation_name,
@@ -135,6 +136,7 @@ class RepresentationInfo:
         self.product_id = product_id
         self.product_name = product_name
         self.product_type = product_type
+        self.product_type_icon = product_type_icon
         self.product_group = product_group
         self.version_id = version_id
         self.representation_name = representation_name
@@ -153,7 +155,17 @@ class RepresentationInfo:
 
     @classmethod
     def new_invalid(cls):
-        return cls(None, None, None, None, None, None, None, None)
+        return cls(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
 
 
 class VersionItem:
@@ -229,6 +241,9 @@ class ContainersModel:
     def get_representation_info_items(self, project_name, representation_ids):
         output = {}
         missing_repre_ids = set()
+        icons_mapping = self._controller.get_product_type_icons_mapping(
+            project_name
+        )
         for repre_id in representation_ids:
             try:
                 uuid.UUID(repre_id)
@@ -253,6 +268,7 @@ class ContainersModel:
                 "product_id": None,
                 "product_name": None,
                 "product_type": None,
+                "product_type_icon": None,
                 "product_group": None,
                 "version_id": None,
                 "representation_name": None,
@@ -265,10 +281,17 @@ class ContainersModel:
                 kwargs["folder_id"] = folder["id"]
                 kwargs["folder_path"] = folder["path"]
             if product:
+                product_type = product["productType"]
+                product_base_type = product.get("productBaseType")
+                icon = icons_mapping.get_icon(
+                    product_base_type=product_base_type,
+                    product_type=product_type,
+                )
                 group = product["attrib"]["productGroup"]
                 kwargs["product_id"] = product["id"]
                 kwargs["product_name"] = product["name"]
                 kwargs["product_type"] = product["productType"]
+                kwargs["product_type_icon"] = icon
                 kwargs["product_group"] = group
             if version:
                 kwargs["version_id"] = version["id"]


### PR DESCRIPTION
## Changelog Description
Use project config to visually show product types the same way AYON frontend does.

## Additional info
The feature is available with https://github.com/ynput/ayon-backend/pull/622 but it should work as it was before without it.

## Testing notes:
1. Make sure you have AYON server with https://github.com/ynput/ayon-backend/pull/622 .
2. Setup product types looks in a project's anatomy.
3. Loader should visually show the products the way you define it in anatomy.
