### PR TITLE
Integrate: Fix 'product_name' to 'name'

### DIFF
--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -399,7 +399,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             product_id = existing_product_entity["id"]
 
         new_product_entity_kwargs = {
-            "product_name": product_name,
+            "name": product_name,
             "product_type": product_type,
             "folder_id": folder_entity["id"],
             "data": data,


### PR DESCRIPTION
## Changelog Description
Use correct `name` kwarg when creating product entity.

## Testing notes:
1. Integrate works.
