### PR TITLE
Added webpublisher to extract thumbnail

### DIFF
--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -48,6 +48,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         "unreal",
         "houdini",
         "batchdelivery",
+        "webpublisher",
     ]
     settings_category = "core"
     enabled = False


### PR DESCRIPTION
## Changelog Description
If image sequence was published via Webpublisher, thumbnail wasn't created for `ftrack` to show clickable icon in there.


## Testing notes:
0. set `Resize` mode if you are handling very large resolutions (17000x14000)
`ayon+settings://core/publish/ExtractThumbnail`
<img width="926" height="533" alt="image" src="https://github.com/user-attachments/assets/d29e996d-4d88-445b-8c3c-0bc22c7c9246" />

1. publish image sequence via WP, check ftrack to have clickable thumbnail, check AYON to have clickable online review
2. publish single image via WP, check ftrack to have clickable thumbnail, check AYON to have clickable online review
