### PR TITLE
Workfile template builder: Save workfile with context

### DIFF
--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -651,10 +651,14 @@ class AbstractTemplateBuilder(ABC):
     def save_workfile(self, workfile_path):
         """Save workfile in current host."""
         # Save current scene, continue to open file
-        if isinstance(self.host, IWorkfileHost):
-            self.host.save_workfile(workfile_path)
-        else:
+        if not isinstance(self.host, IWorkfileHost):
             self.host.save_file(workfile_path)
+            return
+        self.host.save_workfile_with_context(
+            workfile_path,
+            self.current_folder_entity,
+            self.current_task_entity,
+        )
 
     def _prepare_placeholders(self, placeholders):
         """Run preparation part for placeholders on plugins.


### PR DESCRIPTION
## Changelog Description
Workfile template builder is saving workfiles with context which also creates workfile entity.

## Additional info
This does fix issue that workfile from templace builder is created and saved but is not available in database.

## Testing notes:
1. Run workfile builder in a host.
2. The workfile is available in launcher tool.
