### PR TITLE
Add The Foundry Mari application

### DIFF
--- a/client/ayon_core/hooks/pre_add_last_workfile_arg.py
+++ b/client/ayon_core/hooks/pre_add_last_workfile_arg.py
@@ -19,6 +19,7 @@ class AddLastWorkfileToLaunchArgs(PreLaunchHook):
         "nuke",
         "nukex",
         "hiero",
+        "mari",
         "houdini",
         "nukestudio",
         "fusion",

--- a/client/ayon_core/hooks/pre_ocio_hook.py
+++ b/client/ayon_core/hooks/pre_ocio_hook.py
@@ -16,6 +16,7 @@ class OCIOEnvHook(PreLaunchHook):
         "aftereffects",
         "max",
         "houdini",
+        "mari",
         "maya",
         "nuke",
         "hiero",

--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -165,6 +165,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
         "batchdelivery",
         "photoshop",
         "substancepainter",
+        "mari",
     ]
 
     settings_category = "core"

--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -40,6 +40,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         "fusion",
         "resolve",
         "traypublisher",
+        "mari",
         "substancepainter",
         "substancedesigner",
         "nuke",

--- a/client/ayon_core/plugins/publish/validate_file_saved.py
+++ b/client/ayon_core/plugins/publish/validate_file_saved.py
@@ -37,7 +37,7 @@ class ValidateCurrentSaveFile(pyblish.api.ContextPlugin):
     label = "Validate File Saved"
     order = pyblish.api.ValidatorOrder - 0.1
     hosts = ["fusion", "houdini", "max", "maya", "nuke", "substancepainter",
-             "cinema4d", "silhouette", "gaffer", "blender", "loki"]
+             "cinema4d", "silhouette", "gaffer", "blender", "loki", "mari"]
     actions = [SaveByVersionUpAction, ShowWorkfilesAction]
 
     def process(self, context):

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -1329,7 +1329,8 @@ DEFAULT_PUBLISH_VALUES = {
             "photoshop",
             "resolve",
             "tvpaint",
-            "substancepainter"
+            "substancepainter",
+            "mari",
         ],
         "skip_hosts_headless_publish": []
     },
@@ -1424,6 +1425,7 @@ DEFAULT_PUBLISH_VALUES = {
                     "photoshop",
                     "substancepainter",
                     "silhouette",
+                    "mari",
                 ],
                 "enabled": True,
                 "optional": False,


### PR DESCRIPTION
## Changelog Description

Add The Foundry Mari application

## Additional info

Purely draft for https://github.com/ynput/ayon-mari

Needs more work on `ayon-mari` to be useful, but currently should launch and show AYON menu.

## Testing notes:

1. Mari integration should work
 - [ ] OCIO should be set, etc.
 - [ ] Last workfile should open (still todo in `ayon-mari`)
 - [ ] Reviews should work (still todo in `ayon-mari`)
