### PR TITLE
Fix Nuke launching in macOS

### DIFF
--- a/client/ayon_core/vendor/python/scriptsmenu/launchfornuke.py
+++ b/client/ayon_core/vendor/python/scriptsmenu/launchfornuke.py
@@ -14,15 +14,8 @@ def _nuke_main_window():
 def _nuke_main_menubar():
     """Retrieve the main menubar of the Nuke window"""
     nuke_window = _nuke_main_window()
-    menubar = [i for i in nuke_window.children()
-               if isinstance(i, QtWidgets.QMenuBar)]
 
-    # OSX fix - nuke_window.children() can't find menubars
-    if not menubar:
-        menubar = [nuke_window.menuBar()]
-
-    assert len(menubar) == 1, "Error, could not find menu bar!"
-    return menubar[0]
+    return nuke_window.menuBar()
 
 
 def main(title="Scripts"):


### PR DESCRIPTION
## Changelog Description
This PR fixes the launching of Nuke in macOS, because of a specific [issue with Qt menu bars in this OS](https://doc.qt.io/qt-6/macos-issues.html#menu-bar).

## Additional info
Conversation in Ayon Forum: https://community.ynput.io/t/error-interpreting-this-plugin-nuke-osx/2730

## Testing notes:
1. Open Nuke from the launcher
