### PR TITLE
Integrator: Fix import of `is_product_base_type_supported`

### DIFF
--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -28,7 +28,7 @@ from ayon_core.pipeline.publish import (
     KnownPublishError,
     get_publish_template_name,
 )
-from pipeline import is_product_base_type_supported
+from ayon_core.pipeline import is_product_base_type_supported
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Changelog Description

Fix incorrect import `from pipeline import is_product_base_type_supported` in Integrator.

## Additional info

Fix:
```
Filepath:
C:\Work\REPO\ayon-core\client\ayon_core\plugins\publish\integrate.py

Traceback:
Traceback (most recent call last):
File "C:\Work\REPO\ayon-core\client\ayon_core\pipeline\publish\lib.py", line 292, in publish_plugins_discover
module = import_filepath(
File "C:\Work\REPO\ayon-core\client\ayon_core\lib\python_module_tools.py", line 45, in import_filepath
module_loader.exec_module(module)
File "", line 850, in exec_module
File "", line 228, in _call_with_frames_removed
File "C:\Work\REPO\ayon-core\client\ayon_core\plugins\publish\integrate.py", line 31, in 
from pipeline import is_product_base_type_supported
ModuleNotFoundError: No module named 'pipeline'
```
See: https://github.com/ynput/ayon-zbrush/pull/33#issuecomment-3616465993

Got broken with: https://github.com/ynput/ayon-core/pull/1315/files#diff-181b1a0d60066e0e3ab6db7a72209332064bb6254e56da721b1d0f0b84adb909R31

## Testing notes:

1. Publishing should work and correctly integrate.
