### PR TITLE
Extract Review: Substance Painter reviewables do not integrate

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -285,6 +285,7 @@ class CoreSettings(BaseSettingsModel):
         "{}",
         title="Global environment variables",
         widget="textarea",
+        syntax="json",
         scope=["studio"],
     )
     update_check_interval: int = SettingsField(
@@ -324,12 +325,14 @@ class CoreSettings(BaseSettingsModel):
             "Defines project folders to create on disk"
             " for 'Create project folders' action."
         ),
+        syntax="json",
         section="---"
     )
     project_environments: str = SettingsField(
         "{}",
         widget="textarea",
         title="Project environments",
+        syntax="json",
         section="---"
     )
     filter_env_profiles: list[FilterEnvsProfileModel] = SettingsField(


### PR DESCRIPTION
## Changelog Description

With https://github.com/ynput/ayon-core/pull/1526 we got reviewables for substance painter textures, but they also got integrated as representations, like `png_png`.

## Additional info

With these changes it should only make the reviewable upload.

See ayon chat conversation; https://discord.com/channels/517362899170230292/563751989075378201/1447931139263168553

Community and @LiborBatek says that these are working settings:

<img width="1014" height="751" alt="image" src="https://github.com/user-attachments/assets/a0302e4e-b759-41f5-81ca-f001ab05da1f" />

https://discord.com/channels/517362899170230292/1447896320101580851/1447972537060298902

## Testing notes:

1. Reviewables should be uploaded, but no extra representation should be integrated.