### PR TITLE
Settings: Make project environments scoped to project settings

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -330,7 +330,8 @@ class CoreSettings(BaseSettingsModel):
         "{}",
         widget="textarea",
         title="Project environments",
-        section="---"
+        section="---",
+        scope=["project"],
     )
     filter_env_profiles: list[FilterEnvsProfileModel] = SettingsField(
         default_factory=list,


### PR DESCRIPTION
## Changelog Description

Settings: Make project environments scoped to project settings

## Additional info

No idea whether this is actually a sensible change. It seems that this setting is focused solely on being project-specific settings, hence I wonder why is it listed in studio settings.

May need some good confirmation it doesn't break anything.

## Testing notes:

1. Project environments setting should work `ayon+settings://core/project_environments?project=projectname`
