### PR TITLE
Extract thumbnail from source: Safe collection of rescale arguments

### DIFF
--- a/client/ayon_core/plugins/publish/extract_thumbnail_from_source.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail_from_source.py
@@ -201,7 +201,6 @@ class ExtractThumbnailFromSource(pyblish.api.InstancePlugin):
             self.log.warning("Failed to get resolution args for ffmpeg.")
             return False
 
-
         max_int = str(2147483647)
         ffmpeg_cmd = get_ffmpeg_tool_args(
             "ffmpeg",


### PR DESCRIPTION
## Changelog Description
Don't hard fail if failed to collect rescale arguments for thumbnail creation.

## Additional info
If input file is not supported by oiio nor ffmpeg the extraction fails, but it should just continue.

## Testing notes:
1. Best is using traypublisher and pass .mov file to a render product type.
2. Publishing should not fail on Extract Thumbnail from source (which with ayon 3rd party addon 1.4.0 would fail on OIIO).
