### PR TITLE
Auto-tag instances with review family when review representation added

### DIFF
--- a/client/ayon_core/plugins/publish/extract_color_transcode.py
+++ b/client/ayon_core/plugins/publish/extract_color_transcode.py
@@ -279,6 +279,12 @@ class ExtractOIIOTranscode(publish.Extractor):
             if "delete" in tags and "thumbnail" not in tags:
                 instance.data["representations"].remove(repre)
 
+            if (
+                added_review
+                and "review" not in instance.data["families"]
+            ):
+                instance.data["families"].append("review")
+
         instance.data["representations"].extend(new_representations)
 
     def _rename_in_representation(self, new_repre, files_to_convert,


### PR DESCRIPTION
## Changelog Description

Instances that receive review representations through OIIO color transcoding are now automatically tagged with the "review" family. This resolves processing gaps where review-enabled instances weren't properly identified downstream, causing batch delivery workflows to fail when review representations were expected but the family tag was missing.

The enhancement ensures consistent family tagging throughout the publish pipeline by automatically appending "review" to the instance families list whenever a review representation is added during color transcoding operations.

## Additional info

The fix modifies `extract_color_transcode.py` to detect when `added_review` flag is set and the "review" family isn't already present in `instance.data["families"]`. When both conditions are met, it appends "review" to the families list, ensuring proper downstream identification and processing.

This change affects the `ExtractOIIOColorTranscode` plugin's process method, occurring after representation cleanup and before new representations are added to the instance data.

## Testing notes:
1. Create a publish instance that triggers OIIO color transcoding with review representation enabled
2. Verify that "review" is automatically added to the instance families list
3. Confirm downstream batch delivery processes correctly identify and process the review representation
4. Test with instances that already have "review" family to ensure no duplicates are created