### PR TITLE
CLI: Remove deprecated 'extractenvironments' command

### DIFF
--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -6,7 +6,6 @@ import logging
 import code
 import traceback
 from pathlib import Path
-import warnings
 
 import click
 


### PR DESCRIPTION
## Changelog Description
Remove deprecated `extractenvironments` command from cli.

## Additional info
The command is deprecated for a very very long time.

## Testing notes:
1. Validate code changes.
