### PR TITLE
Chore: Create hero version loader plugin cleanup

### DIFF
--- a/client/ayon_core/plugins/load/create_hero_version.py
+++ b/client/ayon_core/plugins/load/create_hero_version.py
@@ -210,7 +210,6 @@ class CreateHeroVersion(load.ProductLoaderPlugin):
             task_type = src_task_entity["taskType"]
 
         product_base_type = template_data["product"]["basetype"]
-        product_type = template_data["product"]["type"]
 
         # TODO how to get host name?
         host_name = None


### PR DESCRIPTION
## Changelog Description
Cleanup of Create hero version loader plugin.

## Additional info
I need to do other changes in the plugin but the current code structure makes it really complicated, so I decided to frist do small cleanup before the real changes are applied.

The code was copied from integrate plugin which means that it contained a lot of unnecessary steps and ilogical code. Like get `"hostName"` from context or finding transfers and hard links in instance data.

Avoid of guessing rootless path, instead use the one with which the path is calulated.

## Testing notes:
1. Create hero version load plugin should work.
