### PR TITLE
Launcher: Fix form handling

### DIFF
--- a/client/ayon_core/tools/launcher/ui/actions_widget.py
+++ b/client/ayon_core/tools/launcher/ui/actions_widget.py
@@ -990,7 +990,7 @@ class ActionsWidget(QtWidgets.QWidget):
                 event["addon_name"],
                 event["addon_version"],
             ),
-            event["action_label"],
+            event["full_label"],
             form_data,
         )
 


### PR DESCRIPTION
## Changelog Description
Fix used key to get action label.

## Additional info
Key `"action_label"` was changed to `"full_label"` but the changes was not propagated in .

## Testing notes:
1. Actions that do show forms can be triggered.
