### PR TITLE
Oiio input, process, output arguments sepperation

### DIFF
--- a/client/ayon_core/hooks/pre_ocio_hook.py
+++ b/client/ayon_core/hooks/pre_ocio_hook.py
@@ -75,3 +75,17 @@ class OCIOEnvHook(PreLaunchHook):
             f"Setting OCIO environment to config path: {ocio_path}")
 
         self.launch_context.env["OCIO"] = ocio_path
+
+        custom_vars = config_data.get("custom_vars", {})
+        for var_name, var_value in custom_vars.items():
+            if var_value:
+                # Normalize path to fix mixed slashes like `W:\/AY1_Ayon/foo`
+                import os
+                var_value = os.path.normpath(var_value)
+                if self.host_name in ["nuke", "hiero"]:
+                    var_value = var_value.replace("\\", "/")
+                
+            self.log.info(
+                f"Setting OCIO custom variable '{var_name}' to '{var_value}'"
+            )
+            self.launch_context.env[var_name] = var_value

--- a/client/ayon_core/lib/transcoding.py
+++ b/client/ayon_core/lib/transcoding.py
@@ -1188,7 +1188,10 @@ def oiio_color_convert(
     target_colorspace=None,
     target_display=None,
     target_view=None,
-    additional_command_args=None,
+    custom_global_args=None,
+    custom_input_args=None,
+    custom_process_args=None,
+    custom_output_args=None,
     frames: Optional[str] = None,
     frame_padding: Optional[int] = None,
     parallel_frames: bool = False,
@@ -1223,8 +1226,10 @@ def oiio_color_convert(
             'target_colorspace')
         target_view (str): name for target viewer space (ocio valid)
             both 'view' and 'display' must be filled (if 'target_colorspace')
-        additional_command_args (list): arguments for oiiotool (like binary
-            depth for .dpx)
+        custom_global_args (list): Global settings applied before any files are read.
+        custom_input_args (list): Arguments applied directly to the input file upon loading.
+        custom_process_args (list): Operations that modify the image pixels currently in memory.
+        custom_output_args (list): Arguments applied immediately before the file is written to disk.
         frames (Optional[str]): Complex frame range to process. This requires
             input path and output path to use frame token placeholder like
             `#` or `%d`, e.g. file.#.exr
@@ -1262,6 +1267,7 @@ def oiio_color_convert(
     # Prepare subprocess arguments
     oiio_cmd = get_oiio_tool_args(
         "oiiotool",
+        *(custom_global_args or []),
         # Don't add any additional attributes
         "--nosoftwareattrib",
         "--colorconfig", config_path
@@ -1284,10 +1290,12 @@ def oiio_color_convert(
         oiio_cmd.append("--parallel-frames")
 
     oiio_cmd.extend([
+        *(custom_input_args or []),
         input_arg, input_path,
         # Tell oiiotool which channels should be put to top stack
         #   (and output)
-        "--ch", channels_arg
+        "--ch", channels_arg,
+        *(custom_process_args or [])
     ])
 
     # Validate input parameters
@@ -1317,9 +1325,6 @@ def oiio_color_convert(
             "Both source display/view and source_colorspace provided. "
             "Using source display/view pair and ignoring source_colorspace."
         )
-
-    if additional_command_args:
-        oiio_cmd.extend(additional_command_args)
 
     # Handle the different conversion cases
     # Source view and display are known
@@ -1381,7 +1386,10 @@ def oiio_color_convert(
             target_view,
         ])
 
-    oiio_cmd.extend(["-o", output_path])
+    oiio_cmd.extend([
+        *(custom_output_args or []),
+        "-o", output_path
+    ])
 
     logger.debug("Conversion command: {}".format(" ".join(oiio_cmd)))
     run_subprocess(oiio_cmd, logger=logger)

--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -9,7 +9,7 @@ import platform
 import tempfile
 import warnings
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional
 
 import ayon_api
@@ -40,6 +40,7 @@ class ConfigData:
     path: str = ""
     template: str = ""
     enabled: bool = True
+    custom_vars: dict = field(default_factory=dict)
 
 
 class CachedData:
@@ -737,9 +738,28 @@ def _get_config_path_from_profile_data(
         log.warning(f"Path was not found '{normalized_path}'.")
         return ConfigData()  # Return invalid config data
 
+    custom_vars = {}
+    for var in profile.get("custom_variables", []):
+        var_name = var["var_name"]
+        if var_name in custom_vars:
+            continue
+        var_value = var["value"]
+        formatted_value = StringTemplate.format_template(var_value, template_data)
+        if formatted_value.solved and str(formatted_value).strip():
+            resolved_value = str(formatted_value).strip()
+            if os.path.exists(resolved_value):
+                custom_vars[var_name] = resolved_value
+
+    # Ensure all defined variable names are present, defaulting to empty string if no valid path was found
+    for var in profile.get("custom_variables", []):
+        var_name = var["var_name"]
+        if var_name not in custom_vars:
+            custom_vars[var_name] = ""
+
     return ConfigData(
         path=normalized_path,
-        template=template
+        template=template,
+        custom_vars=custom_vars
     )
 
 
@@ -1044,6 +1064,7 @@ def get_imageio_config_preset(
     return {
         "path": config_data.path,
         "template": config_data.template,
+        "custom_vars": getattr(config_data, "custom_vars", {}),
     }
 
 
@@ -1070,10 +1091,12 @@ def _get_host_config_data(templates, template_data):
 
         path = os.path.abspath(formatted_path)
         if os.path.exists(path):
-            return {
-                "path": os.path.normpath(path),
-                "template": template
-            }
+            return ConfigData(
+                path=os.path.normpath(path),
+                template=template
+            )
+            
+    return ConfigData()
 
 
 def get_imageio_file_rules(project_name, host_name, project_settings=None):

--- a/client/ayon_core/plugins/publish/extract_color_transcode.py
+++ b/client/ayon_core/plugins/publish/extract_color_transcode.py
@@ -180,8 +180,14 @@ class ExtractOIIOTranscode(publish.Extractor):
                     new_repre["colorspaceData"]["colorspace"] = \
                         target_colorspace
 
-                additional_command_args = (output_def["oiiotool_args"]
-                                           ["additional_command_args"])
+                custom_global_args = (output_def.get("oiiotool_args", {})
+                                      .get("custom_global_args", []))
+                custom_input_args = (output_def.get("oiiotool_args", {})
+                                     .get("custom_input_args", []))
+                custom_process_args = (output_def.get("oiiotool_args", {})
+                                       .get("custom_process_args", []))
+                custom_output_args = (output_def.get("oiiotool_args", {})
+                                      .get("custom_output_args", []))
 
                 sequence_files = self._translate_to_sequence(
                     files_to_convert)
@@ -224,7 +230,10 @@ class ExtractOIIOTranscode(publish.Extractor):
                             target_view=target_view,
                             source_display=source_display,
                             source_view=source_view,
-                            additional_command_args=additional_command_args,
+                            custom_global_args=custom_global_args,
+                            custom_input_args=custom_input_args,
+                            custom_process_args=custom_process_args,
+                            custom_output_args=custom_output_args,
                             frames=frames,
                             frame_padding=frame_padding,
                             parallel_frames=parallel_frames,

--- a/client/ayon_core/plugins/publish/extract_oiio_postprocess.py
+++ b/client/ayon_core/plugins/publish/extract_oiio_postprocess.py
@@ -130,13 +130,21 @@ class ExtractOIIOPostProcess(publish.Extractor):
                     output_arguments: list[str] = output_def.get(
                         "output_arguments", []
                     )
+                    custom_global_args = output_def.get("custom_args", {}).get("custom_global_args", [])
+                    custom_input_args = output_def.get("custom_args", {}).get("custom_input_args", [])
+                    custom_process_args = output_def.get("custom_args", {}).get("custom_process_args", [])
+                    custom_output_args = output_def.get("custom_args", {}).get("custom_output_args", [])
 
                     # Prepare subprocess arguments
                     oiio_cmd = get_oiio_tool_args(
                         "oiiotool",
+                        *custom_global_args,
                         *input_arguments,
+                        *custom_input_args,
                         input_path,
+                        *custom_process_args,
                         *output_arguments,
+                        *custom_output_args,
                         "-o",
                         output_path
                     )

--- a/package.py
+++ b/package.py
@@ -1,6 +1,6 @@
 name = "core"
 title = "Core"
-version = "1.8.4+dev"
+version = "1.8.4+dev1"
 
 client_dir = "ayon_core"
 

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -145,6 +145,12 @@ class PublishedProductModel(BaseSettingsModel):
     )
 
 
+class OCIOCustomVariableModel(BaseSettingsModel):
+    _layout = "expanded"
+    var_name: str = SettingsField("", title="Variable name")
+    value: str = SettingsField("", title="Anatomy template key")
+
+
 class CoreImageIOConfigProfilesModel(BaseSettingsModel):
     _layout = "expanded"
     host_names: list[str] = SettingsField(
@@ -180,6 +186,11 @@ class CoreImageIOConfigProfilesModel(BaseSettingsModel):
         "",
         title="OCIO config path",
         description="Path to OCIO config. Anatomy formatting is supported.",
+    )
+    custom_variables: list[OCIOCustomVariableModel] = SettingsField(
+        default_factory=list,
+        title="Custom variables",
+        description="Variables to set in OCIO context. Resolved top-down."
     )
     published_product: PublishedProductModel = SettingsField(
         default_factory=PublishedProductModel,
@@ -370,6 +381,7 @@ DEFAULT_VALUES = {
                 "type": "builtin_path",
                 "builtin_path": "{BUILTIN_OCIO_ROOT}/aces_1.2/config.ocio",
                 "custom_path": "",
+                "custom_variables": [],
                 "published_product": {
                     "product_name": "",
                     "fallback": {

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -494,10 +494,25 @@ def _extract_oiio_transcoding_type():
 
 
 class OIIOToolArgumentsModel(BaseSettingsModel):
-    additional_command_args: list[str] = SettingsField(
+    custom_global_args: list[str] = SettingsField(
         default_factory=list,
-        title="Arguments",
-        description="Additional command line arguments for *oiiotool*."
+        title="Custom Global Arguments",
+        description="Global settings applied before any files are read. Examples: --threads, --colorconfig, --nosoftwareattrib, --info."
+    )
+    custom_input_args: list[str] = SettingsField(
+        default_factory=list,
+        title="Custom Input Arguments",
+        description="Arguments applied directly to the input file upon loading. Examples: -i:ch=R,G,B, --iscolorspace scene_linear, --frames."
+    )
+    custom_process_args: list[str] = SettingsField(
+        default_factory=list,
+        title="Custom Process Arguments",
+        description="Operations that modify the image pixels currently in memory. Examples: --resize, --crop, --ociodisplay, --colorconvert."
+    )
+    custom_output_args: list[str] = SettingsField(
+        default_factory=list,
+        title="Custom Output Arguments",
+        description="Arguments applied immediately before the file is written to disk. Examples: -d uint8, --attrib oiio:ColorSpace sRGB, --compression."
     )
 
 
@@ -683,6 +698,11 @@ class ExtractOIIOPostProcessOutputModel(BaseSettingsModel):
         default_factory=list,
         title="Output arguments",
         description="Arguments passed prior to the -o argument.",
+    )
+    custom_args: OIIOToolArgumentsModel = SettingsField(
+        default_factory=OIIOToolArgumentsModel,
+        title="Custom Arguments",
+        description="Additional custom arguments inserted at various points of OIIOtool command execution.",
     )
     tags: list[str] = SettingsField(
         default_factory=list,


### PR DESCRIPTION
## Changelog Description
Additional OIIO arguments that can be inserted as a custom global, input, process or output argument.

As OIIO has a strictly left to right order of operations it's important to be able to set where the extra arguments can be inserted.
The previous arguments could only be inserted after the input path. (at the processing stage)
But as i experienced some issue's with converting png's that stayed linear i needed to add "-d uint8 --attrib oiio:ColorSpace sRGB" just before the -o.
But even then, now you have full control over the argument and can finetune the commend better.


This is now the new order of the OIIO operations.

```python
args = [
    "oiiotool",
    "custom_global_arg"  # NEW
    *input_arguments,
    "custom_input_arg"  # NEW
     input_path,
    "custom_process_arg"  # replaces the old arguments
    *output_arguments,
    "custom_output_arg"  # NEW
     "-o",
    output_path
]
```

## Additional info
<img width="1132" height="1179" alt="image" src="https://github.com/user-attachments/assets/1eddbeea-cfdf-47a9-8bdf-c67cc5b9d55d" />


## Testing notes:
1. start with this step
2. follow this step
