### PR TITLE
Farm: Studio bundle name to farm

### DIFF
--- a/client/ayon_core/plugins/publish/collect_farm_env_variables.py
+++ b/client/ayon_core/plugins/publish/collect_farm_env_variables.py
@@ -32,6 +32,7 @@ class CollectCoreJobEnvVars(pyblish.api.ContextPlugin):
 
         for key in [
             "AYON_BUNDLE_NAME",
+            "AYON_STUDIO_BUNDLE_NAME",
             "AYON_USE_STAGING",
             "AYON_IN_TESTS",
             # NOTE Not sure why workdir is needed?


### PR DESCRIPTION
## Changelog Description
Pass `AYON_STUDIO_BUNDLE_NAME` to farm environment variables.

## Testing notes:
1. Using dev bundles should work with deadline.
