### PR TITLE
Fix: Get the correct template for resources

### DIFF
--- a/client/ayon_core/plugins/publish/collect_resources_path.py
+++ b/client/ayon_core/plugins/publish/collect_resources_path.py
@@ -88,7 +88,7 @@ class CollectResourcesPath(pyblish.api.InstancePlugin):
             task_type = task_entity["taskType"]
 
         template_name = get_publish_template_name(
-            project_name=template_data["project"]["name"],
+            project_name=instance.context.data["projectName"],
             host_name=instance.context.data["hostName"],
             product_type=instance.data["productType"],
             task_name=task_name,


### PR DESCRIPTION
## Changelog Description
Fix resource collector to respect associated template and not to use hardcoded default one.

## Testing notes:
1. Set template (for example with different root, or with some distinct dir structure to check the result more easily)
2. Assign it to some product utilizing resources (look)
3. Publish - resources should be integrated in the correct folder
