### PR TITLE
Publisher: Fix Context card being clickable in Nuke 14/15 only outside the Context label area

### DIFF
--- a/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
@@ -211,7 +211,12 @@ class ContextCardWidget(CardWidget):
         icon_widget = PublishPixmapLabel(None, self)
         icon_widget.setObjectName("ProductTypeIconLabel")
 
-        label_widget = QtWidgets.QLabel(CONTEXT_LABEL, self)
+        label_widget = QtWidgets.QLabel(f"<span>{CONTEXT_LABEL}</span>", self)
+        # HTML text will cause that label start catch mouse clicks
+        # - disabling with changing interaction flag
+        label_widget.setTextInteractionFlags(
+            QtCore.Qt.NoTextInteraction
+        )
 
         icon_layout = QtWidgets.QHBoxLayout()
         icon_layout.setContentsMargins(5, 5, 5, 5)


### PR DESCRIPTION
## Changelog Description

Fix Context card being clickable in Nuke 14/15 only outside the Context label area. Previously you could only click on the far left or far right side of the context card to be able to select it and access the Context attributes.

Cosmetically the removal of the `<span>` shouldn't do much to the Context card because it doesn't have a sublabel.

## Additional info

I did notice the **Context** card does have a little drop shadow in Nuke now,  but the other cards doesn't.

See:

<img width="386" height="149" alt="image" src="https://github.com/user-attachments/assets/c53a3aaf-1a51-489c-a281-76b1a26165a3" />
<img width="390" height="158" alt="image" src="https://github.com/user-attachments/assets/830750f5-41d4-474f-8477-520f8bea2411" />

The instance cards are selectable completely fine.
No errors are raised or logged on the Context card when clicking the 'non-clickable' area.

Related to private discussion: https://discord.com/channels/517362899170230292/1439920568626315356
`YN-0220`

Fix https://github.com/ynput/ayon-core/issues/1552

## Testing notes:

1. Clicking context card in Nuke 14 / 15 should work.
