### PR TITLE
Launcher tool: Webactions cleanup environment variables

### DIFF
--- a/client/ayon_core/tools/launcher/models/actions.py
+++ b/client/ayon_core/tools/launcher/models/actions.py
@@ -548,7 +548,7 @@ class ActionsModel:
             env = os.environ.copy()
             env.pop("AYON_BUNDLE_NAME", None)
             env.pop("AYON_STUDIO_BUNDLE_NAME", None)
-            clean_envs_for_ayon_process(env)
+            env = clean_envs_for_ayon_process(env)
             run_detached_ayon_launcher_process(uri, env=env)
 
         elif response_type in ("query", "navigate"):


### PR DESCRIPTION
## Changelog Description
Clean envirnment variables for webaction subprocess.

## Additional info
The issue is that triggered subprocess keepts PYTHONPATH which contains paths to studio bundle addons, which is "auto-fixed" in AYON launcher but not for DCC subprocess.

## Testing notes:
1. Application actions do start DCC with project bundle addons.
