### PR TITLE
Publisher: Fill task type color in tasks enum

### DIFF
--- a/client/ayon_core/tools/publisher/widgets/tasks_model.py
+++ b/client/ayon_core/tools/publisher/widgets/tasks_model.py
@@ -146,19 +146,19 @@ class TasksModel(QtGui.QStandardItemModel):
                 self._controller.get_current_project_name()
             )
         }
-        icon_name_by_task_name = {}
+        type_item_by_task_name = {}
         for task_items in task_items_by_folder_path.values():
             for task_item in task_items:
                 task_name = task_item.name
                 if (
                     task_name not in new_task_names
-                    or task_name in icon_name_by_task_name
+                    or task_name in type_item_by_task_name
                 ):
                     continue
                 task_type_name = task_item.task_type
                 task_type_item = task_type_items.get(task_type_name)
                 if task_type_item:
-                    icon_name_by_task_name[task_name] = task_type_item.icon
+                    type_item_by_task_name[task_name] = task_type_item
 
         for task_name in new_task_names:
             item = self._items_by_name.get(task_name)
@@ -171,13 +171,18 @@ class TasksModel(QtGui.QStandardItemModel):
             if not task_name:
                 continue
 
-            icon_name = icon_name_by_task_name.get(task_name)
-            icon = None
+            icon = icon_name = icon_color = None
+            task_type_item = type_item_by_task_name.get(task_name)
+            if task_type_item is not None:
+                icon_name = task_type_item.icon
+                icon_color = task_type_item.color
             if icon_name:
+                if not icon_color:
+                    icon_color = get_default_entity_icon_color()
                 icon = get_qt_icon({
                     "type": "material-symbols",
                     "name": icon_name,
-                    "color": get_default_entity_icon_color(),
+                    "color": icon_color,
                 })
             if icon is None:
                 icon = default_icon


### PR DESCRIPTION
## Changelog Description
Fill task type icon color in publisher's tasks enumerator.

### Screenshot
<img width="899" height="300" alt="image" src="https://github.com/user-attachments/assets/9a0bd9d8-290c-4747-8738-74b8b7e95e3c" />


## Testing notes:
1. Tasks enum in publisher respects icon colors set in anatomy.

Following PR to https://github.com/ynput/ayon-core/pull/1438