### PR TITLE
Fix: Template profile folder unresolved keys

### DIFF
--- a/client/ayon_core/pipeline/create/creator_plugins.py
+++ b/client/ayon_core/pipeline/create/creator_plugins.py
@@ -512,8 +512,12 @@ class BaseCreator(ABC):
 
         These may be dynamically created based on current context of workfile.
         """
-
-        return {}
+        return {
+                "asset": folder_entity["name"],
+                "folder": {
+                            "name": folder_entity["name"]
+                }
+            }
 
     def get_product_name(
         self,


### PR DESCRIPTION
## Changelog Description
Add default key mapping to `Creator.get_dynamic_data` in order to resolve `{folder[name]}`  key in `ayon+settings://core/tools/creator/product_name_profiles/0/template`

Fix #1213


## Additional info
Code copied from https://github.com/ynput/ayon-maya/blob/develop/client/ayon_maya/plugins/create/create_unreal_skeletalmesh.py#L23

## Testing notes:
1. In `ayon+settings://core/tools/creator/product_name_profiles/0/template` set `{folder[name]}`
2. Open Harmony and try to create a template 

