### PR TITLE
Chore: Use ayon api implementation of mime type

### DIFF
--- a/client/ayon_core/lib/transcoding.py
+++ b/client/ayon_core/lib/transcoding.py
@@ -1519,6 +1519,9 @@ def get_media_mime_type(filepath: str) -> Optional[str]:
         Optional[str]: Mime type or None if is unknown mime type.
 
     """
+    # The implementation is identical or better with ayon_api >=1.1.0,
+    #   which is used in AYON launcher >=1.3.0.
+    # NOTE Remove safe import when AYON launcher >=1.2.0.
     try:
         from ayon_api.utils import (
             get_media_mime_type_for_content as _ayon_api_func


### PR DESCRIPTION
## Changelog Description
Allow all known jpeg markers and use `get_media_mime_type_for_content` form `ayon_api`, if is available.

## Additional info
The `get_media_mime_type_for_content` function in `ayon_api` should be used all the time, but the implementation may warry based on used AYON launcher, that's why ayon api function result is used only if return a mime type.

## Testing notes:
This one PR is created to handle jpeg images which was exclusive to one jpeg marker.
1. All jpeg types can be used for thumbnail.
