### PR TITLE
Transcoding: Fix issues with `oiiotool` arguments

### DIFF
--- a/client/ayon_core/lib/transcoding.py
+++ b/client/ayon_core/lib/transcoding.py
@@ -763,7 +763,7 @@ def convert_input_paths_for_ffmpeg(
         # Convert a sequence of files using a single oiiotool command
         # using its sequence syntax
         if isinstance(input_item, clique.Collection):
-            frames = input_item.format("{head}#{tail}").replace(" ", "")
+            frames = input_item.format("{ranges}")
             oiio_cmd.extend([
                 "--framepadding", str(input_item.padding),
                 "--frames", frames,


### PR DESCRIPTION
## Changelog Description
Fix frame range for sequence conversion using oiiotool.

## Additional info
I think this PR can be considered a follow up PR for #1217

- fix type of `framepadding` argument. (convert it to a string)
- fix value of `frames` argument. (pass frame range not the file path)

## Testing notes:
I publish render marked as reviewable from Houdini.

Resolve #1623 