### PR TITLE
Workfile info: Add application information to workfile entity

### DIFF
--- a/client/ayon_core/host/__init__.py
+++ b/client/ayon_core/host/__init__.py
@@ -1,5 +1,5 @@
 from .constants import ContextChangeReason
-from .abstract import AbstractHost
+from .abstract import AbstractHost, ApplicationInformation
 from .host import (
     HostBase,
     ContextChangeData,
@@ -21,6 +21,7 @@ __all__ = (
     "ContextChangeReason",
 
     "AbstractHost",
+    "ApplicationInformation",
 
     "HostBase",
     "ContextChangeData",

--- a/client/ayon_core/host/abstract.py
+++ b/client/ayon_core/host/abstract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 import typing
 from typing import Optional, Any
 
@@ -11,6 +12,19 @@ if typing.TYPE_CHECKING:
     from ayon_core.pipeline import Anatomy
 
     from .typing import HostContextData
+
+
+@dataclass
+class ApplicationInformation:
+    """Application information.
+
+    Attributes:
+        app_name (Optional[str]): Application name. e.g. Maya, NukeX, Nuke
+        app_version (Optional[str]): Application version. e.g. 15.2.1
+
+    """
+    app_name: Optional[str] = None
+    app_version: Optional[str] = None
 
 
 class AbstractHost(ABC):
@@ -24,6 +38,16 @@ class AbstractHost(ABC):
     @abstractmethod
     def name(self) -> str:
         """Host name."""
+        pass
+
+    @abstractmethod
+    def get_app_information(self) -> ApplicationInformation:
+        """Information about the application where host is running.
+
+        Returns:
+            ApplicationInformation: Application information.
+
+        """
         pass
 
     @abstractmethod

--- a/client/ayon_core/host/host.py
+++ b/client/ayon_core/host/host.py
@@ -12,7 +12,7 @@ import ayon_api
 from ayon_core.lib import emit_event
 
 from .constants import ContextChangeReason
-from .abstract import AbstractHost
+from .abstract import AbstractHost, ApplicationInformation
 
 if typing.TYPE_CHECKING:
     from ayon_core.pipeline import Anatomy
@@ -95,6 +95,18 @@ class HostBase(AbstractHost):
         """
 
         pass
+
+    def get_app_information(self) -> ApplicationInformation:
+        """Running application information.
+
+        Host integration should override this method and return correct
+            information.
+
+        Returns:
+            ApplicationInformation: Application information.
+
+        """
+        return ApplicationInformation()
 
     def install(self):
         """Install host specific functionality.

--- a/client/ayon_core/host/interfaces/workfiles.py
+++ b/client/ayon_core/host/interfaces/workfiles.py
@@ -1554,6 +1554,22 @@ class IWorkfileHost(AbstractHost):
         if platform.system().lower() == "windows":
             rootless_path = rootless_path.replace("\\", "/")
 
+        # Get application information
+        app_info = self.get_app_information()
+        data = {}
+        if app_info.app_name:
+            data["app_name"] = app_info.app_name
+        if app_info.app_version:
+            data["app_version"] = app_info.app_version
+
+        # Use app group and app variant from applications addon (if available)
+        app_addon_name = os.environ.get("AYON_APP_NAME") or ""
+        app_addon_name_parts = app_addon_name.split("/")
+        if len(app_addon_name_parts) == 2:
+            app_group, app_variant = app_addon_name_parts
+            data["app_group"] = app_group
+            data["app_variant"] = app_variant
+
         workfile_info = save_workfile_info(
             project_name,
             save_workfile_context.task_entity["id"],
@@ -1562,6 +1578,7 @@ class IWorkfileHost(AbstractHost):
             version,
             comment,
             description,
+            data=data,
             workfile_entities=save_workfile_context.workfile_entities,
         )
         return workfile_info


### PR DESCRIPTION
## Changelog Description
Add more information about application to workfile entity.

## Additional info
Function `save_workfile_info` now allows to pass data for the workfile entity.

Host can implement `get_app_information` to fill DCC name and version which is then stored to workfile entity if is implemented. Also use application name defined by applications addon to fill `app_group` and `app_variant` in the workfile entity.

There will be following PRs in host addons to implement `get_app_information`.

## Testing notes:
1. Look at the code changes.

Resolves https://github.com/ynput/ayon-core/issues/1443