### PR TITLE
Chore: Use published template name based on settings

### DIFF
--- a/client/ayon_core/pipeline/farm/tools.py
+++ b/client/ayon_core/pipeline/farm/tools.py
@@ -1,6 +1,6 @@
 import os
 
-from ayon_core.pipeline.publish.lib import get_template_name_from_instance
+from ayon_core.pipeline.publish.lib import get_template_name_for_instance
 
 
 def get_published_workfile_instance(context):
@@ -58,7 +58,7 @@ def from_published_scene(instance, replace_in_path=True):
     template_data["representation"] = rep.get("name")
     template_data["ext"] = rep.get("ext")
     template_data["comment"] = None
-    template_name = get_template_name_from_instance(instance)
+    template_name = get_template_name_for_instance(instance)
 
     anatomy = instance.context.data['anatomy']
     template_obj = anatomy.get_template_item("publish", template_name, "path")

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -31,7 +31,7 @@ from ayon_core.lib import (
 )
 from ayon_core.settings import get_project_settings
 from ayon_core.addon import AddonsManager
-from ayon_core.pipeline import get_staging_dir_info, CreatedInstance
+from ayon_core.pipeline import get_staging_dir_info
 from ayon_core.pipeline.plugin_discover import DiscoverResult
 from ayon_core.lib.file_transaction import copyfile
 from .constants import (
@@ -228,17 +228,17 @@ def get_publish_template_name(
     return template or default_template
 
 
-def get_template_name_from_instance(
-    instance: CreatedInstance,
-    mapped_product_base_type: Optional[dict[str, str]] = None,
+def get_template_name_for_instance(
+    instance: pyblish.api.Instance,
+    product_base_type: Optional[str] = None,
     logger: Optional[logging.Logger] = None,
-):
+) -> str:
     """Return anatomy template name to use for integration of instance.
 
     Args:
-        instance (CreatedInstance): Instance object.
-        mapped_product_base_type (dict[str, str] or None): Mapping of
-            product base types.
+        instance (pyblish.api.Instance): Instance object.
+        product_base_type (str or None): Optional override for product
+            base type.
         logger (logging.Logger or none): Custom logger used for
             'filter_profiles' function.
 
@@ -253,23 +253,23 @@ def get_template_name_from_instance(
 
     # Task can be optional in anatomy data
     host_name = context.data["hostName"]
-    product_base_type = instance.data.get("productBaseType")
     if not product_base_type:
-        product_base_type = instance.data["productType"]
-    if mapped_product_base_type:
         product_base_type = (
-            mapped_product_base_type.get(product_base_type)
-            or product_base_type
+            instance.data.get("productBaseType")
+            or instance.data["productType"]
         )
-    anatomy_data = instance.data["anatomyData"]
-    task_info = anatomy_data.get("task") or {}
+    task_name = task_type = None
+    task_entity = instance.data["taskEntity"]
+    if task_entity:
+        task_name = task_entity["name"]
+        task_type = task_entity["taskType"]
 
     return get_publish_template_name(
         project_name=project_name,
         host_name=host_name,
         product_base_type=product_base_type,
-        task_name=task_info.get("name"),
-        task_type=task_info.get("type"),
+        task_name=task_name,
+        task_type=task_type,
         project_settings=context.data["project_settings"],
         logger=logger
     )
@@ -947,7 +947,7 @@ def replace_with_published_scene_path(instance, replace_in_path=True):
     template_data["comment"] = None
 
     anatomy = instance.context.data["anatomy"]
-    template_name = get_template_name_from_instance(
+    template_name = get_template_name_for_instance(
         workfile_instance, logger=log
     )
     template = anatomy.get_template_item("publish", template_name, "path")
@@ -1122,7 +1122,7 @@ def get_instance_expected_output_path(
     })
 
     # Get instance publish template name
-    template_name = get_template_name_from_instance(instance)
+    template_name = get_template_name_for_instance(instance)
 
     path_template_obj = anatomy.get_template_item(
         "publish",

--- a/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
+++ b/client/ayon_core/plugins/publish/collect_otio_subset_resources.py
@@ -13,7 +13,7 @@ import pyblish.api
 
 from ayon_core.pipeline import publish
 from ayon_core.pipeline.publish import (
-    get_template_name_from_instance
+    get_template_name_for_instance
 )
 
 
@@ -50,7 +50,7 @@ class CollectOtioSubsetResources(
         if not instance.data.get("versionData"):
             instance.data["versionData"] = {}
 
-        template_name = get_template_name_from_instance(instance)
+        template_name = get_template_name_for_instance(instance)
         anatomy = instance.context.data["anatomy"]
         publish_path_template = anatomy.get_template_item(
             "publish", template_name, "path"

--- a/client/ayon_core/plugins/publish/collect_resources_path.py
+++ b/client/ayon_core/plugins/publish/collect_resources_path.py
@@ -13,7 +13,7 @@ import copy
 
 import pyblish.api
 
-from ayon_core.pipeline.publish import get_template_name_from_instance
+from ayon_core.pipeline.publish import get_template_name_for_instance
 
 
 class CollectResourcesPath(pyblish.api.InstancePlugin):
@@ -82,7 +82,7 @@ class CollectResourcesPath(pyblish.api.InstancePlugin):
         # TODO remove when all clients have solved this issue
         template_data.update({"frame": "FRAME_TEMP", "representation": "TEMP"})
 
-        template_name = get_template_name_from_instance(
+        template_name = get_template_name_for_instance(
             instance, logger=self.log
         )
 

--- a/client/ayon_core/plugins/publish/validate_publish_dir.py
+++ b/client/ayon_core/plugins/publish/validate_publish_dir.py
@@ -2,7 +2,7 @@ import pyblish.api
 from ayon_core.pipeline.publish import ValidateContentsOrder
 from ayon_core.pipeline.publish import (
     PublishXmlValidationError,
-    get_template_name_from_instance,
+    get_template_name_for_instance,
 )
 
 
@@ -28,9 +28,18 @@ class ValidatePublishDir(pyblish.api.InstancePlugin):
 
     def process(self, instance):
 
-        template_name = get_template_name_from_instance(
+        product_base_type = (
+            instance.data.get("productBaseType")
+            or instance.data["productType"]
+        )
+        mapped_product_base_type = (
+            self.product_base_type_mapping.get(product_base_type)
+            or product_base_type
+        )
+
+        template_name = get_template_name_for_instance(
             instance,
-            mapped_product_base_type=self.product_base_type_mapping,
+            product_base_type=mapped_product_base_type,
             logger=self.log,
         )
 


### PR DESCRIPTION
## Changelog Description
Use published template based on instance data instead of `"default"`.

## Additional info
This fixes an issue where "default" was hardcoded as the template name in `ayon_core.pipeline.farm.tools.from_published_scene`.
Added the function `get_template_name_from_instance` to consolidate a few instances in the code base that had duplicated functionality and use in the function mentioned above.

## Testing notes:
To test the `from_published_scene` fix
1. Create a template that is not called "default"
2. Set it as a template on some usd publish
3. Publish something belonging to that type
