### PR TITLE
Workfiles tool: Fix my tasks filtering

### DIFF
--- a/client/ayon_core/tools/workfiles/widgets/window.py
+++ b/client/ayon_core/tools/workfiles/widgets/window.py
@@ -411,7 +411,6 @@ class WorkfilesToolWindow(QtWidgets.QWidget):
             entity_ids = self._controller.get_my_tasks_entity_ids(
                 self._project_name
             )
-            print(entity_ids)
             folder_ids = entity_ids["folder_ids"]
             task_ids = entity_ids["task_ids"]
         self._folders_widget.set_folder_ids_filter(folder_ids)


### PR DESCRIPTION
## Changelog Description
Fix filtering by my tasks in workfiles tool.

## Additional info
Workfiles window stored current project before refresh of the controller. Now is the project re-set after each refresh.

## Testing notes:
1. My tasks filter works as expected.

Resolves https://github.com/ynput/ayon-core/issues/1504