### PR TITLE
Add six into module blacklist for representation trait

### DIFF
--- a/client/ayon_core/pipeline/traits/representation.py
+++ b/client/ayon_core/pipeline/traits/representation.py
@@ -65,7 +65,7 @@ class Representation(Generic[T]):  # noqa: PLR0904
 
     _data: dict[str, T]
     _module_blacklist: ClassVar[list[str]] = [
-        "_", "builtins", "pydantic",
+        "_", "builtins", "pydantic", "six",
     ]
     name: str
     representation_id: str


### PR DESCRIPTION
## Changelog Description
This PR is to add `six` into module blacklist for representation trait so that loading the asset with the trait won't hit the error with the `six` module.

```
File "D:\ayon_launcher\ayon-launcher\build\output\dependencies\urllib3\packages\six.py", line 96, in get
    result = self._resolve()
             ^^^^^^^^^^^^^^^
  File "D:\ayon_launcher\ayon-launcher\build\output\dependencies\urllib3\packages\six.py", line 118, in _resolve
    return _import_module(self.mod)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\ayon_launcher\ayon-launcher\build\output\dependencies\urllib3\packages\six.py", line 87, in _import_module
    import(name)
  File "C:\Users/Public/Documents/MarvelousDesigner/Configuration/python311/Lib\dbm\gnu.py", line 3, in <module>
    from _gdbm import *
ModuleNotFoundError: No module named '_gdbm'
```
## Additional info
Discover the issue when testing https://github.com/ynput/ayon-marvelous-designer/pull/2

## Testing notes:
1. Build Core addon with this branch
2. Load asset with the representation trait.
