### PR TITLE
USD Contribution: Support "Instance in same context" and other optional states from parent instance

### DIFF
--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -1,8 +1,9 @@
-from operator import attrgetter
+import copy
 import dataclasses
 import os
 import platform
 from collections import defaultdict
+from operator import attrgetter
 from typing import Any, Dict, List
 
 import pyblish.api
@@ -485,6 +486,15 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
         # so that there will never be conflicts between contributions from
         # different departments and scenes.
         new_instance.data["followWorkfileVersion"] = False
+
+        # Transfer any creator and publish attributes, to ensure any optional
+        # validators that may also apply to these instances will have the
+        # state inherited from its parent
+        for key in ("creator_attributes", "publish_attributes"):
+            if key in source_instance.data:
+                new_instance.data[key] = copy.deepcopy(
+                    source_instance.data[key]
+                )
 
         return new_instance
 


### PR DESCRIPTION
## Changelog Description

When publish USD with AYON USD Contribution enabled to another context, then disabling the "Instance in same context" optional attribute on the main instance does not propagate to the children instances, and hence it'll still invalidate on the department layers, etc.

It should instead inherit the optional state from parent so that whatever optional state is set, it passes through to these instances.

## Additional info

This was reproducable in e.g. Maya (not in Houdini because it skipped that particular validation for these instances for another reason).

The inheriting of `creator_attributes` and `publish_attributes` _may_ potentially have other side effects. But I couldn't think of any out of the top of my head that would be direct problems here. 🤔 

Fix: #1706

## Testing notes:

1. Publish to another instance from Maya with USD contribution workflow 
2. Disable "Instance in same context validation"
3. It should be allowed.
