### PR TITLE
Library: Copy over product grouping

### DIFF
--- a/client/ayon_core/tools/push_to_project/models/integrate.py
+++ b/client/ayon_core/tools/push_to_project/models/integrate.py
@@ -955,8 +955,9 @@ class ProjectPushItemProcess:
             "description",
             "productGroup",
         }:
-            if key in src_attrib:
-                dst_attrib[key] = src_attrib[key]
+            value = src_attrib.get(key)
+            if value:
+                dst_attrib[key] = value
 
         product_entity = new_product_entity(
             product_name,
@@ -1001,8 +1002,9 @@ class ProjectPushItemProcess:
             "description",
             "intent",
         }:
-            if key in src_attrib:
-                dst_attrib[key] = src_attrib[key]
+            value = src_attrib.get(key)
+            if value:
+                dst_attrib[key] = value
 
         if version is None:
             last_version_entity = ayon_api.get_last_version_by_product_id(


### PR DESCRIPTION
## Changelog Description
This PR copies also product grouping that could be configured in source project.

## Additional info
Product grouping is stored on `attrib` of product entity.

## Testing notes:
1. group any products in Loader with `CTRL+G`
2. push them to Library project
3. check that group got copied too in destination project
<img width="1171" height="329" alt="image" src="https://github.com/user-attachments/assets/0386e8c3-3d4e-41e2-bab6-3f61536e3999" />
