### PR TITLE
Loader: Elide status name text

### DIFF
--- a/client/ayon_core/tools/utils/delegates.py
+++ b/client/ayon_core/tools/utils/delegates.py
@@ -186,8 +186,15 @@ class StatusDelegate(QtWidgets.QStyledItemDelegate):
         )
         fm = QtGui.QFontMetrics(option.font)
         if text_rect.width() < fm.width(text):
-            text = self._get_status_short_name(index)
-            if text_rect.width() < fm.width(text):
+            short_text = self._get_status_short_name(index)
+            if short_text:
+                text = short_text
+
+            text = fm.elidedText(
+                text, QtCore.Qt.ElideRight, text_rect.width()
+            )
+            # Allow at least one character
+            if len(text) < 2:
                 text = ""
 
         fg_color = self._get_status_color(index)


### PR DESCRIPTION
## Changelog Description
Elide status name text.

## Additional info
Use-case is that status without an icon and short name is just hidden from the UI if the text does not fit the width of column. 2 things were changed, if short name is not available then use full name. If text does not fit into the text rectangle then elide the text to the width. Elided text must have at least one of the text characters.

### Screenshot
<img width="199" height="474" alt="image" src="https://github.com/user-attachments/assets/3931f8f6-02f0-4fd4-985d-2ff748c62fd1" />

## Testing notes:
1. Set short name of status to empty string `""`.
2. Open loader, make the status column smaller.
3. It should keep the text filled but should be elided (added 3 dots at the end).