### PR TITLE
Burnins: Fix import of adapters

### DIFF
--- a/client/ayon_core/scripts/otio_burnin.py
+++ b/client/ayon_core/scripts/otio_burnin.py
@@ -6,7 +6,10 @@ import json
 import tempfile
 from string import Formatter
 
-import opentimelineio_contrib.adapters.ffmpeg_burnins as ffmpeg_burnins
+try:
+    from otio_burnins_adapter import ffmpeg_burnins
+except ImportError:
+    import opentimelineio_contrib.adapters.ffmpeg_burnins as ffmpeg_burnins
 from ayon_core.lib import (
     get_ffmpeg_tool_args,
     get_ffmpeg_codec_args,


### PR DESCRIPTION
## Changelog Description
Use new import of otio adapters in the code.

## Additional info
Change of the import is/was required since https://github.com/ynput/ayon-core/pull/1424 .

## Testing notes:
1. Create new dependency package using ayon-core 1.6.0 or newer.
2. Burnins should be created ok.
