### PR TITLE
Publisher Create: Do not fallback to current context if no folder or task selected

### DIFF
--- a/client/ayon_core/tools/publisher/widgets/create_widget.py
+++ b/client/ayon_core/tools/publisher/widgets/create_widget.py
@@ -310,9 +310,6 @@ class CreateWidget(QtWidgets.QWidget):
         folder_path = None
         if self._context_change_is_enabled():
             folder_path = self._context_widget.get_selected_folder_path()
-
-        if folder_path is None:
-            folder_path = self.get_current_folder_path()
         return folder_path or None
 
     def _get_folder_id(self):


### PR DESCRIPTION
## Changelog Description

Do not fallback to current task name if no task selected

## Additional info

Fix #1598

## Testing notes:

1. Deselecting task should not fall back to the active task name