### PR TITLE
Tasks widget: Use icon color from project anatomy

### DIFF
--- a/client/ayon_core/tools/common_models/projects.py
+++ b/client/ayon_core/tools/common_models/projects.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 from abc import ABC, abstractmethod
-from typing import Dict, Any
+from typing import Any, Optional
 from dataclasses import dataclass
 
 import ayon_api
@@ -51,7 +51,7 @@ class StatusItem:
         self.icon: str = icon
         self.state: str = state
 
-    def to_data(self) -> Dict[str, Any]:
+    def to_data(self) -> dict[str, Any]:
         return {
             "name": self.name,
             "color": self.color,
@@ -125,16 +125,24 @@ class TaskTypeItem:
         icon (str): Icon name in MaterialIcons ("fiber_new").
 
     """
-    def __init__(self, name, short, icon):
+    def __init__(
+        self,
+        name: str,
+        short: str,
+        icon: str,
+        color: Optional[str],
+    ):
         self.name = name
         self.short = short
         self.icon = icon
+        self.color = color
 
     def to_data(self):
         return {
             "name": self.name,
             "short": self.short,
             "icon": self.icon,
+            "color": self.color,
         }
 
     @classmethod
@@ -147,6 +155,7 @@ class TaskTypeItem:
             name=task_type_data["name"],
             short=task_type_data["shortName"],
             icon=task_type_data["icon"],
+            color=task_type_data.get("color"),
         )
 
 

--- a/client/ayon_core/tools/utils/tasks_widget.py
+++ b/client/ayon_core/tools/utils/tasks_widget.py
@@ -234,10 +234,11 @@ class TasksQtModel(QtGui.QStandardItemModel):
         )
         icon = None
         if task_type_item is not None:
+            color = task_type_item.color or get_default_entity_icon_color()
             icon = get_qt_icon({
                 "type": "material-symbols",
                 "name": task_type_item.icon,
-                "color": get_default_entity_icon_color()
+                "color": color,
             })
 
         if icon is None:


### PR DESCRIPTION
## Changelog Description
Use color from task types in project anatomy in UIs.

## Testing notes:
1. Change color of task type in project anatomy.
2. Look at the task in pipeline UIs.
3. The color should be the same which is set in anatomy.

Resolves https://github.com/ynput/ayon-core/issues/1437