### PR TITLE
Fix: use last published workfile

### DIFF
--- a/client/ayon_core/hooks/pre_collect_last_published_workfile_data.py
+++ b/client/ayon_core/hooks/pre_collect_last_published_workfile_data.py
@@ -1,0 +1,44 @@
+"""Collect launch-context data for published workfile copy flow."""
+
+from ayon_applications import PreLaunchHook, LaunchTypes
+from ayon_core.hooks.pre_find_last_published_workfile_representation import FindLastPublishedWorkfileRepresentation
+from ayon_core.pipeline.workfile import get_workfile_on_launch_profile
+
+
+class CollectLastPublishedWorkfileData(PreLaunchHook):
+    """Collect settings and extension inputs for published workfile copy."""
+
+    order = FindLastPublishedWorkfileRepresentation.order - 0.001
+    launch_types = {LaunchTypes.local}
+
+    def execute(self):
+        if not self.data.get("start_last_workfile"):
+            return
+
+        project_name = self.data["project_name"]
+        task_name = self.data["task_name"]
+        task_type = self.data["task_type"]
+        host_name = self.application.host_name
+
+        profile = get_workfile_on_launch_profile(
+            project_name,
+            host_name,
+            task_name,
+            task_type,
+            project_settings=self.data.get("project_settings"),
+        )
+        if not profile or not profile.get("use_last_published_workfile"):
+            return
+
+        folder_entity = self.data.get("folder_entity")
+        task_entity = self.data.get("task_entity")
+        if not folder_entity or not task_entity:
+            return
+
+        host_addon = self.addons_manager.get_host_addon(host_name)
+        extensions = None
+        if host_addon:
+            extensions = host_addon.get_workfile_extensions()
+
+        self.data["copy_last_published_workfile_enabled"] = True
+        self.data["copy_last_published_workfile_extensions"] = extensions

--- a/client/ayon_core/hooks/pre_collect_last_published_workfile_data.py
+++ b/client/ayon_core/hooks/pre_collect_last_published_workfile_data.py
@@ -11,7 +11,7 @@ class CollectLastPublishedWorkfileData(PreLaunchHook):
     launch_types = {LaunchTypes.local}
 
     def execute(self):
-        if self.data.get("workfile_path") or self.data.get(
+        if self.data.get("workfile_path") or not self.data.get(
             "start_last_workfile"
         ):
             return

--- a/client/ayon_core/hooks/pre_collect_last_published_workfile_data.py
+++ b/client/ayon_core/hooks/pre_collect_last_published_workfile_data.py
@@ -1,14 +1,13 @@
 """Collect launch-context data for published workfile copy flow."""
 
 from ayon_applications import PreLaunchHook, LaunchTypes
-from ayon_core.hooks.pre_find_last_published_workfile_representation import FindLastPublishedWorkfileRepresentation
 from ayon_core.pipeline.workfile import get_workfile_on_launch_profile
 
 
 class CollectLastPublishedWorkfileData(PreLaunchHook):
     """Collect settings and extension inputs for published workfile copy."""
 
-    order = FindLastPublishedWorkfileRepresentation.order - 0.001
+    order = 5 - 0.2  # Before FindLastPublishedWorkfileRepresentation
     launch_types = {LaunchTypes.local}
 
     def execute(self):
@@ -27,7 +26,7 @@ class CollectLastPublishedWorkfileData(PreLaunchHook):
             task_type,
             project_settings=self.data.get("project_settings"),
         )
-        if not profile or not profile.get("use_last_published_workfile"):
+        if not profile or not profile.use_last_published_workfile:
             return
 
         folder_entity = self.data.get("folder_entity")
@@ -35,10 +34,4 @@ class CollectLastPublishedWorkfileData(PreLaunchHook):
         if not folder_entity or not task_entity:
             return
 
-        host_addon = self.addons_manager.get_host_addon(host_name)
-        extensions = None
-        if host_addon:
-            extensions = host_addon.get_workfile_extensions()
-
         self.data["copy_last_published_workfile_enabled"] = True
-        self.data["copy_last_published_workfile_extensions"] = extensions

--- a/client/ayon_core/hooks/pre_collect_last_published_workfile_data.py
+++ b/client/ayon_core/hooks/pre_collect_last_published_workfile_data.py
@@ -11,7 +11,9 @@ class CollectLastPublishedWorkfileData(PreLaunchHook):
     launch_types = {LaunchTypes.local}
 
     def execute(self):
-        if not self.data.get("start_last_workfile"):
+        if self.data.get("workfile_path") or self.data.get(
+            "start_last_workfile"
+        ):
             return
 
         project_name = self.data["project_name"]
@@ -27,11 +29,6 @@ class CollectLastPublishedWorkfileData(PreLaunchHook):
             project_settings=self.data.get("project_settings"),
         )
         if not profile or not profile.use_last_published_workfile:
-            return
-
-        folder_entity = self.data.get("folder_entity")
-        task_entity = self.data.get("task_entity")
-        if not folder_entity or not task_entity:
             return
 
         self.data["copy_last_published_workfile_enabled"] = True

--- a/client/ayon_core/hooks/pre_copy_last_published_workfile.py
+++ b/client/ayon_core/hooks/pre_copy_last_published_workfile.py
@@ -1,68 +1,30 @@
-"""Pre-launch hook to copy the last published workfile into the work directory."""
+"""Copy last published workfile into local work directory."""
 
 from ayon_applications import PreLaunchHook, LaunchTypes
 from ayon_core.hooks.pre_add_last_workfile_arg import AddLastWorkfileToLaunchArgs
-from ayon_core.pipeline.workfile import (
-    get_workfile_on_launch_profile,
-    get_last_published_workfile_representation,
-    copy_last_published_workfile,
-)
+from ayon_core.pipeline.workfile import copy_last_published_workfile
 
 
 class CopyLastPublishedWorkfile(PreLaunchHook):
-    """Copy the last published workfile to the work directory.
-
-    Runs before the workfile path is added to launch args. 
-    Reads the 'use_last_published_workfile' flag from the matched
-    last_workfile_on_startup profile. Only copies when the published
-    file is newer than the latest local workfile.
-    """
+    """Copy the found published workfile and update launch context paths."""
 
     order = AddLastWorkfileToLaunchArgs.order - 0.001
     launch_types = {LaunchTypes.local}
 
     def execute(self):
-        if not self.data.get("start_last_workfile"):
+        if not self.data.get("copy_last_published_workfile_enabled"):
+            return
+
+        published_info = self.data.get("last_published_workfile_info")
+        if not published_info:
             return
 
         project_name = self.data["project_name"]
-        task_name = self.data["task_name"]
-        task_type = self.data["task_type"]
         host_name = self.application.host_name
-
-        profile = get_workfile_on_launch_profile(
-            project_name,
-            host_name,
-            task_name,
-            task_type,
-            project_settings=self.data.get("project_settings"),
-        )
-        if not profile or not profile.get("use_last_published_workfile"):
-            return
-
-        folder_entity = self.data.get("folder_entity")
-        task_entity = self.data.get("task_entity")
-        if not folder_entity or not task_entity:
-            return
-
-        host_addon = self.addons_manager.get_host_addon(host_name)
-        extensions = None
-        if host_addon:
-            extensions = host_addon.get_workfile_extensions()
-
+        folder_entity = self.data["folder_entity"]
+        task_entity = self.data["task_entity"]
         anatomy = self.data.get("anatomy")
         project_settings = self.data.get("project_settings")
-
-        published_info = get_last_published_workfile_representation(
-            project_name,
-            folder_entity["id"],
-            task_entity["id"],
-            extensions=extensions,
-            anatomy=anatomy,
-            project_settings=project_settings,
-        )
-        if not published_info:
-            return
 
         new_path = copy_last_published_workfile(
             project_name,
@@ -79,3 +41,4 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         )
         if new_path:
             self.data["last_workfile_path"] = new_path
+            self.data["env"]["AYON_LAST_WORKFILE"] = new_path

--- a/client/ayon_core/hooks/pre_copy_last_published_workfile.py
+++ b/client/ayon_core/hooks/pre_copy_last_published_workfile.py
@@ -1,0 +1,81 @@
+"""Pre-launch hook to copy the last published workfile into the work directory."""
+
+from ayon_applications import PreLaunchHook, LaunchTypes
+from ayon_core.hooks.pre_add_last_workfile_arg import AddLastWorkfileToLaunchArgs
+from ayon_core.pipeline.workfile import (
+    get_workfile_on_launch_profile,
+    get_last_published_workfile_representation,
+    copy_last_published_workfile,
+)
+
+
+class CopyLastPublishedWorkfile(PreLaunchHook):
+    """Copy the last published workfile to the work directory.
+
+    Runs before the workfile path is added to launch args. 
+    Reads the 'use_last_published_workfile' flag from the matched
+    last_workfile_on_startup profile. Only copies when the published
+    file is newer than the latest local workfile.
+    """
+
+    order = AddLastWorkfileToLaunchArgs.order - 0.001
+    launch_types = {LaunchTypes.local}
+
+    def execute(self):
+        if not self.data.get("start_last_workfile"):
+            return
+
+        project_name = self.data["project_name"]
+        task_name = self.data["task_name"]
+        task_type = self.data["task_type"]
+        host_name = self.application.host_name
+
+        profile = get_workfile_on_launch_profile(
+            project_name,
+            host_name,
+            task_name,
+            task_type,
+            project_settings=self.data.get("project_settings"),
+        )
+        if not profile or not profile.get("use_last_published_workfile"):
+            return
+
+        folder_entity = self.data.get("folder_entity")
+        task_entity = self.data.get("task_entity")
+        if not folder_entity or not task_entity:
+            return
+
+        host_addon = self.addons_manager.get_host_addon(host_name)
+        extensions = None
+        if host_addon:
+            extensions = host_addon.get_workfile_extensions()
+
+        anatomy = self.data.get("anatomy")
+        project_settings = self.data.get("project_settings")
+
+        published_info = get_last_published_workfile_representation(
+            project_name,
+            folder_entity["id"],
+            task_entity["id"],
+            extensions=extensions,
+            anatomy=anatomy,
+            project_settings=project_settings,
+        )
+        if not published_info:
+            return
+
+        new_path = copy_last_published_workfile(
+            project_name,
+            folder_entity,
+            task_entity,
+            host_name,
+            published_info,
+            workdir=None,
+            file_template=None,
+            workdir_data=None,
+            anatomy=anatomy,
+            project_settings=project_settings,
+            log=self.log,
+        )
+        if new_path:
+            self.data["last_workfile_path"] = new_path

--- a/client/ayon_core/hooks/pre_copy_last_published_workfile.py
+++ b/client/ayon_core/hooks/pre_copy_last_published_workfile.py
@@ -1,44 +1,82 @@
 """Copy last published workfile into local work directory."""
 
+from pathlib import Path
+import shutil
 from ayon_applications import PreLaunchHook, LaunchTypes
-from ayon_core.hooks.pre_add_last_workfile_arg import AddLastWorkfileToLaunchArgs
-from ayon_core.pipeline.workfile import copy_last_published_workfile
+from ayon_core.pipeline import Anatomy, get_representation_path
+from ayon_core.pipeline.workfile import (
+    find_workfile_rootless_path,
+    save_workfile_info,
+)
+from ayon_core.settings import get_project_settings
 
 
 class CopyLastPublishedWorkfile(PreLaunchHook):
     """Copy the found published workfile and update launch context paths."""
 
-    order = AddLastWorkfileToLaunchArgs.order - 0.001
+    order = 5
     launch_types = {LaunchTypes.local}
 
     def execute(self):
         if not self.data.get("copy_last_published_workfile_enabled"):
             return
 
-        published_info = self.data.get("last_published_workfile_info")
-        if not published_info:
+        representation_entity = self.data.get("last_published_workfile_info")
+        if not representation_entity:
             return
 
         project_name = self.data["project_name"]
         host_name = self.application.host_name
         folder_entity = self.data["folder_entity"]
         task_entity = self.data["task_entity"]
-        anatomy = self.data.get("anatomy")
-        project_settings = self.data.get("project_settings")
+        anatomy = self.data.get("anatomy", Anatomy(project_name))
+        project_settings = self.data.get(
+            "project_settings", get_project_settings(project_name)
+        )
+        if not (last_workfile_path := self.data.get("last_workfile_path")):
+            return
 
-        new_path = copy_last_published_workfile(
+        source_path = Path(
+            get_representation_path(
+                project_name,
+                representation_entity,
+                anatomy=anatomy,
+            )
+        )
+        if not source_path.exists():
+            return
+
+        dst_path = Path(last_workfile_path).resolve()
+        if dst_path.exists():
+            published_mtime = source_path.stat().st_mtime
+            local_mtime = dst_path.stat().st_mtime
+            if published_mtime <= local_mtime:
+                if self.log:
+                    self.log.debug(
+                        "Latest local workfile is newer than last published; "
+                        "skipping copy."
+                    )
+                return
+
+        dst_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, dst_path)
+
+        rootless_path = find_workfile_rootless_path(
+            str(dst_path),
             project_name,
             folder_entity,
             task_entity,
             host_name,
-            published_info,
-            workdir=None,
-            file_template=None,
-            workdir_data=None,
-            anatomy=anatomy,
             project_settings=project_settings,
-            log=self.log,
+            anatomy=anatomy,
         )
-        if new_path:
-            self.data["last_workfile_path"] = new_path
-            self.data["env"]["AYON_LAST_WORKFILE"] = new_path
+        save_workfile_info(
+            project_name,
+            task_entity["id"],
+            rootless_path,
+            host_name,
+        )
+        self.log.info(f"Copied last published workfile to {dst_path}")
+
+        self.data["last_workfile_path"] = dst_path.as_posix()
+        self.data["env"]["AYON_LAST_WORKFILE"] = dst_path.as_posix()

--- a/client/ayon_core/hooks/pre_find_last_published_workfile_representation.py
+++ b/client/ayon_core/hooks/pre_find_last_published_workfile_representation.py
@@ -1,0 +1,36 @@
+"""Resolve latest published workfile representation for launch context."""
+
+from ayon_applications import PreLaunchHook, LaunchTypes
+from ayon_core.hooks.pre_copy_last_published_workfile import CopyLastPublishedWorkfile
+from ayon_core.pipeline.workfile import get_last_published_workfile_representation
+
+
+class FindLastPublishedWorkfileRepresentation(PreLaunchHook):
+    """Find the latest published workfile representation for the context."""
+
+    order = CopyLastPublishedWorkfile.order - 0.001
+    launch_types = {LaunchTypes.local}
+
+    def execute(self):
+        if not self.data.get("copy_last_published_workfile_enabled"):
+            return
+
+        project_name = self.data["project_name"]
+        folder_entity = self.data.get("folder_entity")
+        task_entity = self.data.get("task_entity")
+        if not folder_entity or not task_entity:
+            return
+
+        anatomy = self.data.get("anatomy")
+        project_settings = self.data.get("project_settings")
+        extensions = self.data.get("copy_last_published_workfile_extensions")
+
+        published_info = get_last_published_workfile_representation(
+            project_name,
+            folder_entity["id"],
+            task_entity["id"],
+            extensions=extensions,
+            anatomy=anatomy,
+            project_settings=project_settings,
+        )
+        self.data["last_published_workfile_info"] = published_info

--- a/client/ayon_core/hooks/pre_find_last_published_workfile_representation.py
+++ b/client/ayon_core/hooks/pre_find_last_published_workfile_representation.py
@@ -1,14 +1,15 @@
 """Resolve latest published workfile representation for launch context."""
 
 from ayon_applications import PreLaunchHook, LaunchTypes
-from ayon_core.hooks.pre_copy_last_published_workfile import CopyLastPublishedWorkfile
-from ayon_core.pipeline.workfile import get_last_published_workfile_representation
+from ayon_core.pipeline.workfile import (
+    get_last_published_workfile_representation,
+)
 
 
 class FindLastPublishedWorkfileRepresentation(PreLaunchHook):
     """Find the latest published workfile representation for the context."""
 
-    order = CopyLastPublishedWorkfile.order - 0.001
+    order = 5 - 0.1  # Before CopyLastPublishedWorkfile
     launch_types = {LaunchTypes.local}
 
     def execute(self):
@@ -21,16 +22,27 @@ class FindLastPublishedWorkfileRepresentation(PreLaunchHook):
         if not folder_entity or not task_entity:
             return
 
+        host_addon = self.addons_manager.get_host_addon(
+            self.application.host_name
+        )
+        extensions = set()
+        if host_addon:
+            extensions = {
+                str(ext).lstrip(".").lower()
+                for ext in host_addon.get_workfile_extensions()
+            }
+        if not extensions:
+            return
+
         anatomy = self.data.get("anatomy")
         project_settings = self.data.get("project_settings")
-        extensions = self.data.get("copy_last_published_workfile_extensions")
-
-        published_info = get_last_published_workfile_representation(
-            project_name,
-            folder_entity["id"],
-            task_entity["id"],
-            extensions=extensions,
-            anatomy=anatomy,
-            project_settings=project_settings,
+        self.data["last_published_workfile_info"] = (
+            get_last_published_workfile_representation(
+                project_name,
+                folder_entity["id"],
+                task_entity["id"],
+                extensions=extensions,
+                anatomy=anatomy,
+                project_settings=project_settings,
+            )
         )
-        self.data["last_published_workfile_info"] = published_info

--- a/client/ayon_core/hooks/pre_find_last_published_workfile_representation.py
+++ b/client/ayon_core/hooks/pre_find_last_published_workfile_representation.py
@@ -19,20 +19,14 @@ class FindLastPublishedWorkfileRepresentation(PreLaunchHook):
         project_name = self.data["project_name"]
         folder_entity = self.data.get("folder_entity")
         task_entity = self.data.get("task_entity")
-        if not folder_entity or not task_entity:
-            return
 
         host_addon = self.addons_manager.get_host_addon(
             self.application.host_name
         )
-        extensions = set()
-        if host_addon:
-            extensions = {
-                str(ext).lstrip(".").lower()
-                for ext in host_addon.get_workfile_extensions()
-            }
-        if not extensions:
-            return
+        extensions = {
+            str(ext).lstrip(".").lower()
+            for ext in host_addon.get_workfile_extensions()
+        }
 
         anatomy = self.data.get("anatomy")
         project_settings = self.data.get("project_settings")

--- a/client/ayon_core/pipeline/workfile/__init__.py
+++ b/client/ayon_core/pipeline/workfile/__init__.py
@@ -18,11 +18,13 @@ from .path_resolving import (
 )
 
 from .utils import (
+    get_workfile_on_launch_profile,
     should_use_last_workfile_on_launch,
-    should_copy_last_published_workfile_on_launch,
     should_open_workfiles_tool_on_launch,
     MissingWorkdirError,
 
+    LastPublishedWorkfileInfo,
+    get_last_published_workfile_representation,
     copy_last_published_workfile,
 
     save_workfile_info,
@@ -64,11 +66,13 @@ __all__ = (
 
     "get_comments_from_workfile_paths",
 
+    "get_workfile_on_launch_profile",
     "should_use_last_workfile_on_launch",
-    "should_copy_last_published_workfile_on_launch",
     "should_open_workfiles_tool_on_launch",
     "MissingWorkdirError",
 
+    "LastPublishedWorkfileInfo",
+    "get_last_published_workfile_representation",
     "copy_last_published_workfile",
 
     "save_workfile_info",

--- a/client/ayon_core/pipeline/workfile/__init__.py
+++ b/client/ayon_core/pipeline/workfile/__init__.py
@@ -19,8 +19,11 @@ from .path_resolving import (
 
 from .utils import (
     should_use_last_workfile_on_launch,
+    should_copy_last_published_workfile_on_launch,
     should_open_workfiles_tool_on_launch,
     MissingWorkdirError,
+
+    copy_last_published_workfile,
 
     save_workfile_info,
     save_current_workfile_to,
@@ -62,8 +65,11 @@ __all__ = (
     "get_comments_from_workfile_paths",
 
     "should_use_last_workfile_on_launch",
+    "should_copy_last_published_workfile_on_launch",
     "should_open_workfiles_tool_on_launch",
     "MissingWorkdirError",
+
+    "copy_last_published_workfile",
 
     "save_workfile_info",
     "save_current_workfile_to",

--- a/client/ayon_core/pipeline/workfile/__init__.py
+++ b/client/ayon_core/pipeline/workfile/__init__.py
@@ -22,10 +22,8 @@ from .utils import (
     should_use_last_workfile_on_launch,
     should_open_workfiles_tool_on_launch,
     MissingWorkdirError,
-
-    LastPublishedWorkfileInfo,
+    WorkfileOnLaunchProfile,
     get_last_published_workfile_representation,
-    copy_last_published_workfile,
 
     save_workfile_info,
     save_current_workfile_to,
@@ -70,10 +68,8 @@ __all__ = (
     "should_use_last_workfile_on_launch",
     "should_open_workfiles_tool_on_launch",
     "MissingWorkdirError",
-
-    "LastPublishedWorkfileInfo",
+    "WorkfileOnLaunchProfile",
     "get_last_published_workfile_representation",
-    "copy_last_published_workfile",
 
     "save_workfile_info",
     "save_current_workfile_to",

--- a/client/ayon_core/pipeline/workfile/utils.py
+++ b/client/ayon_core/pipeline/workfile/utils.py
@@ -170,13 +170,9 @@ def should_copy_last_published_workfile_on_launch(
     """
     if project_settings is None:
         project_settings = get_project_settings(project_name)
-    setting_profiles = (
-        project_settings
-        ["core"]
-        ["tools"]
-        ["Workfiles"]
-        ["last_workfile_on_startup"]
-    )
+    setting_profiles = project_settings["core"]["tools"]["Workfiles"][
+        "last_workfile_on_startup"
+    ]
     if not setting_profiles:
         return None
 
@@ -189,7 +185,9 @@ def should_copy_last_published_workfile_on_launch(
     if not matched_settings:
         return None
 
-    return matched_settings.get("enabled", False) and matched_settings.get("use_last_published_workfile", False)
+    return matched_settings.get("enabled", False) and matched_settings.get(
+        "use_last_published_workfile", False
+    )
 
 
 def copy_last_published_workfile(
@@ -217,7 +215,8 @@ def copy_last_published_workfile(
         folder_id (str): Folder id.
         task_id (str): Task id (used to filter published versions).
         workdir (str): Path to the work directory.
-        extensions (Iterable[str]): Allowed workfile extensions (e.g. [".blend", ".png"]).
+        extensions (Iterable[str]): Allowed workfile extensions
+            (e.g. [".blend", ".png"]).
         anatomy (Anatomy): Project anatomy for resolving representation paths.
         file_template (str): Workfile filename template.
         workdir_data (dict[str, Any]): Template data for the work context.
@@ -272,7 +271,9 @@ def copy_last_published_workfile(
         )
     )
     if not repre_entities:
-        log.debug("No representations found for latest published workfile version.")
+        log.debug(
+            "No representations found for latest published workfile version."
+        )
         return None
 
     # Pick first representation whose file extension matches
@@ -283,12 +284,14 @@ def copy_last_published_workfile(
             name = Path(repre_file.get("name", ""))
             ext = name.suffix.lower()
             if ext in ext_set:
-                representation_path = Path(get_representation_path_with_anatomy(repre, anatomy))
+                representation_path = Path(
+                    get_representation_path_with_anatomy(repre, anatomy)
+                )
                 if representation_path.exists():
                     source_path = representation_path
                     repre_entity = repre
                     break
-                
+
             if source_path is not None:
                 break
         if source_path is not None:
@@ -326,10 +329,13 @@ def copy_last_published_workfile(
         )
     else:
         published_mtime = os.path.getmtime(source_path)
-        local_mtime = os.path.getmtime(local_path) if os.path.exists(local_path) else 0
+        local_mtime = (
+            os.path.getmtime(local_path) if os.path.exists(local_path) else 0
+        )
         if published_mtime <= local_mtime:
             log.debug(
-                "Latest local workfile is up-to-date with published; skipping copy."
+                "Latest local workfile is up-to-date with published; "
+                "skipping copy."
             )
             return None
         next_version = local_version + 1
@@ -346,7 +352,8 @@ def copy_last_published_workfile(
     dst_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(source_path, dst_path)
     log.info(
-        f"Copied last published workfile to {dst_path} (version {next_version})"
+        f"Copied last published workfile to {dst_path} "
+        f"(version {next_version})"
     )
     return dst_path.as_posix()
 

--- a/client/ayon_core/pipeline/workfile/utils.py
+++ b/client/ayon_core/pipeline/workfile/utils.py
@@ -247,20 +247,19 @@ def copy_last_published_workfile(
         return None
 
     # Include version number to pick the latest
-    version_entities = list(
+    latest_version = next(
         ayon_api.get_versions(
             project_name,
             product_ids={p["id"] for p in product_entities},
             task_ids={task_id},
             latest=True,
             fields={"id", "author", "version"},
-        )
+        ),
+        None
     )
-    if not version_entities:
+    if not latest_version:
         log.debug("No published workfile versions found for task.")
         return None
-
-    latest_version = version_entities[0]
     version_id = latest_version["id"]
 
     # Get representations for the latest version

--- a/client/ayon_core/pipeline/workfile/utils.py
+++ b/client/ayon_core/pipeline/workfile/utils.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
+import copy
 import os
 import platform
+import shutil
 import uuid
 import typing
+from pathlib import Path
 from typing import Optional, Any
 
 import ayon_api
 from ayon_api.operations import OperationsSession
 
-from ayon_core.lib import filter_profiles, get_ayon_username
+from ayon_core.lib import filter_profiles, get_ayon_username, StringTemplate
 from ayon_core.settings import get_project_settings
 from ayon_core.host.interfaces import (
     SaveWorkfileOptionalData,
@@ -17,10 +20,12 @@ from ayon_core.host.interfaces import (
 )
 from ayon_core.pipeline.version_start import get_versioning_start
 from ayon_core.pipeline.template_data import get_template_data
+from ayon_core.pipeline.load import get_representation_path_with_anatomy
 
 from .path_resolving import (
     get_workdir,
     get_workfile_template_key,
+    get_last_workfile_with_version,
 )
 
 if typing.TYPE_CHECKING:
@@ -136,6 +141,214 @@ def should_use_last_workfile_on_launch(
     if output is None:
         return default_output
     return output
+
+
+def should_copy_last_published_workfile_on_launch(
+    project_name: str,
+    host_name: str,
+    task_name: str,
+    task_type: str,
+    project_settings: Optional[dict[str, Any]] = None,
+) -> bool:
+    """Check if published workfile should be copied to workdir on launch.
+
+    Only relevant when last workfile on startup is enabled for the same
+    profile. Returns the value of 'use_last_published_workfile' from the
+    matching last_workfile_on_startup profile.
+
+    Args:
+        project_name (str): Name of project.
+        host_name (str): Name of launched host. Not case sensitive.
+        task_name (str): Name of launched task.
+            Not case sensitive.
+        task_type (str): Type of launched task.
+        project_settings (Optional[dict[str, Any]]): Project settings.
+
+    Returns:
+        bool: True if last published workfile should be copied to workdir
+            before opening. None if no profile is found.
+    """
+    if project_settings is None:
+        project_settings = get_project_settings(project_name)
+    setting_profiles = (
+        project_settings
+        ["core"]
+        ["tools"]
+        ["Workfiles"]
+        ["last_workfile_on_startup"]
+    )
+    if not setting_profiles:
+        return None
+
+    filter_data = {
+        "tasks": task_name,
+        "task_types": task_type,
+        "hosts": host_name,
+    }
+    matched_settings = filter_profiles(setting_profiles, filter_data)
+    if not matched_settings:
+        return None
+
+    return matched_settings.get("enabled", False) and matched_settings.get("use_last_published_workfile", False)
+
+
+def copy_last_published_workfile(
+    project_name: str,
+    folder_id: str,
+    task_id: str,
+    workdir: str,
+    extensions: typing.Iterable[str],
+    anatomy: "Anatomy",
+    file_template: str,
+    workdir_data: dict[str, Any],
+    host_name: str,
+    project_settings: Optional[dict[str, Any]],
+    log: Any,
+) -> Optional[str]:
+    """Copy the latest published workfile to the work directory if it is newer.
+
+    Queries the AYON API for published workfiles for the given folder and task,
+    resolves the latest version's file path, and copies it to the workdir as
+    the next version if no local workfile exists or the published file is
+    newer than the latest local workfile.
+
+    Args:
+        project_name (str): Project name.
+        folder_id (str): Folder id.
+        task_id (str): Task id (used to filter published versions).
+        workdir (str): Path to the work directory.
+        extensions (Iterable[str]): Allowed workfile extensions (e.g. [".blend", ".png"]).
+        anatomy (Anatomy): Project anatomy for resolving representation paths.
+        file_template (str): Workfile filename template.
+        workdir_data (dict[str, Any]): Template data for the work context.
+        host_name (str): Host name (for versioning start).
+        project_settings (Optional[dict[str, Any]]): Project settings.
+        log (Any): Logger with info/debug/warning methods.
+
+    Returns:
+        Optional[str]: Path to the copied workfile, or None if no copy was
+            performed (no published workfile, or local already up-to-date).
+    """
+    # Normalize extensions for filtering (lowercase, no leading dot)
+    ext_set = {ext.lower() for ext in extensions} if extensions else set()
+    if not ext_set:
+        return None
+
+    # Fetch workfile products for the folder
+    product_entities = list(
+        ayon_api.get_products(
+            project_name,
+            folder_ids={folder_id},
+            product_types={"workfile"},
+            fields={"id", "name"},
+        )
+    )
+    if not product_entities:
+        log.debug("No published workfile products found for folder.")
+        return None
+
+    # Include version number to pick the latest
+    version_entities = list(
+        ayon_api.get_versions(
+            project_name,
+            product_ids={p["id"] for p in product_entities},
+            task_ids={task_id},
+            latest=True,
+            fields={"id", "author", "version"},
+        )
+    )
+    if not version_entities:
+        log.debug("No published workfile versions found for task.")
+        return None
+
+    latest_version = version_entities[0]
+    version_id = latest_version["id"]
+
+    # Get representations for the latest version
+    repre_entities = list(
+        ayon_api.get_representations(
+            project_name,
+            version_ids={version_id},
+        )
+    )
+    if not repre_entities:
+        log.debug("No representations found for latest published workfile version.")
+        return None
+
+    # Pick first representation whose file extension matches
+    source_path = None
+    repre_entity = None
+    for repre in repre_entities:
+        for repre_file in repre.get("files", []):
+            name = Path(repre_file.get("name", ""))
+            ext = name.suffix.lower()
+            if ext in ext_set:
+                representation_path = Path(get_representation_path_with_anatomy(repre, anatomy))
+                if representation_path.exists():
+                    source_path = representation_path
+                    repre_entity = repre
+                    break
+                
+            if source_path is not None:
+                break
+        if source_path is not None:
+            break
+
+    if not source_path or repre_entity is None:
+        log.warning("Published workfile is not accessible on this machine.")
+        return None
+
+    # Compare with latest local workfile
+    template_data = dict(workdir_data)
+    template_data.setdefault("user", get_ayon_username())
+    if "ext" not in template_data or template_data["ext"] is None:
+        template_data["ext"] = next(iter(ext_set), "")
+    template_data["ext"] = template_data["ext"].lstrip(".")
+
+    local_path, local_version = get_last_workfile_with_version(
+        workdir,
+        file_template,
+        template_data,
+        ext_set,
+    )
+
+    # Decide next version number
+    task_name = workdir_data.get("task", {}).get("name")
+    task_type = workdir_data.get("task", {}).get("type")
+    if local_version is None:
+        next_version = get_versioning_start(
+            project_name,
+            host_name,
+            task_name=task_name,
+            task_type=task_type,
+            product_base_type="workfile",
+            project_settings=project_settings,
+        )
+    else:
+        published_mtime = os.path.getmtime(source_path)
+        local_mtime = os.path.getmtime(local_path) if os.path.exists(local_path) else 0
+        if published_mtime <= local_mtime:
+            log.debug(
+                "Latest local workfile is up-to-date with published; skipping copy."
+            )
+            return None
+        next_version = local_version + 1
+
+    # Build destination path and copy
+    data = copy.deepcopy(template_data)
+    data["version"] = next_version
+    data.pop("comment", None)
+    data["ext"] = data.get("ext", next(iter(ext_set), "")).lstrip(".")
+    filename = StringTemplate.format_strict_template(file_template, data)
+    dst_path = Path(workdir) / str(filename)
+    dst_path = dst_path.resolve()
+
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_path, dst_path)
+    log.info(
+        f"Copied last published workfile to {dst_path} (version {next_version})"
+    )
+    return dst_path.as_posix()
 
 
 def should_open_workfiles_tool_on_launch(

--- a/client/ayon_core/pipeline/workfile/utils.py
+++ b/client/ayon_core/pipeline/workfile/utils.py
@@ -279,22 +279,21 @@ def copy_last_published_workfile(
     source_path = None
     repre_entity = None
     for repre in repre_entities:
-        for repre_file in repre.get("files", []):
-            name = Path(repre_file.get("name", ""))
-            ext = name.suffix.lower()
-            if ext in ext_set:
-                representation_path = Path(
-                    get_representation_path_with_anatomy(repre, anatomy)
-                )
-                if representation_path.exists():
-                    source_path = representation_path
-                    repre_entity = repre
-                    break
+        representation_path = Path(get_representation_path(
+            project_name,
+            repre,
+            anatomy=anatomy,
+        ))
+        if not representation_path.exists():
+            continue
 
-            if source_path is not None:
-                break
-        if source_path is not None:
-            break
+        ext = representation_path.suffix.lower()
+        if ext not ext_set:
+            continue
+
+        source_path = representation_path
+        repre_entity = repre
+        break
 
     if not source_path or repre_entity is None:
         log.warning("Published workfile is not accessible on this machine.")

--- a/client/ayon_core/pipeline/workfile/utils.py
+++ b/client/ayon_core/pipeline/workfile/utils.py
@@ -228,8 +228,11 @@ def get_last_published_workfile_representation(
             latest=True,
             standard=True,
             fields={"id", "author", "version", "taskId"},
-        )
+        ),
+        None,
     )
+    if latest_version is None:
+        return None
 
     repre_entities = list(
         ayon_api.get_representations(

--- a/client/ayon_core/pipeline/workfile/utils.py
+++ b/client/ayon_core/pipeline/workfile/utils.py
@@ -339,7 +339,7 @@ def copy_last_published_workfile(
             )
             workdir = str(workdir_result)
 
-    # Use a copy for template filling; do not mutate callers' workdir_data
+    # Use a copy for template filling
     template_data = copy.deepcopy(workdir_data)
     template_data["ext"] = published_info.extension
     ext_set = {published_info.extension}

--- a/client/ayon_core/pipeline/workfile/utils.py
+++ b/client/ayon_core/pipeline/workfile/utils.py
@@ -199,50 +199,47 @@ def get_last_published_workfile_representation(
     Returns:
         Optional[LastPublishedWorkfileInfo]: Resolved info, or None.
     """
+    if not extensions:
+        return None
+
     if anatomy is None:
         from ayon_core.pipeline import Anatomy
         anatomy = Anatomy(project_name)
     if project_settings is None:
         project_settings = get_project_settings(project_name)
 
-    ext_set = None
-    if extensions:
-        ext_set = {str(ext).lstrip(".").lower() for ext in extensions}
+    extensions = {str(ext).lstrip(".").lower() for ext in extensions}
 
-    product_entities = list(
-        ayon_api.get_products(
+    product_ids = {
+        product_entity["id"]
+        for product_entity in ayon_api.get_products(
             project_name,
             folder_ids={folder_id},
             product_types={"workfile"},
-            fields={"id", "name"},
+            fields={"id"},
         )
-    )
-    if not product_entities:
+    }
+    if not product_ids:
         return None
 
     latest_version = next(
         ayon_api.get_versions(
             project_name,
-            product_ids={p["id"] for p in product_entities},
+            product_ids=product_ids,
             task_ids={task_id},
             latest=True,
             standard=True,
-            fields={"id", "author", "version", "taskId"},
+            fields={"id"},
         ),
         None,
     )
     if latest_version is None:
         return None
 
-    repre_entities = list(
-        ayon_api.get_representations(
-            project_name,
-            version_ids={latest_version["id"]},
-        )
+    repre_entities = ayon_api.get_representations(
+        project_name,
+        version_ids={latest_version["id"]},
     )
-    if not repre_entities:
-        return None
-
     for repre in repre_entities:
         representation_path = Path(get_representation_path(
             project_name,
@@ -253,7 +250,7 @@ def get_last_published_workfile_representation(
             continue
 
         ext = representation_path.suffix.lower().lstrip(".")
-        if ext_set is not None and ext in ext_set:
+        if ext in extensions:
             return LastPublishedWorkfileInfo(
                 source_path=representation_path.as_posix(),
                 representation_entity=repre,

--- a/client/ayon_core/pipeline/workfile/utils.py
+++ b/client/ayon_core/pipeline/workfile/utils.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
-import copy
 import os
 import platform
-import shutil
 import uuid
 import typing
 from dataclasses import dataclass
@@ -13,7 +11,7 @@ import ayon_api
 from ayon_api.operations import OperationsSession
 
 from ayon_core.host.interfaces.workfiles import deprecated
-from ayon_core.lib import filter_profiles, get_ayon_username, StringTemplate
+from ayon_core.lib import filter_profiles, get_ayon_username
 from ayon_core.pipeline import get_representation_path
 from ayon_core.settings import get_project_settings
 from ayon_core.host.interfaces import (
@@ -27,7 +25,6 @@ from ayon_core.pipeline.template_data import get_template_data
 from .path_resolving import (
     get_workdir,
     get_workfile_template_key,
-    get_last_workfile_with_version,
 )
 
 if typing.TYPE_CHECKING:
@@ -40,13 +37,12 @@ class MissingWorkdirError(Exception):
 
 
 @dataclass
-class LastPublishedWorkfileInfo:
-    """Resolved info about the last published workfile."""
+class WorkfileOnLaunchProfile:
+    """Resolved launch behavior from last_workfile_on_startup profile."""
 
-    source_path: str
-    representation_entity: dict[str, Any]
-    version_entity: dict[str, Any]
-    extension: str  # e.g. "blend", no dot prefix
+    enabled: bool
+    use_last_published_workfile: bool
+    profile: Optional[dict[str, Any]] = None
 
 
 def get_workfiles_info(
@@ -102,11 +98,11 @@ def get_workfile_on_launch_profile(
     task_name: str,
     task_type: str,
     project_settings: Optional[dict[str, Any]] = None,
-) -> Optional[dict[str, Any]]:
+) -> Optional[WorkfileOnLaunchProfile]:
     """Get matched last_workfile_on_startup profile for the context.
 
-    Returns the profile dict with keys 'enabled' and
-    'use_last_published_workfile', or None if no profile matches.
+    Returns object with 'enabled' and 'use_last_published_workfile',
+    or None if no profile matches.
 
     Args:
         project_name (str): Name of project.
@@ -116,7 +112,7 @@ def get_workfile_on_launch_profile(
         project_settings (Optional[dict[str, Any]]): Project settings.
 
     Returns:
-        Optional[dict[str, Any]]: Matched profile dict or None.
+        Optional[WorkfileOnLaunchProfile]: Matched profile object or None.
     """
     if project_settings is None:
         project_settings = get_project_settings(project_name)
@@ -134,7 +130,16 @@ def get_workfile_on_launch_profile(
         "task_types": task_type,
         "hosts": host_name,
     }
-    return filter_profiles(profiles, filter_data)
+    profile = filter_profiles(profiles, filter_data)
+    if profile is None:
+        return None
+    return WorkfileOnLaunchProfile(
+        enabled=bool(profile.get("enabled", False)),
+        use_last_published_workfile=bool(
+            profile.get("use_last_published_workfile", False)
+        ),
+        profile=profile,
+    )
 
 
 @deprecated("Use get_workfile_on_launch_profile() instead.")
@@ -170,7 +175,7 @@ def should_use_last_workfile_on_launch(
     if profile is None:
 
         return False
-    return profile.get("enabled", False)
+    return profile.enabled
 
 
 def get_last_published_workfile_representation(
@@ -180,10 +185,8 @@ def get_last_published_workfile_representation(
     extensions: Optional[typing.Iterable[str]] = None,
     anatomy: Optional["Anatomy"] = None,
     project_settings: Optional[dict[str, Any]] = None,
-) -> Optional[LastPublishedWorkfileInfo]:
-    """Resolve info about the latest published workfile for the context.
-
-    Returns data needed to copy the file, or None if none found or accessible.
+) -> Optional[dict[str, Any]]:
+    """Resolve latest published workfile representation for the context.
 
     Args:
         project_name (str): Project name.
@@ -197,7 +200,7 @@ def get_last_published_workfile_representation(
             Resolved from project_name if not provided.
 
     Returns:
-        Optional[LastPublishedWorkfileInfo]: Resolved info, or None.
+        Optional[dict[str, Any]]: Representation entity, or None.
     """
     if not extensions:
         return None
@@ -251,163 +254,9 @@ def get_last_published_workfile_representation(
 
         ext = representation_path.suffix.lower().lstrip(".")
         if ext in extensions:
-            return LastPublishedWorkfileInfo(
-                source_path=representation_path.as_posix(),
-                representation_entity=repre,
-                version_entity=latest_version,
-                extension=ext,
-            )
+            return repre
 
     return None
-
-
-def copy_last_published_workfile(
-    project_name: str,
-    folder_entity: dict[str, Any],
-    task_entity: dict[str, Any],
-    host_name: str,
-    published_info: LastPublishedWorkfileInfo,
-    workdir: Optional[str] = None,
-    file_template: Optional[str] = None,
-    workdir_data: Optional[dict[str, Any]] = None,
-    anatomy: Optional["Anatomy"] = None,
-    project_settings: Optional[dict[str, Any]] = None,
-    log: Optional[Any] = None,
-) -> Optional[str]:
-    """Copy the published workfile to the work directory.
-
-    Compares with latest local workfile; copies only if none exist or published
-    is newer.
-
-    Args:
-        project_name (str): Project name.
-        folder_entity (dict[str, Any]): Folder entity.
-        task_entity (dict[str, Any]): Task entity.
-        host_name (str): Host name.
-        published_info (LastPublishedWorkfileInfo): From
-            get_last_published_workfile_representation().
-        workdir (Optional[str]): Work directory.
-            Resolved from context if None.
-        file_template (Optional[str]): Workfile filename template.
-            Resolved if None.
-        workdir_data (Optional[dict[str, Any]]): Template data.
-            Resolved if None.
-            Not mutated.
-        anatomy (Optional[Anatomy]): Project anatomy. Resolved if None.
-        project_settings (Optional[dict[str, Any]]): Project settings.
-            Resolved from project_name if None.
-        log (Optional[Any]): Logger with debug/info/warning. No-op if None.
-
-    Returns:
-        Optional[str]: Path to the copied workfile, or None if copy skipped.
-    """
-    if anatomy is None:
-        from ayon_core.pipeline import Anatomy
-        anatomy = Anatomy(project_name)
-    if project_settings is None:
-        project_settings = get_project_settings(project_name)
-
-    if workdir is None or file_template is None or workdir_data is None:
-        project_entity = ayon_api.get_project(project_name)
-        if workdir_data is None:
-            workdir_data = get_template_data(
-                project_entity,
-                folder_entity,
-                task_entity,
-                host_name,
-                project_settings,
-            )
-        template_key = get_workfile_template_key(
-            project_name,
-            task_entity["taskType"],
-            host_name,
-            project_settings=project_settings,
-        )
-        if file_template is None:
-            file_template = anatomy.get_template_item(
-                "work", template_key, "file"
-            ).template
-        if workdir is None:
-            workdir_result = get_workdir(
-                project_entity,
-                folder_entity,
-                task_entity,
-                host_name,
-                anatomy=anatomy,
-                template_key=template_key,
-                project_settings=project_settings,
-            )
-            workdir = str(workdir_result)
-
-    # Use a copy for template filling
-    template_data = copy.deepcopy(workdir_data)
-    template_data["ext"] = published_info.extension
-    ext_set = {published_info.extension}
-
-    local_path, local_version = get_last_workfile_with_version(
-        workdir,
-        file_template,
-        template_data,
-        ext_set,
-    )
-
-    published_version = published_info.version_entity.get("version", 0)
-
-    if local_version is None:
-        # No local workfiles: use latest published version + 1
-        next_version = published_version + 1
-    else:
-        published_mtime = os.path.getmtime(published_info.source_path)
-        local_mtime = (
-            os.path.getmtime(local_path) if os.path.exists(local_path) else 0
-        )
-        if published_mtime <= local_mtime:
-            if log:
-                log.debug(
-                    "Latest local workfile is newer than last published; "
-                    "skipping copy."
-                )
-            return None
-
-        # Use the greater of local or published version, then + 1
-        next_version = max(local_version, published_version) + 1
-
-    data = copy.deepcopy(template_data)
-    data["version"] = next_version
-    data.pop("comment", None)
-    data["ext"] = published_info.extension
-    filename = StringTemplate.format_strict_template(file_template, data)
-    dst_path = Path(workdir) / str(filename)
-    dst_path = dst_path.resolve()
-
-    dst_path.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(published_info.source_path, dst_path)
-
-    rootless_path = find_workfile_rootless_path(
-        str(dst_path),
-        project_name,
-        folder_entity,
-        task_entity,
-        host_name,
-        project_settings=project_settings,
-        anatomy=anatomy,
-    )
-    save_workfile_info(
-        project_name,
-        task_entity["id"],
-        rootless_path,
-        host_name,
-        version=next_version,
-        comment=None,
-        description=None,
-    )
-
-    if log:
-        log.info(
-            f"Copied last published workfile to {dst_path} "
-            f"(version {next_version})",
-        )
-    return dst_path.as_posix()
 
 
 def should_open_workfiles_tool_on_launch(


### PR DESCRIPTION
## Changelog Description
Fix logic for existing `use_last_published_workfile` setting.

## Additional info
Fixes https://github.com/ynput/ayon-core/issues/1346
It'll copy the last published workfile if None is locally present in workdir or if the existing ones are older than the last published one.

## Testing notes:
1. Enable the `ayon+settings://core/tools/Workfiles/last_workfile_on_startup/0/use_last_published_workfile` setting
2. Launch a task from which workfiles has been published but you don't have local workfiles or the local workfile is older than the last published one.
