### PR TITLE
YN-0296: colorspace file rules should override already set colorspace 

### DIFF
--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -1299,9 +1299,9 @@ def set_colorspace_data_to_representation(
     if isinstance(filename, list):
         filename = filename[0]
 
-    # get matching colorspace from rules
-    if colorspace is None:
-        colorspace = get_imageio_file_rules_colorspace_from_filepath(
+    colorspace_from_rules = None
+    if file_rules:
+        colorspace_from_rules = get_imageio_file_rules_colorspace_from_filepath(
             filename,
             host_name,
             project_name,
@@ -1309,6 +1309,10 @@ def set_colorspace_data_to_representation(
             file_rules=file_rules,
             project_settings=project_settings
         )
+
+    # get matching colorspace from rules
+    if colorspace_from_rules:
+        colorspace = colorspace_from_rules
 
     # infuse data to representation
     if colorspace:


### PR DESCRIPTION
## Changelog Description

This enhancement ensures colorspace file rules consistently override any previously set colorspace values, establishing file rules as the authoritative source for colorspace configuration. Previously, if a colorspace was already set, file rules were ignored—leading to inconsistent color management behavior across the pipeline. This fix guarantees that file rules always take precedence, providing predictable and reliable colorspace handling regardless of initial settings.

## Additional info

The change refactors the colorspace assignment logic in `set_colorspace_data_to_representation()` function:
- File rules are now evaluated independently before checking if a colorspace exists
- When file rules produce a match (`colorspace_from_rules`), it unconditionally replaces any existing colorspace value
- This ensures file-based colorspace rules maintain highest priority in the hierarchy

```python
# Before: file rules only checked if colorspace was None
if colorspace is None:
    colorspace = get_imageio_file_rules_colorspace_from_filepath(...)

# After: file rules always override when matched
colorspace_from_rules = get_imageio_file_rules_colorspace_from_filepath(...)
if colorspace_from_rules:
    colorspace = colorspace_from_rules
```

## Testing notes:

1. Set up a representation with a pre-defined colorspace value (e.g., "sRGB")
2. Configure file rules to assign a different colorspace for matching file patterns (e.g., "linear")
3. Process a file that matches the file rule pattern
4. Verify the final colorspace matches the file rule ("linear") instead of the initial value ("sRGB")
5. Test with no file rules configured—colorspace should retain original value if set