### PR TITLE
add proposal to handle the setting of use last published workfile

### DIFF
--- a/client/ayon_core/hooks/pre_add_last_workfile_arg.py
+++ b/client/ayon_core/hooks/pre_add_last_workfile_arg.py
@@ -1,6 +1,24 @@
+from datetime import datetime
+import logging
 import os
+import shutil
+
+import ayon_api
 
 from ayon_applications import PreLaunchHook, LaunchTypes
+from ayon_api import (
+    get_representations,
+    get_products,
+    get_last_versions
+)
+
+from ayon_core.pipeline.template_data import get_template_data
+from ayon_core.pipeline.workfile import get_workfile_template_key
+
+from ayon_core.pipeline.workfile import should_use_last_workfile_on_launch, \
+    should_use_last_published_workfile_on_launch
+
+from ayon_core.pipeline.load import get_representation_path_with_anatomy
 
 
 class AddLastWorkfileToLaunchArgs(PreLaunchHook):
@@ -39,6 +57,9 @@ class AddLastWorkfileToLaunchArgs(PreLaunchHook):
     launch_types = {LaunchTypes.local}
 
     def execute(self):
+        # self.log.addHandler(
+        #     logging.FileHandler(r"C:\TEMP\%s.log" % self.__class__.__name__,
+        #                         encoding="utf-8"))
         workfile_path = self.data.get("workfile_path")
         if not workfile_path:
             if not self.data.get("start_last_workfile"):
@@ -53,6 +74,144 @@ class AddLastWorkfileToLaunchArgs(PreLaunchHook):
         if not os.path.exists(workfile_path):
             self.log.info("Current context does not have any workfile yet.")
             return
+        self.log.info(f"Last workfile path start: {workfile_path}")
+        project_name = self.data["project_name"]
+        project_settings = self.data["project_settings"]
+        anatomy = self.data["anatomy"]
+        task_id = self.data["task_entity"]["id"]
+        folder_entity = self.data["folder_entity"]
+        folder_id = folder_entity["id"]
+        task_name = self.data["task_name"]
+        task_type = self.data["task_type"]
+        project_entity = self.data["project_entity"]
+        task_entity = self.data["task_entity"]
+        host_name = self.application.host_name
+        host_addon = self.addons_manager.get_host_addon(host_name)
+        workfile_extensions = host_addon.get_workfile_extensions()
 
-        # Add path to workfile to arguments
-        self.launch_context.launch_args.append(workfile_path)
+
+        # check the settings is this wanted at all
+        use_last_workfile = should_use_last_workfile_on_launch(
+            project_name,
+            host_name,
+            task_name,
+            task_type,
+            project_settings=project_settings
+        )
+        # check if last published workfile is wanted
+        use_last_published_workfile = should_use_last_published_workfile_on_launch(
+            project_name,
+            host_name,
+            task_name,
+            task_type,
+            project_settings=project_settings
+        )
+        if not use_last_workfile:
+            self.log.info("It is set to not start last workfile on start.")
+            return
+
+        if use_last_workfile and not use_last_published_workfile:
+            # Add path to workfile to arguments
+            self.launch_context.launch_args.append(workfile_path)
+            return
+
+        workfile_representation = (
+            self._get_last_published_workfile_representation(
+                project_name, folder_id, task_id, workfile_extensions
+            )
+        )
+
+        # compare timestamps of the latest publish to the latest local workfile
+        # bail out if the local file is newer
+        created_at_timestamp = datetime.fromisoformat(
+            workfile_representation["createdAt"]).timestamp()
+
+        if created_at_timestamp < os.path.getmtime(workfile_path):
+            self.log.info(
+                "Local workfile is newer than published workfile, skipping")
+            self.launch_context.launch_args.append(workfile_path)
+            return
+
+        # Get workfile data
+        workfile_data = get_template_data(
+            project_entity, folder_entity, task_entity, host_name,
+            project_settings
+        )
+        self.log.info(f"Workfile data: {workfile_data}")
+        last_published_workfile_path = get_representation_path_with_anatomy(
+            workfile_representation, anatomy
+        )
+        workfile_entities = list(ayon_api.get_workfiles_info(
+            project_name,
+            task_ids=[task_id]
+        ))
+
+        latest_workfile_entity = workfile_entities[-1]
+        latest_workfile_entity_version = latest_workfile_entity["data"]["version"]
+        self.log.info(f"Latest workfile version: {latest_workfile_entity_version}")
+        self.log.info(f"Last published workfile path: {last_published_workfile_path}")
+
+        extension = last_published_workfile_path.split(".")[-1]
+        workfile_data["version"] = (
+                latest_workfile_entity_version + 1)
+        workfile_data["ext"] = extension
+
+        template_key = get_workfile_template_key(
+            task_name, host_name, project_name, project_settings
+        )
+        template = anatomy.get_template_item("work", template_key, "path")
+        local_workfile_path = template.format_strict(workfile_data)
+        self.log.info(f"Local workfile path: {local_workfile_path}")
+
+        # Copy last published workfile to local workfile directory
+        shutil.copy(
+            last_published_workfile_path,
+            local_workfile_path,
+        )
+
+        self.data["last_workfile_path"] = local_workfile_path
+        # Keep source filepath for further path conformation
+        self.data["source_filepath"] = last_published_workfile_path
+        self.launch_context.launch_args.append(local_workfile_path)
+
+    def _get_last_published_workfile_representation(self,
+                                                    project_name, folder_id,
+                                                    task_id, workfile_extensions
+                                                    ):
+        """Looks for last published representation for host and context"""
+
+        product_entities = get_products(
+            project_name,
+            folder_ids={folder_id},
+            product_types={"workfile"}
+        )
+        product_ids = {
+            product_entity["id"]
+            for product_entity in product_entities
+        }
+        if not product_ids:
+            return None
+
+        versions_by_product_id = get_last_versions(
+            project_name,
+            product_ids
+        )
+        version_ids = {
+            version_entity["id"]
+            for version_entity in versions_by_product_id.values()
+            if version_entity["taskId"] == task_id
+        }
+        if not version_ids:
+            return None
+
+        for representation_entity in get_representations(
+                project_name,
+                version_ids=version_ids,
+        ):
+            ext = representation_entity["context"].get("ext")
+            if not ext:
+                continue
+            ext = f".{ext}"
+            if ext in workfile_extensions:
+                return representation_entity
+        return None

--- a/client/ayon_core/pipeline/workfile/__init__.py
+++ b/client/ayon_core/pipeline/workfile/__init__.py
@@ -19,6 +19,7 @@ from .path_resolving import (
 
 from .utils import (
     should_use_last_workfile_on_launch,
+    should_use_last_published_workfile_on_launch,
     should_open_workfiles_tool_on_launch,
     MissingWorkdirError,
 
@@ -62,6 +63,7 @@ __all__ = (
     "get_comments_from_workfile_paths",
 
     "should_use_last_workfile_on_launch",
+    "should_use_last_published_workfile_on_launch",
     "should_open_workfiles_tool_on_launch",
     "MissingWorkdirError",
 

--- a/client/ayon_core/pipeline/workfile/utils.py
+++ b/client/ayon_core/pipeline/workfile/utils.py
@@ -137,6 +137,65 @@ def should_use_last_workfile_on_launch(
         return default_output
     return output
 
+def should_use_last_published_workfile_on_launch(
+    project_name: str,
+    host_name: str,
+    task_name: str,
+    task_type: str,
+    default_output: bool = False,
+    project_settings: Optional[dict[str, Any]] = None,
+) -> bool:
+    """Define if host should use the last published workfile if possible.
+
+    Default output is `False`. Can be overridden with environment variable
+    `AYON_OPEN_LAST_WORKFILE`, valid values without case sensitivity are
+    `"0", "1", "true", "false", "yes", "no"`.
+
+    Args:
+        project_name (str): Name of project.
+        host_name (str): Name of host which is launched. In avalon's
+            application context it's value stored in app definition under
+            key `"application_dir"`. Is not case sensitive.
+        task_name (str): Name of task which is used for launching the host.
+            Task name is not case sensitive.
+        task_type (str): Task type.
+        default_output (Optional[bool]): Default output value if no profile
+            is found.
+        project_settings (Optional[dict[str, Any]]): Project settings.
+
+    Returns:
+        bool: True if host should use the latest publish workfile.
+
+    """
+    if project_settings is None:
+        project_settings = get_project_settings(project_name)
+    profiles = (
+        project_settings
+        ["core"]
+        ["tools"]
+        ["Workfiles"]
+        ["last_workfile_on_startup"]
+    )
+
+    if not profiles:
+        return default_output
+
+    filter_data = {
+        "tasks": task_name,
+        "task_types": task_type,
+        "hosts": host_name
+    }
+    matching_item = filter_profiles(profiles, filter_data)
+
+    output = None
+    if matching_item:
+        if matching_item.get("enabled"):
+            output = matching_item.get("use_last_published_workfile")
+
+    if output is None:
+        return default_output
+    return output
+
 
 def should_open_workfiles_tool_on_launch(
     project_name,


### PR DESCRIPTION
…launch

## Changelog Description
The Setting use_last_published_workfile is not implemented.
This is a proposal that would use this setting to use the latest publish workfile in case it is newer compared to the local existing workfiles.

It use mtime of the latest available workfile to compare to the createdAt time from the latest publish.
In case the publish is newer it will copy the file over and version it as the highest workfile number found in the db for that task.

## Additional info
This should close https://github.com/ynput/ayon-core/issues/1346

## Testing notes:
1. start with this step
2. follow this step
