### PR TITLE
Push to project: fix representation context

### DIFF
--- a/client/ayon_core/tools/push_to_project/models/integrate.py
+++ b/client/ayon_core/tools/push_to_project/models/integrate.py
@@ -1172,17 +1172,15 @@ class ProjectPushItemProcess:
         self, anatomy, template_name, formatting_data, file_template
     ):
         processed_repre_items = []
-        repre_context = None
         for repre_item in self._src_repre_items:
             repre_entity = repre_item.repre_entity
             repre_name = repre_entity["name"]
             repre_format_data = copy.deepcopy(formatting_data)
 
-            if not repre_context:
-                repre_context = self._update_repre_context(
-                    copy.deepcopy(repre_entity),
-                    formatting_data
-                )
+            repre_context = self._update_repre_context(
+                copy.deepcopy(repre_entity),
+                formatting_data
+            )
 
             repre_format_data["representation"] = repre_name
             for src_file in repre_item.src_files:


### PR DESCRIPTION
## Changelog Description
Fixing issue affecting pushing of multiple representations to project, where context from the first was used in the rest, resulting in wrong paths resolved on loading.

## Additional info
To fix already pushed representation, some migration filling up the correct context must happen.

Resolves #1628

## Testing notes:
Push some product with multiple representations into another project using *Push to project* action in the Browser/Loader. Locate the new product in destination project and check paths to all pushed representations - they should have a correct path.
