### PR TITLE
Set PlaceholderLineEdit maximum length to something way bigger than the default 32767

### DIFF
--- a/client/ayon_core/tools/utils/widgets.py
+++ b/client/ayon_core/tools/utils/widgets.py
@@ -111,7 +111,7 @@ class PlaceholderLineEdit(QtWidgets.QLineEdit):
     """Set placeholder color of QLineEdit in Qt 5.12 and higher."""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.setMaxLength(10000000)
+        self.setMaxLength(2147483647)
         # Change placeholder palette color
         if hasattr(QtGui.QPalette, "PlaceholderText"):
             filter_palette = self.palette()


### PR DESCRIPTION
## Changelog Description
I ran into this issue when I was running the 'delete old versions' action. I got this error of

`json.decoder.JSONDecodeError: Unterminated string starting ...`

This was the 'delete_data' json string that was being truncated at 32767 characters (a lot of files with long filenames; the json string should have been around 44000 characters). I traced the thing back to `TextAttrWidget` in `client/ayon_core/tools/attribute_defs/widgets.py` and from there on to the `PlaceHolderLineEdit` (`/client/ayon_core/tools/utils/widgets.py`). The default lenght of QLineEdits' i 32767, so I simply set it to some outrageous value. 

## Testing notes:
1. Have a representation with a hefty amount of files (or probably just a lot of versions)
2. Run delete version
3. It does what it's supposed to do
