### PR TITLE
Chore: Added ayon-login to help printout

### DIFF
--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -52,7 +52,7 @@ from ayon_core.lib.env_tools import (
     "--ayon-login",
     is_flag=True,
     expose_value=False,
-    help="Force login dialog")
+    help="Show login dialog (change server or user)")
 def main_cli(ctx, *_args, **_kwargs):
     """AYON is main command serving as entry point to pipeline system.
 


### PR DESCRIPTION
## Changelog Description
`--ayon-login` could be used to force Login dialog (which could solve some issues when artists are connecting to wrong server).

This PR just adds this to `ayon_console --help` printout.

## Additional info
<img width="490" height="168" alt="image" src="https://github.com/user-attachments/assets/5a057272-2012-4dce-a3d5-139641aefd48" />