### PR TITLE
Integrate: Add resolution and pixel aspect to version attributes

### DIFF
--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -926,9 +926,9 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         optionals = [
             "frameStart", "frameEnd",
             "handleEnd", "handleStart",
+            "step",
             "resolutionWidth", "resolutionHeight",
             "pixelAspect",
-            "step",
             "sourceHashes"
         ]
         for key in optionals:


### PR DESCRIPTION
## Changelog Description
Add `resolutionWidth`, `resolutionHeight` and `pixelAspect` to version attributes if instance have them set up.

Fix https://github.com/ynput/ayon-core/issues/1603

## Testing notes:
1. Instances that have filled all the attributes should have filled the values on version attributes.

Resolves https://github.com/ynput/ayon-core/issues/1603