### PR TITLE
Integrate Hero Version: fix file transaction mode to use hardlinks correctly

### DIFF
--- a/client/ayon_core/plugins/publish/integrate_hero_version.py
+++ b/client/ayon_core/plugins/publish/integrate_hero_version.py
@@ -429,7 +429,7 @@ class IntegrateHeroVersion(
             )
             mode = FileTransaction.MODE_COPY
             if self.use_hardlinks:
-                mode = FileTransaction.MODE_LINK
+                mode = FileTransaction.MODE_HARDLINK
 
             try:
                 for src_path, dst_path in itertools.chain(


### PR DESCRIPTION
## Changelog Description

Fix typo `FileTransaction.MODE_LINK` -> `FileTransaction.MODE_HARDLINK`

## Additional info

Error would only occur if `use_hardlinks` was enabled in settings.

Fixes error:
```
During the Integrate step Integrate Hero Version:
DEBUG: --- Integration of Hero version for product workfileModellingMain begins.
WARNING: Argument 'product_base_type' is not provided to 'get_publish_template_name' function. This argument will be required in future versions.
DEBUG: Looking for matching profile for: hosts: "maya" | product_types: "workfile" | product_base_types: "None" | task_names: "modelling" | task_types: "Modelling"
DEBUG: "maya" not found in "hosts": ['substancedesigner', 'substancepainter']
DEBUG: None of profiles match your setup. hosts: "maya" | product_types: "workfile" | product_base_types: "None" | task_names: "modelling" | task_types: "Modelling"
DEBUG: hero template check was successful. {root[work]}/{project[code]}/pub/{hierarchy}/{folder[name]}/{product[type]}/{product[name]}/hero/{product[name]}<.{udim}><.{frame:0>4}>.{ext}
DEBUG: hero publish dir: "/projects/rnd/pub/assets/props/asset/workfile/workfileModellingMain/hero"
DEBUG: https:/productions.ayon.app/ "POST /graphql HTTP/1.1" 200 1116
DEBUG: Response <RestApiResponse [200]>
DEBUG: https:/productions.ayon.app/ "POST /graphql HTTP/1.1" 200 2417
DEBUG: Response <RestApiResponse [200]>
DEBUG: Replacing old hero version.
DEBUG: Backup folder path is "/projects/rnd/pub/assets/props/asset/workfile/workfileModellingMain/hero.BACKUP"
ERROR: !!! Creating of hero version failed. Previous hero version maybe lost some data!
Traceback (most recent call last):
  File ".local/share/AYON/dependency_packages/ayon_2510091450_linux-rocky9.zip/dependencies/pyblish/plugin.py", line 528, in __explicit_process
    runner(*args)
  File ".local/share/AYON/addons/core_1.7.1/ayon_core/plugins/publish/integrate_hero_version.py", line 133, in process
    self.integrate_instance(
  File ".local/share/AYON/addons/core_1.7.1/ayon_core/plugins/publish/integrate_hero_version.py", line 432, in integrate_instance
    mode = FileTransaction.MODE_LINK
           ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'FileTransaction' has no attribute 'MODE_LINK'
```

Mentioned [here](https://discord.com/channels/517362899170230292/1459186983137185864) (private) 
Bug was introduced [here](https://github.com/ynput/ayon-core/pull/1622/files#diff-a74e49bddd3063b5f489ec15de523ab4e4aab068620cb23c4db17f7441dcc5dbR432). 

## Testing notes:

1. Fix error.
