### PR TITLE
Chore: Fill ocio template with environment variables

### DIFF
--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -1715,6 +1715,11 @@ def get_representation_ocio_config_path(
     if not config_template:
         return None
 
+    # Fill template with environment variables
+    # - use StringTemplate to ignore unfilled values so anatomy can try
+    config_template = str(StringTemplate.format_template(
+        config_template, os.environ.copy()
+    ))
     config_path = anatomy.fill_root(config_template)
     if os.path.isfile(config_path):
         return config_path


### PR DESCRIPTION
## Changelog Description
Fill ocio template with environment variables.

## Additional info
This should resolve issue if AYON's builtin ocio config is used, which is using `BUILTIN_OCIO_ROOT` environment variable for root.

## Testing notes:
1. Using builtin OCIO should work on farm (has to be different machine or user).
