### PR TITLE
Workfile template builder: Consider Folder in filtering

### DIFF
--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -853,7 +853,6 @@ class AbstractTemplateBuilder(ABC):
             "folder_paths": folder_path,
         }
 
-
         build_profiles = self._get_build_profiles()
         profile = filter_profiles(
             build_profiles,


### PR DESCRIPTION
## Changelog Description
Add `folderpaths` for template profile filtering

## Additional info
Btw, this will make it work with other DCCs if they have the setting for folder paths added like here https://github.com/ynput/ayon-houdini/pull/318 which only adds this setting.

## Testing notes:
1. template workfile build should work as before in different DCCs.
2. In Houdini DCC with https://github.com/ynput/ayon-houdini/pull/318 PR, workfile templates selection should follow specified folder paths.

Resolve https://github.com/ynput/ayon-houdini/issues/315