### PR TITLE
Refactor profiles filtering: add rank_profile, get_matching_profiles, get_highest_score_profiles

### DIFF
--- a/client/ayon_core/lib/profiles_filtering.py
+++ b/client/ayon_core/lib/profiles_filtering.py
@@ -193,7 +193,7 @@ def get_highest_score_profiles(
     key_values: dict[str, typing.Any],
     logger: logging.Logger,
 ) -> list[dict[str, typing.Any]]:
-    """Return all profiles that have the highest match score.
+    """Return all profiles that have the highest number of matches and score.
 
     Args:
         profiles (list[dict[str, typing.Any]]): List of profiles to rank.
@@ -208,7 +208,16 @@ def get_highest_score_profiles(
     if not ranked_profiles:
         return []
 
-    # get highest score
+    # filter based on number of matches
+    num_matches = [bin(score).count("1") for _, score in ranked_profiles]
+    max_num_matches = max(num_matches)
+    ranked_profiles = [
+        profile
+        for profile, num_matches in zip(ranked_profiles, num_matches)
+        if num_matches == max_num_matches
+    ]
+
+    # filter based on score
     scores = [score for _, score in ranked_profiles]
     highest_profile_points = max(scores)
 

--- a/tests/client/ayon_core/lib/test_profiles_filtering.py
+++ b/tests/client/ayon_core/lib/test_profiles_filtering.py
@@ -1,0 +1,326 @@
+import logging
+import unittest
+
+from ayon_core.lib import profiles_filtering
+
+
+log = logging.getLogger(__name__)
+
+
+class TestRankProfile(unittest.TestCase):
+    """Test `rank_profile` function."""
+
+    def test_simple_match(self):
+        profile = {
+            "host": ["nuke"],
+            "task": "render",
+        }
+        key_values = {
+            "host": "nuke",
+            "task": "render",
+        }
+        result = profiles_filtering.rank_profile(profile, key_values)
+        expected = 0b11  # (both tests passed)
+        self.assertEqual(result, expected)
+
+    def test_no_match(self):
+        profile = {"host": ["nuke"]}
+        key_values = {"host": "maya"}
+        result = profiles_filtering.rank_profile(profile, key_values)
+        self.assertEqual(result, -1)
+
+    def test_wildcard_match(self):
+        profile = {"host": ["*"]}
+        key_values = {"host": "nuke"}
+        result = profiles_filtering.rank_profile(profile, key_values)
+        self.assertEqual(result, 0)
+
+    def test_implicit_wildcard_match(self):
+        """Missing keys should be treated as wildcard."""
+        profile = {"host": ["maya"]}
+        key_values = {
+            "host": "maya",
+            "task": "modeling",  # missing key
+        }
+        result = profiles_filtering.rank_profile(profile, key_values)
+        self.assertEqual(result, 0b10)  # match on host, wildcard on task
+
+    def test_docstring_example_1(self):
+        profile = {"a": ["A"], "b": ["B"]}
+        values = {"a": "A", "b": "D"}
+        result = profiles_filtering.rank_profile(profile, values)
+        self.assertEqual(result, -1)
+
+    def test_docstring_example_2(self):
+        profile = {"a": ["A"], "b": ["B"]}
+        values = {"a": "A", "b": "B"}
+        result = profiles_filtering.rank_profile(profile, values)
+        self.assertEqual(result, 0b11)  # match on both
+
+    def test_docstring_example_3(self):
+        profile = {"a": ["A"], "b": ["*"]}
+        values = {"a": "A", "b": "B"}
+        result = profiles_filtering.rank_profile(profile, values)
+        self.assertEqual(result, 0b10)  # match on a, wildcard on b
+
+    def test_docstring_example_4(self):
+        profile = {"b": ["B"]}
+        values = {"a": "A", "b": "B"}
+        result = profiles_filtering.rank_profile(profile, values)
+        self.assertEqual(result, 0b01)  # wildcard on a, match on b
+
+    def test_many_conditions(self):
+        profile = {
+            "a": [],     # 0
+            "b": ["y"],  # 1
+            "c": ["y"],  # 1
+            "d": [],     # 0
+            "e": ["y"],  # 1
+            "f": ["*"],  # 0
+        }
+        key_values = {
+            "a": "y",
+            "b": "y",
+            "c": "y",
+            "d": "y",
+            "e": "y",
+            "f": "y",
+        }
+        result = profiles_filtering.rank_profile(profile, key_values)
+        expected = 0b011010
+        self.assertEqual(result, expected)
+
+    def test_empty_key_values_returns_zero(self):
+        """No keys to match means score 0 (all wildcards)."""
+        profile = {"host": "nuke", "task": "render"}
+        key_values = {}
+        result = profiles_filtering.rank_profile(profile, key_values)
+        self.assertEqual(result, 0)
+
+    def test_profile_value_as_list_matches(self):
+        """Profile value can be a list of allowed values (literal match)."""
+        profile = {"host": ["nuke", "maya"], "task": "render"}
+        key_values = {"host": "maya", "task": "render"}
+        result = profiles_filtering.rank_profile(profile, key_values)
+        self.assertEqual(result, 0b11)
+
+    def test_profile_value_as_list_no_match(self):
+        profile = {"host": ["nuke", "maya"]}
+        key_values = {"host": "houdini"}
+        result = profiles_filtering.rank_profile(profile, key_values)
+        self.assertEqual(result, -1)
+
+    def test_regex_in_profile_matches(self):
+        profile = {"host": [r"nuke\d*"], "task": "*"}
+        key_values = {"host": "nuke13", "task": "render"}
+        result = profiles_filtering.rank_profile(profile, key_values)
+        self.assertEqual(result, 0b10)  # host match (1), task wildcard (0)
+
+
+class TestGetMatchingProfiles(unittest.TestCase):
+    """Test `get_matching_profiles` function."""
+
+    def test_no_match(self):
+        profiles = [
+            {"host": ["maya"]},
+            {"host": ["houdini"]},
+            {"host": ["nuke"]},
+        ]
+        key_values = {
+            "host": "softimage",
+        }
+        matched_profiles = profiles_filtering.get_matching_profiles(profiles, key_values, log)  # noqa: E501
+        self.assertEqual(len(matched_profiles), 0)
+
+    def test_empty_profiles(self):
+        profiles = []
+        key_values = {
+            "host": "houdini",
+        }
+        matched_profiles = profiles_filtering.get_matching_profiles(profiles, key_values, log)  # noqa: E501
+        self.assertEqual(len(matched_profiles), 0)
+
+    def test_single_match(self):
+        """
+        basic test
+        - multiple profiles
+        - a single clear winner
+
+        """
+        profiles = [
+            {"host": "maya", "task": "modeling"},
+            {"host": "maya", "task": "rigging"},     # match
+            {"host": "maya", "task": "animation"},
+        ]
+        key_values = {
+            "host": "maya",
+            "task": "rigging",
+        }
+        matched_profiles = profiles_filtering.get_matching_profiles(profiles, key_values, log)  # noqa: E501
+        self.assertEqual(len(matched_profiles), 1)
+
+        matched_profile = matched_profiles[0]
+        self.assertEqual(matched_profile["host"], "maya")
+        self.assertEqual(matched_profile["task"], "rigging")
+
+    def test_multiple_matches(self):
+        """
+        test with multiple matches
+        - multiple profiles
+        - multiple matches
+
+        """
+        profiles = [
+            {"host": "maya", "task": "modeling"},
+            {"host": "maya", "task": "rigging"},
+            {"host": "maya", "task": "animation"},
+            {"host": "houdini", "task": "fx"},      # match
+            {"host": "houdini", "task": "render"},  # match
+            {"host": "nuke", "task": "comp"},
+        ]
+        key_values = {
+            "host": "houdini",
+        }
+
+        matched_profiles = profiles_filtering.get_matching_profiles(profiles, key_values, log)  # noqa: E501
+
+        self.assertEqual(len(matched_profiles), 2)
+        tasks = [profile["task"] for profile in matched_profiles]
+        tasks = sorted(tasks)
+        self.assertEqual(tasks, ["fx", "render"])
+
+    def test_multiple_matches_with_wildcard(self):
+        """
+        test with multiple matches
+        - multiple profiles
+        - multiple matches
+
+        """
+        profiles = [
+            {"host": "maya", "task": "modeling"},
+            {"host": "maya", "task": "rigging"},
+            {"host": "maya", "task": "animation"},
+            {"host": "*", "task": "modeling"},      # match with wildcard
+            {"host": "houdini", "task": "fx"},      # match
+            {"host": "houdini", "task": "render"},  # match
+            {"host": "nuke", "task": "comp"},
+        ]
+        key_values = {
+            "host": "houdini",
+        }
+
+        matched_profiles = profiles_filtering.get_matching_profiles(
+            profiles,
+            key_values,
+            log,
+        )
+
+        self.assertEqual(len(matched_profiles), 3)
+        tasks = [profile["task"] for profile in matched_profiles]
+        tasks = sorted(tasks)
+        self.assertEqual(tasks, ["fx", "modeling", "render"])
+
+
+class TestGetHighestScoreProfiles(unittest.TestCase):
+    """Test `get_highest_score_profiles` function."""
+
+    def test_single_match(self):
+        profiles = [
+            {"host": "nuke", "task": "modeling"},   # -1: host no match
+            {"host": "*", "task": "modeling"},     # 1: task matches
+            {"host": "maya", "task": "*"},         # 1: host matches
+            {"host": "maya", "task": "modeling"},  # 2: both => winner
+        ]
+        key_values = {
+            "host": "maya",
+            "task": "modeling",
+        }
+        matched_profiles = profiles_filtering.get_highest_score_profiles(
+            profiles,
+            key_values,
+            log,
+        )
+        self.assertEqual(len(matched_profiles), 1, matched_profiles)
+
+        matched_profile = matched_profiles[0]
+        expected_profile = {"host": "maya", "task": "modeling"}
+        self.assertEqual(matched_profile, expected_profile)
+
+    def test_exact_match_wins_over_wildcard_match(self):
+        # both match on a and b, but exact match wins
+        profiles = [
+            {"a": "X", "b": "X", "d": 0},
+            {"a": "X", "b": "*", "d": 1},
+        ]
+        key_values = {"a": "X", "b": "X"}
+        matched_profiles = profiles_filtering.get_highest_score_profiles(profiles, key_values, log)  # noqa: E501
+        self.assertEqual(len(matched_profiles), 1, matched_profiles)
+        self.assertEqual(matched_profiles[0]["d"], 0)
+
+    def test_order_of_keys_matters(self):
+        # both have 2 exact matches and one wildcard match but the first
+        # profile wins because it has an exact match on an earlier key
+        profiles = [
+            {"a": "X", "b": "X", "c": "*", "d": 0},  # match on a and b => winner
+            {"a": "X", "b": "*", "c": "X", "d": 1},  # match on a and c
+        ]
+        key_values = {"a": "X", "b": "X", "c": "X"}
+        matched_profiles = profiles_filtering.get_highest_score_profiles(profiles, key_values, log)  # noqa: E501
+        self.assertEqual(len(matched_profiles), 1, matched_profiles)
+        self.assertEqual(matched_profiles[0]["d"], 0)
+
+    def test_multiple_matches(self):
+        profiles = [
+            {"a": "A", "b": "B", "c": "0", "d": 0},
+            {"a": "B", "b": "A", "c": "2", "d": 1},
+            {"a": "B", "b": "B", "c": "4", "d": 2},
+            {"a": "B", "b": "B", "c": "8", "d": 3},
+            {"a": "B", "b": "B", "c": "8", "d": 4},
+            {"a": "B", "b": "B", "c": "8", "d": 5},
+        ]
+
+        key_values = {"a": "B"}
+        matched_profiles = profiles_filtering.get_highest_score_profiles(
+            profiles, key_values, log
+        )
+        self.assertEqual(len(matched_profiles), 5, matched_profiles)
+
+        # test without order
+        key_values = {"b": "B"}
+        matched_profiles = profiles_filtering.get_highest_score_profiles(
+            profiles, key_values, log
+        )
+        self.assertEqual(len(matched_profiles), 5, matched_profiles)
+
+        key_values = {"a": "B", "b": "B"}
+        matched_profiles = profiles_filtering.get_highest_score_profiles(
+            profiles, key_values, log
+        )
+        self.assertEqual(len(matched_profiles), 4, matched_profiles)
+
+        key_values = {"a": "B", "b": "B", "c": "8"}
+        matched_profiles = profiles_filtering.get_highest_score_profiles(
+            profiles, key_values, log
+        )
+        self.assertEqual(len(matched_profiles), 3, matched_profiles)
+
+    def test_empty_profiles_returns_empty_list(self):
+        matched = profiles_filtering.get_highest_score_profiles(
+            [], {"host": "maya"}, log
+        )
+        self.assertEqual(matched, [])
+
+    def test_all_no_match_returns_empty_list(self):
+        profiles = [
+            {"host": "nuke"},
+            {"host": "houdini"},
+        ]
+        key_values = {"host": "maya"}
+        matched = profiles_filtering.get_highest_score_profiles(
+            profiles, key_values, log
+        )
+        self.assertEqual(matched, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/client/ayon_core/lib/test_profiles_filtering.py
+++ b/tests/client/ayon_core/lib/test_profiles_filtering.py
@@ -261,7 +261,7 @@ class TestGetHighestScoreProfiles(unittest.TestCase):
         # both have 2 exact matches and one wildcard match but the first
         # profile wins because it has an exact match on an earlier key
         profiles = [
-            {"a": "X", "b": "X", "c": "*", "d": 0},  # match on a and b => winner
+            {"a": "X", "b": "X", "c": "*", "d": 0},  # match on a and b => winner  # noqa: E501
             {"a": "X", "b": "*", "c": "X", "d": 1},  # match on a and c
         ]
         key_values = {"a": "X", "b": "X", "c": "X"}

--- a/tests/client/ayon_core/lib/test_profiles_filtering.py
+++ b/tests/client/ayon_core/lib/test_profiles_filtering.py
@@ -220,6 +220,58 @@ class TestGetMatchingProfiles(unittest.TestCase):
         tasks = sorted(tasks)
         self.assertEqual(tasks, ["fx", "modeling", "render"])
 
+    def test_explicit_over_implicit_match(self):
+        """This test validates that an explicit match wins over an
+        implicit match.
+
+        the first two profiles have 2 explicit matches and rank as 1010 and
+        1100, respectively.
+        The third profile has 3 explicit matches and ranks as 0111.
+
+        The third profile should win because it has the most explicit matches,
+        even though it matches "lower keys" than the other ones.
+
+        """
+        profiles = [
+
+            # 2 explicit matches, ranking 1010
+            {
+                "product_base_type": "model",
+                # host: *
+                "task": "modeling",
+                # test: *
+            },
+
+            # 2 implicit matches, ranking 1100
+            {
+                "product_base_type": "model",
+                "host": "maya",
+                # task: *
+                # test: *
+            },
+
+            # 3 explicit matches, ranking 0111
+            {
+                # product_base_type: *
+                "host": "maya",
+                "task": "modeling",
+                "test": "1",
+            },
+        ]
+
+        key_values = {
+            "product_base_type": "model",
+            "host": "maya",
+            "task": "modeling",
+            "test": "1",
+        }
+
+        matched_profiles = profiles_filtering.get_highest_score_profiles(profiles, key_values, log)  # noqa: E501
+
+        # only the 3rd profile should be matched
+        self.assertEqual(len(matched_profiles), 1, matched_profiles)
+        self.assertEqual(matched_profiles[0], profiles[2])
+
 
 class TestGetHighestScoreProfiles(unittest.TestCase):
     """Test `get_highest_score_profiles` function."""


### PR DESCRIPTION
## Changelog Description

Refactored profile filtering and added new methods so callers can match multiple profiles instead of only picking the single best one.

## Additional info

### Unchanged

- `filter_profiles` expected behaviour is unchanged and backwards compatible. (hopefully)

### New
- **`rank_profile`**:  ranks a single profile using a lexicographic binary score.
  - Each key contributes one bit (`1` = exact match, `0` = wildcard); results form a bitmask so earlier keys matter more.
  - e.g. `0b110 = 6` beats `0b101 = 5` (both have 2 value matches and 1 wildcard).
  - Total number of exact matches = number of `1` bits (e.g. `score.bit_count()`).
- **`rank_profiles`**: helper to rank multiple profiles
- **`get_matching_profiles`**: returns all profiles with a non‑negative score.
- **`get_highest_score_profiles`**: Returns all profiles with the highest score.
- Unit tests added for the new helpers and edge cases.

## Use case

Useful for addons that want to compose profiles dynamically (eg. merge multiple rules into one).

Example (eg. dynamic profiles for deadline):

```py
profiles = {
    # default priority
    ["host": ["*"], "priority": 50],

    # increase chunk size to run the entire playblast in one chunk
    ["host": ["maya"],  "productBaseTypes": ["playblast"], "chunk_size": 999, "overrides": ["chunk_size"]],

    # allow FX tasks to choose the machine pool + allow them to overwrite the default pool
    ["host": ["maya"],  "task": ["fx"], "pool": "high_memory", "overrides": ["pool"]],
}


def get_profile_for_instance(self, instance):
    values = {
        "host": "maya",
        "productBaseTypes": "playblast",
        "task": "fx",
    }
    # custom filter to only include profiles with at least two exact matches
    profiles = [profile for profile, score in rank_profiles(self.profiles, values) if score.bit_count() >= 2]

    # addon specific merge of profiles
    profile = self.combine_profiles(profiles)
    # {
    #     "priority": 50,
    #     "chunk_size": 999,
    #     "pool": "high_memory",
    #     "overrides": ["chunk_size", "pool"]
    # }
```
