### PR TITLE
Chore: Simple version lock

### DIFF
--- a/client/ayon_core/pipeline/load/utils.py
+++ b/client/ayon_core/pipeline/load/utils.py
@@ -964,7 +964,12 @@ def get_outdated_containers(host=None, project_name=None):
         containers = host.get_containers()
     else:
         containers = host.ls()
-    return filter_containers(containers, project_name).outdated
+    outdated_containers = []
+    for container in filter_containers(containers, project_name).outdated:
+        if container.get("locked_version") is True:
+            continue
+        outdated_containers.append(container)
+    return outdated_containers
 
 
 def _is_valid_representation_id(repre_id: Any) -> bool:

--- a/client/ayon_core/pipeline/load/utils.py
+++ b/client/ayon_core/pipeline/load/utils.py
@@ -1042,13 +1042,13 @@ def filter_containers(containers, project_name):
         hero=True,
         fields={"id", "productId", "version"}
     )
-    verisons_by_id = {}
+    versions_by_id = {}
     versions_by_product_id = collections.defaultdict(list)
     hero_version_ids = set()
     for version_entity in version_entities:
         version_id = version_entity["id"]
         # Store versions by their ids
-        verisons_by_id[version_id] = version_entity
+        versions_by_id[version_id] = version_entity
         # There's no need to query products for hero versions
         #   - they are considered as latest?
         if version_entity["version"] < 0:
@@ -1083,24 +1083,23 @@ def filter_containers(containers, project_name):
 
         repre_entity = repre_entities_by_id.get(repre_id)
         if not repre_entity:
-            log.debug((
-                "Container '{}' has an invalid representation."
+            log.debug(
+                f"Container '{container_name}' has an invalid representation."
                 " It is missing in the database."
-            ).format(container_name))
+            )
             not_found_containers.append(container)
             continue
 
         version_id = repre_entity["versionId"]
-        if version_id in outdated_version_ids:
-            outdated_containers.append(container)
-
-        elif version_id not in verisons_by_id:
-            log.debug((
-                "Representation on container '{}' has an invalid version."
-                " It is missing in the database."
-            ).format(container_name))
+        if version_id not in versions_by_id:
+            log.debug(
+                f"Representation on container '{container_name}' has an"
+                " invalid version. It is missing in the database."
+            )
             not_found_containers.append(container)
 
+        elif version_id in outdated_version_ids:
+            outdated_containers.append(container)
         else:
             uptodate_containers.append(container)
 

--- a/client/ayon_core/tools/sceneinventory/delegates.py
+++ b/client/ayon_core/tools/sceneinventory/delegates.py
@@ -1,10 +1,14 @@
 from qtpy import QtWidgets, QtCore, QtGui
 
-from .model import VERSION_LABEL_ROLE
+from ayon_core.tools.utils import get_qt_icon
+
+from .model import VERSION_LABEL_ROLE, CONTAINER_VERSION_LOCKED_ROLE
 
 
 class VersionDelegate(QtWidgets.QStyledItemDelegate):
     """A delegate that display version integer formatted as version string."""
+    _locked_icon = None
+
     def paint(self, painter, option, index):
         fg_color = index.data(QtCore.Qt.ForegroundRole)
         if fg_color:
@@ -45,10 +49,35 @@ class VersionDelegate(QtWidgets.QStyledItemDelegate):
             QtWidgets.QStyle.PM_FocusFrameHMargin, option, option.widget
         ) + 1
 
+        text_rect_f = text_rect.adjusted(
+            text_margin, 0, - text_margin, 0
+        )
+
         painter.drawText(
-            text_rect.adjusted(text_margin, 0, - text_margin, 0),
+            text_rect_f,
             option.displayAlignment,
             text
         )
+        if index.data(CONTAINER_VERSION_LOCKED_ROLE) is True:
+            icon = self._get_locked_icon()
+            size = max(text_rect_f.height() // 2, 16)
+            margin = (text_rect_f.height() - size) // 2
+
+            icon_rect = QtCore.QRect(
+                text_rect_f.right() - size,
+                text_rect_f.top() + margin,
+                size,
+                size
+            )
+            icon.paint(painter, icon_rect)
 
         painter.restore()
+
+    def _get_locked_icon(cls):
+        if cls._locked_icon is None:
+            cls._locked_icon = get_qt_icon({
+                "type": "material-symbols",
+                "name": "lock",
+                "color": "white",
+            })
+        return cls._locked_icon

--- a/client/ayon_core/tools/sceneinventory/model.py
+++ b/client/ayon_core/tools/sceneinventory/model.py
@@ -37,6 +37,7 @@ REMOTE_SITE_ICON_ROLE = QtCore.Qt.UserRole + 23
 #     containers inbetween refresh.
 ITEM_UNIQUE_NAME_ROLE = QtCore.Qt.UserRole + 24
 PROJECT_NAME_ROLE = QtCore.Qt.UserRole + 25
+CONTAINER_VERSION_LOCKED_ROLE = QtCore.Qt.UserRole + 26
 
 
 class InventoryModel(QtGui.QStandardItemModel):
@@ -291,6 +292,10 @@ class InventoryModel(QtGui.QStandardItemModel):
                     item.setData(container_item.object_name, OBJECT_NAME_ROLE)
                     item.setData(True, IS_CONTAINER_ITEM_ROLE)
                     item.setData(unique_name, ITEM_UNIQUE_NAME_ROLE)
+                    item.setData(
+                        container_item.version_locked,
+                        CONTAINER_VERSION_LOCKED_ROLE
+                    )
                     container_model_items.append(item)
 
                 progress = progress_by_id[repre_id]

--- a/client/ayon_core/tools/sceneinventory/models/containers.py
+++ b/client/ayon_core/tools/sceneinventory/models/containers.py
@@ -95,7 +95,8 @@ class ContainerItem:
         namespace,
         object_name,
         item_id,
-        project_name
+        project_name,
+        version_locked,
     ):
         self.representation_id = representation_id
         self.loader_name = loader_name
@@ -103,6 +104,7 @@ class ContainerItem:
         self.namespace = namespace
         self.item_id = item_id
         self.project_name = project_name
+        self.version_locked = version_locked
 
     @classmethod
     def from_container_data(cls, current_project_name, container):
@@ -114,7 +116,8 @@ class ContainerItem:
             item_id=uuid.uuid4().hex,
             project_name=container.get(
                 "project_name", current_project_name
-            )
+            ),
+            version_locked=container.get("version_locked", False),
         )
 
 

--- a/client/ayon_core/tools/sceneinventory/view.py
+++ b/client/ayon_core/tools/sceneinventory/view.py
@@ -17,6 +17,7 @@ from ayon_core.tools.utils.lib import (
     format_version,
     preserve_expanded_rows,
     preserve_selection,
+    get_qt_icon,
 )
 from ayon_core.tools.utils.delegates import StatusDelegate
 
@@ -46,7 +47,7 @@ class SceneInventoryView(QtWidgets.QTreeView):
     hierarchy_view_changed = QtCore.Signal(bool)
 
     def __init__(self, controller, parent):
-        super(SceneInventoryView, self).__init__(parent=parent)
+        super().__init__(parent=parent)
 
         # view settings
         self.setIndentation(12)
@@ -623,17 +624,20 @@ class SceneInventoryView(QtWidgets.QTreeView):
         containers_by_id = self._controller.get_containers_by_item_ids(
             item_ids
         )
-        result = action.process(list(containers_by_id.values()))
-        if result:
-            self.data_changed.emit()
+        try:
+            result = action.process(list(containers_by_id.values()))
+            if not result:
+                pass
 
-            if isinstance(result, (list, set)):
+            elif isinstance(result, (list, set)):
                 self._select_items_by_action(result)
 
-            if isinstance(result, dict):
+            elif isinstance(result, dict):
                 self._select_items_by_action(
                     result["objectNames"], result["options"]
                 )
+        finally:
+            self.data_changed.emit()
 
     def _select_items_by_action(self, object_names, options=None):
         """Select view items by the result of action

--- a/client/ayon_core/tools/sceneinventory/view.py
+++ b/client/ayon_core/tools/sceneinventory/view.py
@@ -524,7 +524,15 @@ class SceneInventoryView(QtWidgets.QTreeView):
             submenu = QtWidgets.QMenu("Actions", self)
             for action in custom_actions:
                 color = action.color or DEFAULT_COLOR
-                icon = qtawesome.icon("fa.%s" % action.icon, color=color)
+                icon_def = action.icon
+                if not isinstance(action.icon, dict):
+                    icon_def = {
+                        "type": "awesome-font",
+                        "name": icon_def,
+                        "color": color,
+                    }
+                icon = get_qt_icon(icon_def)
+                # icon = qtawesome.icon("fa.%s" % action.icon, color=color)
                 action_item = QtWidgets.QAction(icon, action.label, submenu)
                 action_item.triggered.connect(
                     partial(


### PR DESCRIPTION
## Changelog Description
Implemented base logic of version lock on container items.

## Additional info
Versions can be locked by setting `"locked_version"` on container data to `True`. In that case the container is not considered as outdated.

It is still returned within "outdated containers" from `filter_containers` but is not considered as outdated in `get_outdated_containers`. The reason behind is that `get_outdated_containers` is used for validations, but it makes sence to be able to detect if the version is outdated even if is locked (so UI can show that information too).

Because this the container data are load plugin specific we can't really do more in core and the rest has to be implemented in each of the host load plugins.

## Testing notes:
1. Look at the code changes and verify it does what it needs to.
2. Verify the logic makes sense and the changes are reasonable.

Resolves https://github.com/ynput/ayon-core/issues/1446