### PR TITLE
Bugfix/add back OpenPype compatibility

### DIFF
--- a/client/ayon_core/pipeline/load/utils.py
+++ b/client/ayon_core/pipeline/load/utils.py
@@ -752,12 +752,18 @@ def get_representation_path(representation, root=None):
 
     """
     if root is None:
-        from ayon_core.pipeline import get_current_project_name, Anatomy
+        try:
+            from ayon_core.pipeline import get_current_project_name, Anatomy
 
-        anatomy = Anatomy(get_current_project_name())
-        return get_representation_path_with_anatomy(
-            representation, anatomy
-        )
+            anatomy = Anatomy(get_current_project_name())
+            return get_representation_path_with_anatomy(
+                representation, anatomy
+            )
+        except Exception:
+            # fall back to registered_root if anatomy path fails
+            # for OpenPype compatibility
+            from ayon_core.pipeline import registered_root
+            root = registered_root()
 
     def path_from_representation():
         try:

--- a/client/ayon_core/pipeline/load/utils.py
+++ b/client/ayon_core/pipeline/load/utils.py
@@ -636,6 +636,37 @@ def _fix_representation_context_compatibility(repre_context):
     udim = repre_context.get("udim")
     if isinstance(udim, list):
         repre_context["udim"] = udim[0]
+        
+    # convert OpenPype subset to Ayon product
+    old_product = repre_context.get("subset")
+    new_product = repre_context.get("product")
+    if old_product is not None and new_product is None:
+        repre_context["product"] = {
+            "name": repre_context.get("subset"),
+            "type": repre_context.get("family"),
+        }
+
+    # convert OpenPype asset to Ayon folder
+    old_folder = repre_context.get("asset")
+    new_folder = repre_context.get("folder")
+    if old_folder is not None and new_folder is None:
+        hierarchy = repre_context.get("hierarchy")
+        asset = repre_context.get("asset")
+        parents = []
+        path = ""
+        type = "Shot"
+        if hierarchy is not None:
+            hierarchy = hierarchy.strip("/")
+            parents = hierarchy.split("/")
+            path = f"/{hierarchy}/{asset}"
+            if "asset" in hierarchy.lower():
+                type = "Asset"
+        repre_context["folder"] = {
+            "name": asset,
+            "parents": parents,
+            "path": path,
+            "type": type
+        }
 
 
 def get_representation_path_from_context(context):


### PR DESCRIPTION
## Changelog Description
Adds compatibility for older OpenPype context keys.

The change ensures that 'subset' and 'asset' keys present in older OpenPype representations are correctly mapped to the new 'product' and 'folder' keys used in Ayon. This allows older representations to be loaded correctly.

Also adds a fallback mechanism when project anatomy is unavailable. This ensures the application remains functional by using the registered root path in cases where anatomy retrieval fails, enhancing OpenPype compatibility.

## Additional info
Paragraphs of text giving context of additional technical information or code examples.

## Testing notes:
1. Open project migrated from OpenPype
2. Load product in Maya or Resolve
