### PR TITLE
Representation Traits: fix context and attributes

### DIFF
--- a/client/ayon_core/plugins/publish/integrate_traits.py
+++ b/client/ayon_core/plugins/publish/integrate_traits.py
@@ -391,11 +391,6 @@ class IntegrateTraits(pyblish.api.InstancePlugin):
         for transfer in transfers:
             transfer.related_trait.file_path = transfer.destination
 
-        # 8.5) Get attributes for representation
-        attr_defs = self.get_attributes_by_type(instance.context)[
-            "representation"
-        ]
-
         # 9) Create representation entities
         for representation in representations:
             attributes = {
@@ -403,7 +398,7 @@ class IntegrateTraits(pyblish.api.InstancePlugin):
                 "template": transfers[0].template,
             }
 
-            data={"context": self.get_template_data_from_representation(
+            data = {"context": self.get_template_data_from_representation(
                 representation, instance)}
 
             # Original integrator at this moment took all additional data

--- a/tests/client/ayon_core/plugins/publish/test_integrate_traits.py
+++ b/tests/client/ayon_core/plugins/publish/test_integrate_traits.py
@@ -253,7 +253,8 @@ def test_get_template_name(mock_context: pyblish.api.Context) -> None:
 
 
 @pytest.mark.server
-def test_get_template_data_from_representation(mock_context: pyblish.api.Context) -> None:
+def test_get_template_data_from_representation(
+        mock_context: pyblish.api.Context) -> None:
     """Test get_template_data_from_representation."""
     integrator = IntegrateTraits()
     instance = mock_context[0]


### PR DESCRIPTION
## Changelog Description
Add `data["context"]` and `attributes` back to the representation for backward compatibilty.

## Additional information
Data in `data["context"]` are something we shouldn't rely on when using representation traits. They are unstructured - mostly data used by Anatomy. This is already handled by `TemplatePath` trait where this should be taken from.

This PR is also aligning some support for product base types with the legacy integrator, this shouldn't affect the functionality at all.

Closes #1642

## Testing notes:
Publish something using representation traits, load it using existing loader logic and it should get the path and templates correctly.
