### PR TITLE
LoaderPlugin: Implement __repr__ to avoid printing instance like list as []

### DIFF
--- a/client/ayon_core/pipeline/load/plugins.py
+++ b/client/ayon_core/pipeline/load/plugins.py
@@ -284,6 +284,10 @@ class LoaderPlugin(list):
         """
         return []
 
+    def __repr__(self):
+        # Avoid printing as a list (due to inheritance), but print like object.
+        return object.__repr__(self)
+
 
 class ProductLoaderPlugin(LoaderPlugin):
     """Load product into host application


### PR DESCRIPTION
## Changelog Description

Print `LoaderPlugin` and inherited like object instead of `[]` due to `list` inheritance on the base class.

## Additional info

...

## Testing notes:

Check code changes.

Test:
```python
from ayon_core.pipeline import discover_loader_plugins

for Loader in discover_loader_plugins():
    print(Loader())
```

Should not print many `[]` but be more descriptive about the object.
