### PR TITLE
Publish plugins: Use product base types

### DIFF
--- a/client/ayon_core/plugins/publish/cleanup.py
+++ b/client/ayon_core/plugins/publish/cleanup.py
@@ -76,14 +76,17 @@ class CleanUp(pyblish.api.InstancePlugin):
 
         # TODO: Figure out whether this could be refactored to just a
         #  product_type in self.exclude_families check.
-        product_type = instance.data["productType"]
+        product_base_type = instance.data["productBaseType"]
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
+
         if any(
-            product_type in exclude_family
+            product_base_type in exclude_family
             for exclude_family in self.exclude_families
         ):
             self.log.debug(
-                "Skipping cleanup for instance because product "
-                f"type is excluded from cleanup: {product_type}")
+                "Skipping cleanup for instance because product base"
+                f" type is excluded from cleanup: {product_base_type}")
             return
 
         temp_root = tempfile.gettempdir()
@@ -116,7 +119,9 @@ class CleanUp(pyblish.api.InstancePlugin):
         transfers = instance.data.get("transfers", list())
 
         instance_families = instance.data.get("families", list())
-        instance_product_type = instance.data.get("productType")
+        instance_product_base_type = instance.data.get("productBaseType")
+        if not instance_product_base_type:
+            instance_product_base_type = instance.data.get("productType")
         dirnames = []
         transfers_dirs = []
 
@@ -141,7 +146,7 @@ class CleanUp(pyblish.api.InstancePlugin):
                 continue
 
             if (
-                instance_product_type == "render"
+                instance_product_base_type == "render"
                 or "render" in instance_families
             ):
                 self.log.info("Removing src: `{}`...".format(src))

--- a/client/ayon_core/plugins/publish/collect_anatomy_instance_data.py
+++ b/client/ayon_core/plugins/publish/collect_anatomy_instance_data.py
@@ -5,6 +5,7 @@ Requires:
     context     -> anatomyData
     instance    -> folderPath
     instance    -> productName
+    instance    -> productBaseType
     instance    -> productType
 
 Optional:
@@ -300,10 +301,14 @@ class CollectAnatomyInstanceData(pyblish.api.ContextPlugin):
             anatomy_data = copy.deepcopy(context.data["anatomyData"])
             product_name = instance.data["productName"]
             product_type = instance.data["productType"]
+            product_base_type = instance.data.get("productBaseType")
+            if not product_base_type:
+                product_base_type = product_type
             anatomy_data.update({
                 "product": {
                     "name": product_name,
                     "type": product_type,
+                    "basetype": product_base_type,
                 }
             })
 
@@ -340,9 +345,6 @@ class CollectAnatomyInstanceData(pyblish.api.ContextPlugin):
                 task_data = anatomy_data.get("task") or {}
                 task_name = task_data.get("name")
                 task_type = task_data.get("type")
-                product_base_type = instance.data.get("productBaseType")
-                if not product_base_type:
-                    product_base_type = instance.data["productType"]
                 version_number = get_versioning_start(
                     context.data["projectName"],
                     instance.context.data["hostName"],

--- a/client/ayon_core/plugins/publish/collect_from_create_context.py
+++ b/client/ayon_core/plugins/publish/collect_from_create_context.py
@@ -110,8 +110,12 @@ class CollectFromCreateContext(pyblish.api.ContextPlugin):
         product_name = in_data["productName"]
         # If instance data already contain families then use it
         instance_families = in_data.get("families") or []
-        # Add product type to families
-        instance_families.append(in_data["productType"])
+        # Add product base type to families
+        product_type = in_data["productType"]
+        product_base_type = in_data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_type
+        instance_families.append(product_base_type)
 
         instance = context.create_instance(product_name)
         instance.data.update({
@@ -121,8 +125,9 @@ class CollectFromCreateContext(pyblish.api.ContextPlugin):
             "folderPath": in_data["folderPath"],
             "task": in_data["task"],
             "productName": product_name,
-            "productType": in_data["productType"],
-            "family": in_data["productType"],
+            "productBaseType": product_base_type,
+            "productType": product_type,
+            "family": product_base_type,
             "families": instance_families,
             "representations": [],
             "thumbnailSource": thumbnail_path

--- a/client/ayon_core/plugins/publish/collect_hierarchy.py
+++ b/client/ayon_core/plugins/publish/collect_hierarchy.py
@@ -68,11 +68,13 @@ class CollectHierarchy(
         shot_instances = []
         for instance in context:
             # shot data dict
-            product_type = instance.data["productType"]
+            product_base_type = instance.data.get("productBaseType")
+            if not product_base_type:
+                product_base_type = instance.data["productType"]
             families = instance.data["families"]
 
             # exclude other families then "shot" with intersection
-            if "shot" not in (families + [product_type]):
+            if "shot" not in (families + [product_base_type]):
                 self.log.debug("Skipping not a shot: {}".format(families))
                 continue
 

--- a/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
+++ b/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
@@ -37,7 +37,11 @@ class CollectOtioSubsetResources(
             make_sequence_collection
         )
 
-        if "audio" in instance.data["productType"]:
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
+
+        if "audio" in product_base_type:
             return
 
         if not instance.data.get("representations"):

--- a/client/ayon_core/plugins/publish/extract_burnin.py
+++ b/client/ayon_core/plugins/publish/extract_burnin.py
@@ -159,7 +159,9 @@ class ExtractBurnin(publish.Extractor):
 
     def main_process(self, instance):
         host_name = instance.context.data["hostName"]
-        product_type = instance.data["productType"]
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
         product_name = instance.data["productName"]
         task_data = instance.data["anatomyData"].get("task", {})
         task_name = task_data.get("name")
@@ -167,7 +169,7 @@ class ExtractBurnin(publish.Extractor):
 
         filtering_criteria = {
             "hosts": host_name,
-            "product_types": product_type,
+            "product_types": product_base_type,
             "product_names": product_name,
             "task_names": task_name,
             "task_types": task_type,
@@ -178,23 +180,26 @@ class ExtractBurnin(publish.Extractor):
             logger=self.log
         )
         if not profile:
-            self.log.debug((
+            self.log.debug(
                 "Skipped instance. None of profiles in presets are for"
-                " Host: \"{}\" | Product type: \"{}\" | Product name \"{}\""
-                " | Task name \"{}\" | Task type \"{}\""
-            ).format(
-                host_name, product_type, product_name, task_name, task_type
-            ))
+                f" Host name: \"{host_name}\""
+                f" | Product base type: \"{product_base_type}\""
+                f" | Product name \"{product_name}\""
+                f" | Task name \"{task_name}\""
+                f" | Task type \"{task_type}\""
+            )
             return
 
         # Pre-filter burnin definitions by instance families
         burnin_defs = self.filter_burnins_defs(profile, instance)
         if not burnin_defs:
-            self.log.debug((
+            self.log.debug(
                 "Skipped instance. Burnin definitions are not set for profile"
-                " Host: \"{}\" | Product type: \"{}\" | Task name \"{}\""
-                " | Profile \"{}\""
-            ).format(host_name, product_type, task_name, profile))
+                f" Host name: \"{host_name}\""
+                f" | Product base type: \"{product_base_type}\""
+                f" | Task name \"{task_name}\""
+                f" | Profile \"{profile}\""
+            )
             return
 
         burnins_per_repres = self._get_burnins_per_representations(

--- a/client/ayon_core/plugins/publish/extract_color_transcode.py
+++ b/client/ayon_core/plugins/publish/extract_color_transcode.py
@@ -351,29 +351,35 @@ class ExtractOIIOTranscode(publish.Extractor):
     def _get_profile(self, instance):
         """Returns profile if and how repre should be color transcoded."""
         host_name = instance.context.data["hostName"]
-        product_type = instance.data["productType"]
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
         product_name = instance.data["productName"]
         task_data = instance.data["anatomyData"].get("task", {})
         task_name = task_data.get("name")
         task_type = task_data.get("type")
         filtering_criteria = {
             "hosts": host_name,
-            "product_types": product_type,
+            "product_types": product_base_type,
             "product_names": product_name,
             "task_names": task_name,
             "task_types": task_type,
         }
-        profile = filter_profiles(self.profiles, filtering_criteria,
-                                  logger=self.log)
+        profile = filter_profiles(
+            self.profiles,
+            filtering_criteria,
+            logger=self.log
+        )
 
         if not profile:
-            self.log.debug((
-              "Skipped instance. None of profiles in presets are for"
-              " Host: \"{}\" | Product types: \"{}\" | Product names: \"{}\""
-              " | Task name \"{}\" | Task type \"{}\""
-            ).format(
-                host_name, product_type, product_name, task_name, task_type
-            ))
+            self.log.debug(
+                "Skipped instance. None of profiles in presets are for"
+                f" Host name: \"{host_name}\""
+                f" | Product types: \"{product_base_type}\""
+                f" | Product names: \"{product_name}\""
+                f" | Task name \"{task_name}\""
+                f" | Task type \"{task_type}\""
+            )
 
         return profile
 

--- a/client/ayon_core/plugins/publish/extract_oiio_postprocess.py
+++ b/client/ayon_core/plugins/publish/extract_oiio_postprocess.py
@@ -272,7 +272,9 @@ class ExtractOIIOPostProcess(publish.Extractor):
     ) -> Optional[dict[str, Any]]:
         """Returns profile if it should process this instance."""
         host_name = instance.context.data["hostName"]
-        product_type = instance.data["productType"]
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
         product_name = instance.data["productName"]
         task_data = instance.data["anatomyData"].get("task", {})
         task_name = task_data.get("name")
@@ -281,7 +283,7 @@ class ExtractOIIOPostProcess(publish.Extractor):
         repre_ext: str = repre["ext"]
         filtering_criteria = {
             "host_names": host_name,
-            "product_types": product_type,
+            "product_types": product_base_type,
             "product_names": product_name,
             "task_names": task_name,
             "task_types": task_type,
@@ -294,12 +296,12 @@ class ExtractOIIOPostProcess(publish.Extractor):
         if not profile:
             self.log.debug(
               "Skipped instance. None of profiles in presets are for"
-              f" Host: \"{host_name}\" |"
-              f" Product types: \"{product_type}\" |"
-              f" Product names: \"{product_name}\" |"
-              f" Task name \"{task_name}\" |"
-              f" Task type \"{task_type}\" |"
-              f" Representation: \"{repre_name}\" (.{repre_ext})"
+              f" Host name: \"{host_name}\""
+              f" | Product types: \"{product_base_type}\""
+              f" | Product names: \"{product_name}\""
+              f" | Task name \"{task_name}\""
+              f" | Task type \"{task_type}\""
+              f" | Representation: \"{repre_name}\" (.{repre_ext})"
             )
 
         return profile

--- a/client/ayon_core/plugins/publish/extract_otio_audio_tracks.py
+++ b/client/ayon_core/plugins/publish/extract_otio_audio_tracks.py
@@ -22,8 +22,12 @@ def get_audio_instances(context):
     for instance in context:
         if not instance.data.get("parent_instance_id"):
             continue
+
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
         if (
-            instance.data["productType"] == "audio"
+            product_base_type == "audio"
             or instance.data.get("reviewAudio")
         ):
             audio_instances.append(instance)
@@ -185,7 +189,11 @@ class ExtractOtioAudioTracks(pyblish.api.ContextPlugin):
                 shot_audio_fpath = recycling_file.pop()
 
             # audio file needs to be published as representation
-            if audio_instance.data["productType"] == "audio":
+            a_product_base_type = audio_instance.data.get("productBaseType")
+            if not a_product_base_type:
+                a_product_base_type = audio_instance.data["productType"]
+
+            if a_product_base_type == "audio":
                 # create empty representation attr
                 if "representations" not in audio_instance.data:
                     audio_instance.data["representations"] = []

--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -207,29 +207,34 @@ class ExtractReview(pyblish.api.InstancePlugin):
 
     def _get_outputs_for_instance(self, instance):
         host_name = instance.context.data["hostName"]
-        product_type = instance.data["productType"]
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
         task_type = None
         task_entity = instance.data.get("taskEntity")
         if task_entity:
             task_type = task_entity["taskType"]
 
-        self.log.debug("Host: \"{}\"".format(host_name))
-        self.log.debug("Product type: \"{}\"".format(product_type))
-        self.log.debug("Task type: \"{}\"".format(task_type))
+        self.log.debug(
+            f"Host: \"{host_name}\""
+            f"\nProduct base type: \"{product_base_type}\""
+            f"\nTask type: \"{task_type}\""
+        )
 
         profile = filter_profiles(
             self.profiles,
             {
                 "hosts": host_name,
-                "product_types": product_type,
+                "product_types": product_base_type,
                 "task_types": task_type
             },
             logger=self.log)
         if not profile:
-            self.log.info((
+            self.log.info(
                 "Skipped instance. None of profiles in presets are for"
-                " Host: \"{}\" | Product type: \"{}\""
-            ).format(host_name, product_type))
+                f" Host: \"{host_name}\""
+                f" | Product base type: \"{product_base_type}\""
+            )
             return
 
         self.log.debug("Matching profile: \"{}\"".format(json.dumps(profile)))

--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -733,14 +733,16 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
     ) -> Optional[ThumbnailDef]:
         """Returns profile if and how repre should be color transcoded."""
         host_name = instance.context.data["hostName"]
-        product_type = instance.data["productType"]
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
         product_name = instance.data["productName"]
         task_data = instance.data["anatomyData"].get("task", {})
         task_name = task_data.get("name")
         task_type = task_data.get("type")
         filtering_criteria = {
             "host_names": host_name,
-            "product_types": product_type,
+            "product_types": product_base_type,
             "product_names": product_name,
             "task_names": task_name,
             "task_types": task_type,
@@ -754,8 +756,8 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         if not profile:
             self.log.debug(
                 "Skipped instance. None of profiles in presets are for"
-                f' Host: "{host_name}"'
-                f' | Product types: "{product_type}"'
+                f' Host name: "{host_name}"'
+                f' | Product types: "{product_base_type}"'
                 f' | Product names: "{product_name}"'
                 f' | Task name "{task_name}"'
                 f' | Task type "{task_type}"'

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -465,14 +465,16 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
             return existing_instance
 
         # Otherwise create the instance
+        product_base_type = "usd"
         new_instance = context.create_instance(name=product_name)
         new_instance.data.update(data)
 
         new_instance.data["label"] = (
             "{0} ({1})".format(product_name, new_instance.data["folderPath"])
         )
-        new_instance.data["family"] = "usd"
-        new_instance.data["productType"] = "usd"
+        new_instance.data["family"] = product_base_type
+        new_instance.data["productBaseType"] = product_base_type
+        new_instance.data["productType"] = product_base_type
         new_instance.data["icon"] = "link"
         new_instance.data["comment"] = "Automated bootstrap USD file."
         new_instance.append(source_instance.id)
@@ -494,8 +496,11 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
 
         # Set default target layer based on product type
         current_context_task_type = create_context.get_current_task_type()
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
         profile = filter_profiles(cls.profiles, {
-            "product_types": instance.data["productType"],
+            "product_types": product_base_type,
             "task_types": current_context_task_type
         })
         if not profile:

--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -141,10 +141,13 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         # Skip instance if there are not representations to integrate
         #   all representations should not be integrated
         if not filtered_repres:
-            self.log.info((
+            product_base_type = instance.data.get("productBaseType")
+            if not product_base_type:
+                product_base_type = instance.data["productType"]
+            self.log.info(
                 "Skipping, there are no representations"
-                " to integrate for instance {}"
-            ).format(instance.data["productType"]))
+                f" to integrate for instance {product_base_type}"
+            )
             return
 
         file_transactions = FileTransaction(log=self.log,
@@ -360,6 +363,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         product_name = instance.data["productName"]
         product_type = instance.data["productType"]
         product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_type
 
         self.log.debug("Product: {}".format(product_name))
 
@@ -388,18 +393,19 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
 
         new_product_entity_kwargs = {
             "name": product_name,
-            "product_type": product_type,
             "folder_id": folder_entity["id"],
             "attribs": attributes,
             "entity_id": product_id,
             "product_base_type": product_base_type,
+            "product_type": product_type,
         }
 
         if not is_product_base_type_supported():
             new_product_entity_kwargs.pop("product_base_type")
             if (
-                    product_base_type is not None
-                    and product_base_type != product_type):
+                product_base_type is not None
+                and product_base_type != product_type
+            ):
                 self.log.warning((
                     "Product base type %s is not supported by the server, "
                     "but it's defined - and it differs from product type %s. "

--- a/client/ayon_core/plugins/publish/integrate_attach_reviewable.py
+++ b/client/ayon_core/plugins/publish/integrate_attach_reviewable.py
@@ -117,7 +117,7 @@ class AttachReviewables(
                 continue
 
             # Do not allow attaching to other reviewable instances
-            if other_instance.data["productType"] in cls.families:
+            if other_instance.product_base_type in cls.families:
                 continue
 
             items.append(

--- a/client/ayon_core/plugins/publish/integrate_inputlinks.py
+++ b/client/ayon_core/plugins/publish/integrate_inputlinks.py
@@ -72,8 +72,11 @@ class IntegrateInputLinksAYON(pyblish.api.ContextPlugin):
                     "Instance {} doesn't have version.".format(instance))
                 continue
 
-            product_type = instance.data["productType"]
-            if product_type == "workfile":
+            product_base_type = instance.data.get("productBaseType")
+            if not product_base_type:
+                product_base_type = instance.data["productType"]
+
+            if product_base_type == "workfile":
                 workfile_instance = instance
             else:
                 other_instances.append(instance)

--- a/client/ayon_core/plugins/publish/integrate_product_group.py
+++ b/client/ayon_core/plugins/publish/integrate_product_group.py
@@ -60,6 +60,9 @@ class IntegrateProductGroup(pyblish.api.InstancePlugin):
         template = profile["template"]
         product_name = instance.data["productName"]
         product_type = instance.data["productType"]
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = product_type
 
         fill_pairs = prepare_template_data({
             "task": filter_criteria["tasks"],
@@ -67,6 +70,7 @@ class IntegrateProductGroup(pyblish.api.InstancePlugin):
             "product": {
                 "name": product_name,
                 "type": product_type,
+                "basetype": product_base_type,
             },
             "renderlayer": instance.data.get("renderlayer")
         })
@@ -96,8 +100,11 @@ class IntegrateProductGroup(pyblish.api.InstancePlugin):
         task = anatomy_data.get("task", {})
 
         # Return filter criteria
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
         return {
-            "product_types": instance.data["productType"],
+            "product_types": product_base_type,
             "tasks": task.get("name"),
             "hosts": instance.context.data["hostName"],
             "task_types": task.get("type")

--- a/client/ayon_core/plugins/publish/preintegrate_thumbnail_representation.py
+++ b/client/ayon_core/plugins/publish/preintegrate_thumbnail_representation.py
@@ -39,7 +39,9 @@ class PreIntegrateThumbnails(pyblish.api.InstancePlugin):
         if not thumbnail_repres:
             return
 
-        product_type = instance.data["productType"]
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
         product_name = instance.data["productName"]
         host_name = instance.context.data["hostName"]
 
@@ -52,7 +54,7 @@ class PreIntegrateThumbnails(pyblish.api.InstancePlugin):
                 "hosts": host_name,
                 "task_names": task.get("name"),
                 "task_types": task.get("type"),
-                "product_types": product_type,
+                "product_types": product_base_type,
                 "product_names": product_name,
             },
             logger=self.log


### PR DESCRIPTION
## Changelog Description
Use product base types in publish plugins as source for family and source of filtering.

## Additional info
This PR does not include changes of settings, that will be added in separate PR which will change all existing settings all over ayon-core.

This PR also does not change logic in `pipeline/publish`, that will be different change which will require more carefull testing across multiple addons.

## Testing notes:
1. Validate that all publish plugins are using product base type.
