### PR TITLE
Local registry: Local settings refactor

### DIFF
--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -289,6 +289,7 @@ class AYONSecureRegistry(ASettingRegistry):
         try:
             value = keyring.get_password(self._name, name)
         except (ItemNotFoundException, PasswordSetError):
+            pass
 
         if value is not None:
             return value


### PR DESCRIPTION
## Changelog Description
Refactored local registry to be more "safe" to use.

## Additional info
ALl registry items do inherit from `ASettingRegistry`. Changed signature of methods to support `default` for getter and to support `ignore_missing` in delete method. It is not necessary to capture `RegistryItemNotFound` in getters if `default` value is provided.

## Testing notes:
1. Validate code changes.
2. Use any of registry class.
3. When using getters without default it still fails with `RegistryItemNotFound` but does not fail with default.
4. When deleting item that is not available then nothing happens unless `ignore_missing` is set to `False`.