### PR TITLE
Chore: change pytest-ayon dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ opentimelineio = "^0.17.0"
 speedcopy = "^2.1"
 qtpy="^2.4.3"
 pyside6 = "^6.5.2"
-pytest-ayon = { git = "https://github.com/ynput/pytest-ayon.git", branch = "chore/align-dependencies" }
+pytest-ayon = { git = "https://github.com/ynput/pytest-ayon.git", branch = "develop" }
 
 [tool.codespell]
 # Ignore words that are not in the dictionary.


### PR DESCRIPTION
## Changelog Description
Dependency ynput/pytest-ayon used to run unit tests changed to develop branch to retain functionality.

## Additional info
This affects only CI/CD

## Testing notes:
Running unit test should work as before