### PR TITLE
fix hardcoded template path for "replace_with_published_scene_path"

### DIFF
--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -803,7 +803,20 @@ def replace_with_published_scene_path(instance, replace_in_path=True):
     template_data["comment"] = None
 
     anatomy = instance.context.data["anatomy"]
-    template = anatomy.get_template_item("publish", "default", "path")
+    project_name = anatomy.project_name
+    task_entity = instance.data.get("taskEntity", {})
+    project_settings = get_project_settings(project_name)
+    template_name = get_publish_template_name(
+        project_name=project_name,
+        host_name=instance.context.data.get("hostName", os.environ["AYON_HOST_NAME"]),
+        # publish template has to match productType "workfile",
+        # otherwise default template will be used:
+        product_type="workfile",
+        task_name=task_entity.get("name", os.environ["AYON_TASK_NAME"]),
+        task_type=task_entity.get("taskType"),
+        project_settings=project_settings,
+    )
+    template = anatomy.get_template_item("publish", template_name, "path")
     template_filled = template.format_strict(template_data)
     file_path = os.path.normpath(template_filled)
 


### PR DESCRIPTION
replace_with_published_scene looks up the actual publish path defined in anatomy and core settings.

## Changelog Description
Before replace_with_published_scene always took the default publish path, which caused tools looking into the wrong location if the publish path was not configured in "default", leading to errors.
Requires the productType of the scene to be "workfile", as the method is looking for the scene path, not the publish instance, otherwise will still fallback to default.

## Additional info
Fixes one of the five hardcoded template paths mentioned in [#1450](https://github.com/ynput/ayon-core/issues/1450).
