### PR TITLE
Add extract review for workflow publishes

### DIFF
--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -165,7 +165,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
         "batchdelivery",
         "photoshop",
         "substancepainter",
-        "workflow"
+        "workflow",
     ]
 
     settings_category = "core"


### PR DESCRIPTION
## Changelog Description
We want extract_review to run when workflows are publishing. The hosts filter restricts this extractor so it doesn't run for workflow publishes, adding workflow to hosts resolves this.

## Additional info
+ Add workflow host to extract review.

## Testing notes:
1. Run a workflow with a publish node

Closes #1691 
