### PR TITLE
Feature: Launcher workfiles listing options

### DIFF
--- a/client/ayon_core/pipeline/actions/launcher.py
+++ b/client/ayon_core/pipeline/actions/launcher.py
@@ -34,11 +34,13 @@ class LauncherActionSelection:
         folder_id,
         task_id,
         workfile_id,
+        published_workfile=False,
         folder_path=None,
         task_name=None,
         project_entity=None,
         folder_entity=None,
         task_entity=None,
+        representation_entity=None,
         workfile_entity=None,
         project_settings=None,
     ):
@@ -46,6 +48,7 @@ class LauncherActionSelection:
         self._folder_id = folder_id
         self._task_id = task_id
         self._workfile_id = workfile_id
+        self._published_workfile = published_workfile
 
         self._folder_path = folder_path
         self._task_name = task_name
@@ -53,6 +56,7 @@ class LauncherActionSelection:
         self._project_entity = project_entity
         self._folder_entity = folder_entity
         self._task_entity = task_entity
+        self._representation_entity = representation_entity
         self._workfile_entity = workfile_entity
 
         self._project_settings = project_settings
@@ -278,6 +282,7 @@ class LauncherActionSelection:
         if (
             self._project_name is None
             or self._workfile_id is None
+            or self._published_workfile
         ):
             return None
         if self._workfile_entity is None:
@@ -285,6 +290,20 @@ class LauncherActionSelection:
                 self._project_name, self._workfile_id
             )
         return self._workfile_entity
+
+    def get_representation_entity(self):
+        """Published representation entity for the selection."""
+        if (
+            self._project_name is None
+            or self._workfile_id is None
+            or not self._published_workfile
+        ):
+            return None
+        if self._representation_entity is None:
+            self._representation_entity = ayon_api.get_representation_by_id(
+                self._project_name, self._workfile_id
+            )
+        return self._representation_entity
 
     def get_project_settings(self):
         """Project settings for the selection.
@@ -342,6 +361,10 @@ class LauncherActionSelection:
         """
         return self._workfile_id is not None
 
+    @property
+    def is_published_workfile(self):
+        return self._published_workfile
+
     project_name = property(get_project_name)
     folder_id = property(get_folder_id)
     task_id = property(get_task_id)
@@ -353,6 +376,7 @@ class LauncherActionSelection:
     folder_entity = property(get_folder_entity)
     task_entity = property(get_task_entity)
     workfile_entity = property(get_workfile_entity)
+    representation_entity = property(get_representation_entity)
 
 
 class LauncherAction(object):

--- a/client/ayon_core/plugins/actions/copy_and_launch_published.py
+++ b/client/ayon_core/plugins/actions/copy_and_launch_published.py
@@ -1,0 +1,271 @@
+import shutil
+from pathlib import Path
+from typing import Any
+
+import ayon_api
+
+from ayon_core.addon import AddonsManager, IHostAddon
+from ayon_core.lib import StringTemplate
+from ayon_core.pipeline import Anatomy, LauncherAction
+from ayon_core.pipeline.load import get_representation_path_with_anatomy
+from ayon_core.pipeline.template_data import get_template_data
+from ayon_core.pipeline.version_start import get_versioning_start
+from ayon_core.pipeline.workfile.path_resolving import (
+    get_last_workfile_with_version,
+    get_workdir,
+    get_workfile_template_key,
+)
+from ayon_core.pipeline.workfile.utils import (
+    find_workfile_rootless_path,
+    save_workfile_info,
+)
+
+
+class _CopyAndLaunchPublishedLogic:
+    name = "copy_and_launch_published"
+    label = "Copy and Open"
+    order = 5
+    app_full_name = None
+    host_name = None
+    supported_exts = frozenset()
+
+    def is_compatible(self, selection) -> bool:
+        """Return whether this app variant can process current selection."""
+        if not (
+            selection.is_published_workfile
+            and selection.is_project_selected
+            and selection.is_folder_selected
+            and selection.is_task_selected
+            and selection.is_workfile_selected
+        ):
+            return False
+
+        representation_entity = selection.representation_entity
+        if not representation_entity:
+            return False
+        source_path = get_representation_path_with_anatomy(
+            representation_entity, Anatomy(selection.project_name)
+        )
+        if not source_path:
+            return False
+        src_ext = Path(source_path).suffix.lower().lstrip(".")
+        return src_ext in self.supported_exts
+
+    def process(self, selection, **kwargs) -> None:
+        """Copy selected published workfile to workdir and launch app."""
+        project_name = selection.project_name
+        project_entity = selection.project_entity
+        folder_entity = selection.folder_entity
+        task_entity = selection.task_entity
+        representation_entity = selection.representation_entity
+        if representation_entity is None:
+            raise RuntimeError("Published representation is not available.")
+
+        anatomy = Anatomy(project_name, project_entity=project_entity)
+        source_path = get_representation_path_with_anatomy(
+            representation_entity, anatomy
+        )
+        source_path_obj = Path(source_path) if source_path else None
+        if source_path_obj is None or not source_path_obj.exists():
+            raise RuntimeError(
+                "Published workfile path is not available on this machine."
+            )
+
+        src_ext = source_path_obj.suffix.lower().lstrip(".")
+        if not src_ext:
+            raise RuntimeError(
+                "Could not determine source workfile extension."
+            )
+
+        if src_ext not in self.supported_exts:
+            raise RuntimeError(
+                f"Selected workfile '.{src_ext}' is not supported by"
+                f" '{self.app_full_name}'."
+            )
+
+        project_settings = selection.get_project_settings()
+        template_key = get_workfile_template_key(
+            project_name,
+            task_entity["taskType"],
+            self.host_name,
+            project_settings=project_settings,
+        )
+        workdir = get_workdir(
+            project_entity,
+            folder_entity,
+            task_entity,
+            self.host_name,
+            anatomy=anatomy,
+            template_key=template_key,
+            project_settings=project_settings,
+        )
+        workdir_path = Path(workdir)
+        workdir_path.mkdir(parents=True, exist_ok=True)
+
+        template_data = get_template_data(
+            project_entity,
+            folder_entity,
+            task_entity,
+            self.host_name,
+        )
+        file_template = anatomy.get_template_item(
+            "work", template_key, "file"
+        ).template
+
+        _last_path, last_version = get_last_workfile_with_version(
+            str(workdir_path),
+            file_template,
+            template_data,
+            {f".{src_ext}"},
+        )
+        published_version = self._get_published_version(
+            project_name, representation_entity
+        )
+        if last_version is None:
+            version = get_versioning_start(
+                project_name,
+                self.host_name,
+                task_name=task_entity["name"],
+                task_type=task_entity["taskType"],
+                product_base_type="workfile",
+                project_settings=project_settings,
+            )
+            version = max(version, published_version + 1)
+        else:
+            version = max(last_version + 1, published_version + 1)
+
+        template_data["version"] = version
+        template_data["ext"] = src_ext
+        filename = StringTemplate.format_strict_template(
+            file_template, template_data
+        )
+        destination_path = workdir_path / filename
+        shutil.copy2(source_path_obj, destination_path)
+
+        rootless_path = find_workfile_rootless_path(
+            str(destination_path),
+            project_name,
+            folder_entity,
+            task_entity,
+            self.host_name,
+            project_settings=project_settings,
+            anatomy=anatomy,
+        )
+        save_workfile_info(
+            project_name,
+            task_entity["id"],
+            rootless_path,
+            self.host_name,
+            version=version,
+            comment=None,
+            description=None,
+        )
+
+        apps_addon = self._get_applications_addon()
+        apps_addon.launch_application(
+            app_name=self.app_full_name,
+            project_name=project_name,
+            folder_path=folder_entity["path"],
+            task_name=task_entity["name"],
+            workfile_path=str(destination_path),
+        )
+
+    def _get_applications_addon(self) -> Any:
+        """Return applications addon used to launch selected app variant."""
+        addons_manager = AddonsManager()
+        return addons_manager["applications"]
+
+    def _get_published_version(
+        self,
+        project_name: str,
+        representation_entity: dict[str, Any],
+    ) -> int:
+        """Return parent version number for selected representation."""
+        version_id = representation_entity.get("versionId")
+        if not version_id:
+            return 0
+        version_entity = ayon_api.get_version_by_id(
+            project_name, version_id, fields={"version"}
+        )
+        if not version_entity:
+            return 0
+        return version_entity.get("version") or 0
+
+
+def _host_extensions() -> dict[str, set[str]]:
+    """Map host names to supported workfile extensions."""
+    addons_manager = AddonsManager()
+    output: dict[str, set[str]] = {}
+    for addon in addons_manager.get_enabled_addons():
+        if not isinstance(addon, IHostAddon):
+            continue
+        host_name = addon.host_name
+        if not host_name:
+            continue
+        exts = {
+            ext.lower().lstrip(".")
+            for ext in addon.get_workfile_extensions()
+            if ext
+        }
+        if exts:
+            output[host_name] = exts
+    return output
+
+
+def _create_variant_actions() -> dict[str, type[LauncherAction]]:
+    """Dynamically create one launcher action class per app variant."""
+    actions: dict[str, type[LauncherAction]] = {}
+    try:
+        addons_manager = AddonsManager()
+        applications_addon = addons_manager["applications"]
+        apps_manager = applications_addon.get_applications_manager()
+        host_exts = _host_extensions()
+    except Exception:
+        return actions
+    for app_group in apps_manager.app_groups.values():
+        host_name = app_group.host_name
+        if not host_name or host_name not in host_exts:
+            continue
+
+        icon = None
+        if app_group.icon:
+            icon_url = applications_addon.get_app_icon_url(
+                app_group.icon, server=True
+            )
+            if icon_url:
+                # `get_qt_icon` with type "ayon_url" expects a path relative to
+                # the server base URL (it prepends base_url); full URLs break.
+                base_url = ayon_api.get_base_url()
+                if icon_url.startswith(base_url):
+                    icon_url = icon_url[len(base_url) + 1 :]
+                    icon = {"type": "ayon_url", "url": icon_url}
+                else:
+                    icon = {"type": "url", "url": icon_url}
+
+        for app in app_group:
+            if not app.enabled:
+                continue
+            class_name = "CopyAndLaunchPublished_" + app.full_name.replace(
+                "-", "_"
+            ).replace(".", "_")
+            identifier = f"copy_and_launch_published/{app.full_name}"
+            attrs = {
+                "identifier": identifier,
+                "name": "copy_and_launch_published",
+                "label": "Copy and Open",
+                "label_variant": app.full_label,
+                "icon": icon or "fa.copy",
+                "order": 5,
+                "app_full_name": app.full_name,
+                "host_name": host_name,
+                "supported_exts": frozenset(host_exts[host_name]),
+            }
+            actions[class_name] = type(
+                class_name,
+                (_CopyAndLaunchPublishedLogic, LauncherAction),
+                attrs,
+            )
+    return actions
+
+
+globals().update(_create_variant_actions())

--- a/client/ayon_core/tools/launcher/abstract.py
+++ b/client/ayon_core/tools/launcher/abstract.py
@@ -65,6 +65,7 @@ class WorkfileItem:
     exists: bool
     icon: Optional[str]
     version: Optional[int]
+    published: bool = False
 
 
 class AbstractLauncherCommon(ABC):
@@ -360,11 +361,16 @@ class AbstractLauncherFrontEnd(AbstractLauncherCommon):
         pass
 
     @abstractmethod
-    def set_selected_workfile(self, workfile_id: Optional[str]):
+    def set_selected_workfile(
+        self,
+        workfile_id: Optional[str],
+        published: bool = False,
+    ):
         """Change selected workfile.
 
         Args:
             workfile_id (Optional[str]): Workfile id or None.
+            published (bool): Selected workfile represents published file.
 
         """
         pass
@@ -509,6 +515,42 @@ class AbstractLauncherFrontEnd(AbstractLauncherCommon):
 
         Returns:
             list[WorkfileItem]: List of workfile items.
+
+        """
+        pass
+
+    @abstractmethod
+    def get_published_workfile_items(
+        self,
+        project_name: Optional[str],
+        folder_id: Optional[str],
+        task_id: Optional[str],
+    ) -> list[WorkfileItem]:
+        """Get published workfile items for a given context.
+
+        Args:
+            project_name (Optional[str]): Project name.
+            folder_id (Optional[str]): Folder id.
+            task_id (Optional[str]): Task id.
+
+        Returns:
+            list[WorkfileItem]: List of published workfile items.
+
+        """
+        pass
+
+    @abstractmethod
+    def get_show_local_workfiles_only_default(
+        self,
+        project_name: Optional[str],
+    ) -> bool:
+        """Get default launcher preference for local-only workfile list.
+
+        Args:
+            project_name (Optional[str]): Project name.
+
+        Returns:
+            bool: True if only workfiles present locally should be shown.
 
         """
         pass

--- a/client/ayon_core/tools/launcher/control.py
+++ b/client/ayon_core/tools/launcher/control.py
@@ -147,8 +147,10 @@ class BaseLauncherController(
     def set_selected_task(self, task_id, task_name):
         self._selection_model.set_selected_task(task_id, task_name)
 
-    def set_selected_workfile(self, workfile_id):
-        self._selection_model.set_selected_workfile(workfile_id)
+    def set_selected_workfile(self, workfile_id, published=False):
+        self._selection_model.set_selected_workfile(
+            workfile_id, published
+        )
 
     def get_selected_context(self):
         return {
@@ -167,6 +169,32 @@ class BaseLauncherController(
         return self._workfiles_model.get_workfile_items(
             project_name,
             task_id,
+        )
+
+    def get_published_workfile_items(
+        self,
+        project_name: Optional[str],
+        folder_id: Optional[str],
+        task_id: Optional[str],
+    ) -> list[WorkfileItem]:
+        return self._workfiles_model.get_published_workfile_items(
+            project_name,
+            folder_id,
+            task_id,
+        )
+
+    def get_show_local_workfiles_only_default(
+        self,
+        project_name: Optional[str],
+    ) -> bool:
+        """Return project default for the local-only workfile toggle."""
+        settings = self.get_project_settings(project_name)
+        return (
+            settings
+            .get("core", {})
+            .get("tools", {})
+            .get("launcher", {})
+            .get("show_local_workfiles_only", False)
         )
 
     # Actions

--- a/client/ayon_core/tools/launcher/models/actions.py
+++ b/client/ayon_core/tools/launcher/models/actions.py
@@ -107,6 +107,11 @@ class ActionsModel:
         )
 
         self._variant = get_settings_variant()
+        self._published_workfile_selected = False
+        controller.register_event_callback(
+            "selection.workfile.changed",
+            self._on_selection_workfile_changed,
+        )
 
     @staticmethod
     def calculate_full_label(label: str, variant_label: Optional[str]) -> str:
@@ -368,9 +373,13 @@ class ActionsModel:
             folder_id,
             task_id,
             workfile_id,
+            published_workfile=self._published_workfile_selected,
             project_entity=project_entity,
             project_settings=project_settings,
         )
+
+    def _on_selection_workfile_changed(self, event):
+        self._published_workfile_selected = event.get("published", False)
 
     def _get_webaction_request_data(self, selection: LauncherActionSelection):
         entity_type = None

--- a/client/ayon_core/tools/launcher/models/selection.py
+++ b/client/ayon_core/tools/launcher/models/selection.py
@@ -27,6 +27,7 @@ class LauncherSelectionModel:
         self._task_name = None
         self._task_id = None
         self._workfile_id = None
+        self._workfile_published = False
 
     def get_selected_project_name(self) -> Optional[str]:
         return self._project_name
@@ -87,11 +88,19 @@ class LauncherSelectionModel:
     def get_selected_workfile(self) -> Optional[str]:
         return self._workfile_id
 
-    def set_selected_workfile(self, workfile_id: Optional[str]) -> None:
-        if workfile_id == self._workfile_id:
+    def set_selected_workfile(
+        self,
+        workfile_id: Optional[str],
+        published: bool = False,
+    ) -> None:
+        if (
+            workfile_id == self._workfile_id
+            and published == self._workfile_published
+        ):
             return
 
         self._workfile_id = workfile_id
+        self._workfile_published = published
         self._controller.emit_event(
             "selection.workfile.changed",
             {
@@ -100,6 +109,7 @@ class LauncherSelectionModel:
                 "task_name": self._task_name,
                 "task_id": self._task_id,
                 "workfile_id": workfile_id,
+                "published": published,
             },
             self.event_source
         )

--- a/client/ayon_core/tools/launcher/models/workfiles.py
+++ b/client/ayon_core/tools/launcher/models/workfiles.py
@@ -1,13 +1,15 @@
-import os
+from pathlib import Path
 from typing import Optional, Any
 
 import ayon_api
 
+from ayon_core.addon import IHostAddon
 from ayon_core.lib import (
     Logger,
     NestedCacheItem,
 )
 from ayon_core.pipeline import Anatomy
+from ayon_core.pipeline.load import get_representation_path_with_anatomy
 from ayon_core.tools.launcher.abstract import (
     WorkfileItem,
     AbstractLauncherBackend,
@@ -15,18 +17,28 @@ from ayon_core.tools.launcher.abstract import (
 
 
 class WorkfilesModel:
-    def __init__(self, controller: AbstractLauncherBackend):
+    """Model collecting launcher workfiles for the current context."""
+
+    def __init__(self, controller: AbstractLauncherBackend) -> None:
         self._controller = controller
 
         self._log = Logger.get_logger(self.__class__.__name__)
 
-        self._host_icons = None
+        self._host_icons: Optional[dict[str, str]] = None
+        self._workfile_extensions: Optional[set[str]] = None
+        self._extension_to_host_name: Optional[dict[str, str]] = None
         self._workfile_items = NestedCacheItem(
             levels=2, default_factory=list, lifetime=60,
         )
+        self._published_workfile_items = NestedCacheItem(
+            levels=3, default_factory=list, lifetime=60,
+        )
 
     def reset(self) -> None:
+        """Reset cached workfile and host-extension mappings."""
         self._workfile_items.reset()
+        self._published_workfile_items.reset()
+        self._extension_to_host_name = None
 
     def get_workfile_items(
         self,
@@ -50,7 +62,7 @@ class WorkfilesModel:
             exists = False
             try:
                 path = anatomy.fill_root(rootless_path)
-                exists = os.path.exists(path)
+                exists = Path(path).exists()
             except Exception:
                 self._log.warning(
                     "Failed to fill root for workfile path",
@@ -62,7 +74,7 @@ class WorkfilesModel:
 
             items.append(WorkfileItem(
                 workfile_id=workfile_entity["id"],
-                filename=os.path.basename(rootless_path),
+                filename=Path(rootless_path).name,
                 exists=exists,
                 icon=self._get_host_icon(host_name),
                 version=version,
@@ -70,9 +82,163 @@ class WorkfilesModel:
         cache.update_data(items)
         return items
 
+    def get_published_workfile_items(
+        self,
+        project_name: Optional[str],
+        folder_id: Optional[str],
+        task_id: Optional[str],
+    ) -> list[WorkfileItem]:
+        if not project_name or not folder_id or not task_id:
+            return []
+
+        cache = self._published_workfile_items[project_name][folder_id][
+            task_id
+        ]
+        if cache.is_valid:
+            items = cache.get_data()
+        else:
+            project_entity = self._controller.get_project_entity(project_name)
+            anatomy = Anatomy(project_name, project_entity=project_entity)
+            items = []
+
+            product_ids = {
+                product_entity["id"]
+                for product_entity in ayon_api.get_products(
+                    project_name,
+                    folder_ids={folder_id},
+                    product_types={"workfile"},
+                    fields={"id"},
+                )
+            }
+            if product_ids:
+                version_entities = list(
+                    ayon_api.get_versions(
+                        project_name,
+                        product_ids=product_ids,
+                        fields={"id", "version", "taskId"},
+                    )
+                )
+                version_ids = {
+                    version_entity["id"] for version_entity in version_entities
+                }
+                version_by_id = {
+                    version_entity["id"]: version_entity
+                    for version_entity in version_entities
+                }
+                if version_ids:
+                    for repre_entity in ayon_api.get_representations(
+                        project_name,
+                        version_ids=version_ids,
+                        fields={
+                            "id",
+                            "versionId",
+                            "attrib",
+                            "context",
+                            "files",
+                        },
+                    ):
+                        version_entity = version_by_id.get(
+                            repre_entity["versionId"]
+                        )
+                        if version_entity is None:
+                            continue
+                        if task_id and version_entity.get("taskId") != task_id:
+                            continue
+                        if not self._is_supported_workfile_representation(
+                            repre_entity
+                        ):
+                            continue
+                        try:
+                            path = get_representation_path_with_anatomy(
+                                repre_entity, anatomy
+                            )
+                        except Exception:
+                            self._log.warning(
+                                "Failed to get published workfile path",
+                                exc_info=True,
+                            )
+                            continue
+
+                        path_obj = Path(path)
+                        ext = path_obj.suffix.lower().lstrip(".")
+                        host_name = self._get_host_name_for_extension(ext)
+                        items.append(
+                            WorkfileItem(
+                                workfile_id=repre_entity["id"],
+                                filename=path_obj.name,
+                                exists=path_obj.exists(),
+                                icon=self._get_host_icon(host_name),
+                                version=version_entity["version"],
+                                published=True,
+                            )
+                        )
+
+            cache.update_data(items)
+
+        return items
+
+    def _is_supported_workfile_representation(
+        self,
+        repre_entity: dict[str, Any],
+    ) -> bool:
+        """Return whether representation contains a supported workfile file."""
+        extensions = self._get_workfile_extensions()
+        if not extensions:
+            return True
+
+        for repre_file in repre_entity.get("files") or []:
+            filename = repre_file.get("name") or ""
+            ext = Path(filename).suffix.lower().lstrip(".")
+            if ext in extensions:
+                return True
+        return False
+
+    def _get_workfile_extensions(self) -> set[str]:
+        """Collect all known workfile extensions from enabled host addons."""
+        if self._workfile_extensions is None:
+            extensions = set()
+            addons_manager = self._controller.get_addons_manager()
+            for addon in addons_manager.get_enabled_addons():
+                if not isinstance(addon, IHostAddon):
+                    continue
+                for ext in addon.get_workfile_extensions():
+                    ext = ext.lower().lstrip(".")
+                    if ext:
+                        extensions.add(ext)
+            self._workfile_extensions = extensions
+        return self._workfile_extensions
+
+    def _get_extension_to_host_name(self) -> dict[str, str]:
+        """Build deterministic extension->host_name mapping for host icons."""
+        if self._extension_to_host_name is None:
+            mapping: dict[str, str] = {}
+            addons_manager = self._controller.get_addons_manager()
+            host_addons: list[tuple[str, IHostAddon]] = []
+            for addon in addons_manager.get_enabled_addons():
+                if not isinstance(addon, IHostAddon):
+                    continue
+                hn = addon.host_name
+                if not hn:
+                    continue
+                host_addons.append((hn, addon))
+            for host_name, addon in sorted(host_addons, key=lambda t: t[0]):
+                for raw_ext in addon.get_workfile_extensions():
+                    ext = raw_ext.lower().lstrip(".")
+                    if ext and ext not in mapping:
+                        mapping[ext] = host_name
+            self._extension_to_host_name = mapping
+        return self._extension_to_host_name
+
+    def _get_host_name_for_extension(self, ext: str) -> Optional[str]:
+        """Get host name for a normalized extension without leading dot."""
+        if not ext:
+            return None
+        return self._get_extension_to_host_name().get(ext)
+
     def _get_host_icon(
         self, host_name: Optional[str]
-    ) -> Optional[dict[str, Any]]:
+    ) -> Optional[str]:
+        """Return host icon url for a host name."""
         if self._host_icons is None:
             host_icons = {}
             try:
@@ -86,6 +252,7 @@ class WorkfilesModel:
         return self._host_icons.get(host_name)
 
     def _get_host_icons(self) -> dict[str, Any]:
+        """Collect host icon urls from applications addon app groups."""
         addons_manager = self._controller.get_addons_manager()
         applications_addon = addons_manager["applications"]
         apps_manager = applications_addon.get_applications_manager()

--- a/client/ayon_core/tools/launcher/ui/workfiles_page.py
+++ b/client/ayon_core/tools/launcher/ui/workfiles_page.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Callable
 
 import ayon_api
 from qtpy import QtCore, QtWidgets, QtGui
@@ -8,12 +8,20 @@ from ayon_core.tools.launcher.abstract import AbstractLauncherFrontEnd
 
 VERSION_ROLE = QtCore.Qt.UserRole + 1
 WORKFILE_ID_ROLE = QtCore.Qt.UserRole + 2
+PUBLISHED_ROLE = QtCore.Qt.UserRole + 3
 
 
 class WorkfilesModel(QtGui.QStandardItemModel):
+    """Qt model for listing saved or published launcher workfiles."""
+
     refreshed = QtCore.Signal()
 
-    def __init__(self, controller: AbstractLauncherFrontEnd) -> None:
+    def __init__(
+        self,
+        controller: AbstractLauncherFrontEnd,
+        show_published_enabled: Callable[[], bool],
+        show_local_only_enabled: Callable[[], bool],
+    ) -> None:
         super().__init__()
 
         self.setColumnCount(1)
@@ -33,6 +41,8 @@ class WorkfilesModel(QtGui.QStandardItemModel):
         )
 
         self._controller = controller
+        self._show_published_enabled = show_published_enabled
+        self._show_local_only_enabled = show_local_only_enabled
         self._selected_project_name = None
         self._selected_folder_id = None
         self._selected_task_id = None
@@ -42,19 +52,34 @@ class WorkfilesModel(QtGui.QStandardItemModel):
         self._cached_icons = {}
 
     def refresh(self) -> None:
+        """Refresh workfile rows for the currently selected context."""
         root_item = self.invisibleRootItem()
         root_item.removeRows(0, root_item.rowCount())
 
-        workfile_items = self._controller.get_workfile_items(
-            self._selected_project_name, self._selected_task_id
-        )
+        if self._show_published_enabled():
+            workfile_items = self._controller.get_published_workfile_items(
+                self._selected_project_name,
+                self._selected_folder_id,
+                self._selected_task_id,
+            )
+        else:
+            workfile_items = self._controller.get_workfile_items(
+                self._selected_project_name, self._selected_task_id
+            )
         new_items = []
         for workfile_item in workfile_items:
+            if (
+                not self._show_published_enabled()
+                and self._show_local_only_enabled()
+                and not workfile_item.exists
+            ):
+                continue
             icon = self._get_icon(workfile_item.icon)
             item = QtGui.QStandardItem(workfile_item.filename)
             item.setData(icon, QtCore.Qt.DecorationRole)
             item.setData(workfile_item.version, VERSION_ROLE)
             item.setData(workfile_item.workfile_id, WORKFILE_ID_ROLE)
+            item.setData(workfile_item.published, PUBLISHED_ROLE)
             flags = QtCore.Qt.NoItemFlags
             if workfile_item.exists:
                 flags = QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
@@ -76,19 +101,22 @@ class WorkfilesModel(QtGui.QStandardItemModel):
 
         self.refreshed.emit()
 
-    def _on_selection_project_changed(self, event) -> None:
+    def _on_selection_project_changed(self, event: dict[str, str]) -> None:
+        """React to project selection change and refresh workfiles."""
         self._selected_project_name = event["project_name"]
         self._selected_folder_id = None
         self._selected_task_id = None
         self.refresh()
 
-    def _on_selection_folder_changed(self, event) -> None:
+    def _on_selection_folder_changed(self, event: dict[str, str]) -> None:
+        """React to folder selection change and refresh workfiles."""
         self._selected_project_name = event["project_name"]
         self._selected_folder_id = event["folder_id"]
         self._selected_task_id = None
         self.refresh()
 
-    def _on_selection_task_changed(self, event) -> None:
+    def _on_selection_task_changed(self, event: dict[str, str]) -> None:
+        """React to task selection change and refresh workfiles."""
         self._selected_project_name = event["project_name"]
         self._selected_folder_id = event["folder_id"]
         self._selected_task_id = event["task_id"]
@@ -128,11 +156,15 @@ class WorkfilesModel(QtGui.QStandardItemModel):
 
 
 class WorkfilesView(DeselectableTreeView):
+    """Tree view with hidden branch decoration for single-column list."""
+
     def drawBranches(self, painter, rect, index):
         return
 
 
 class WorkfilesPage(QtWidgets.QWidget):
+    """Workfiles section with published/local filtering controls."""
+
     def __init__(
         self,
         controller: AbstractLauncherFrontEnd,
@@ -140,40 +172,92 @@ class WorkfilesPage(QtWidgets.QWidget):
     ) -> None:
         super().__init__(parent)
 
+        show_published_checkbox = QtWidgets.QCheckBox("Published", self)
+        show_local_only_checkbox = QtWidgets.QCheckBox("Local only", self)
         workfiles_view = WorkfilesView(self)
         workfiles_view.setIndentation(0)
-        workfiles_model = WorkfilesModel(controller)
+        workfiles_model = WorkfilesModel(
+            controller,
+            show_published_checkbox.isChecked,
+            show_local_only_checkbox.isChecked,
+        )
         workfiles_proxy = QtCore.QSortFilterProxyModel()
         workfiles_proxy.setSourceModel(workfiles_model)
 
         workfiles_view.setModel(workfiles_proxy)
 
+        # When published is enabled, local-only filtering does not apply.
+        show_local_only_checkbox.setEnabled(
+            not show_published_checkbox.isChecked()
+        )
+
+        toggles_row = QtWidgets.QHBoxLayout()
+        toggles_row.addWidget(show_published_checkbox)
+        toggles_row.addWidget(show_local_only_checkbox)
+        toggles_row.addStretch()
+
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(toggles_row, 0)
         layout.addWidget(workfiles_view, 1)
 
         workfiles_view.selectionModel().selectionChanged.connect(
             self._on_selection_changed
         )
         workfiles_model.refreshed.connect(self._on_refresh)
+        show_published_checkbox.toggled.connect(self._on_show_published_toggle)
+        show_local_only_checkbox.toggled.connect(self._on_show_local_only_toggle)
+        controller.register_event_callback(
+            "selection.project.changed",
+            self._on_project_changed,
+        )
 
         self._controller = controller
+        self._show_published_checkbox = show_published_checkbox
+        self._show_local_only_checkbox = show_local_only_checkbox
         self._workfiles_view = workfiles_view
         self._workfiles_model = workfiles_model
         self._workfiles_proxy = workfiles_proxy
 
     def refresh(self) -> None:
+        """Refresh the workfiles model."""
         self._workfiles_model.refresh()
 
-    def deselect(self):
+    def deselect(self) -> None:
+        """Clear current item selection in workfiles list."""
         sel_model = self._workfiles_view.selectionModel()
         sel_model.clearSelection()
 
     def _on_refresh(self) -> None:
+        """Apply sorting after model data refresh."""
         self._workfiles_proxy.sort(0, QtCore.Qt.DescendingOrder)
 
     def _on_selection_changed(self, selected, _deselected) -> None:
+        """Update selected workfile from current view selection."""
         workfile_id = None
+        published = False
         for index in selected.indexes():
             workfile_id = index.data(WORKFILE_ID_ROLE)
-        self._controller.set_selected_workfile(workfile_id)
+            published = bool(index.data(PUBLISHED_ROLE))
+        self._controller.set_selected_workfile(workfile_id, published)
+
+    def _on_show_published_toggle(self, checked: bool) -> None:
+        """Disable local-only toggle when published mode is enabled."""
+        self._show_local_only_checkbox.setEnabled(not checked)
+        self._workfiles_model.refresh()
+
+    def _on_show_local_only_toggle(self, _checked: bool) -> None:
+        """Refresh list after local-only toggle change."""
+        self._workfiles_model.refresh()
+
+    def _on_project_changed(self, event: dict[str, str]) -> None:
+        """Apply project defaults for local-only toggle and refresh list."""
+        project_name = event["project_name"]
+        show_local_only = (
+            self._controller.get_show_local_workfiles_only_default(
+                project_name
+            )
+        )
+        with QtCore.QSignalBlocker(self._show_local_only_checkbox):
+            self._show_local_only_checkbox.setChecked(show_local_only)
+        self._workfiles_model.refresh()

--- a/server/settings/tools.py
+++ b/server/settings/tools.py
@@ -230,6 +230,17 @@ class WorkfilesToolModel(BaseSettingsModel):
     )
 
 
+class LauncherToolModel(BaseSettingsModel):
+    show_local_workfiles_only: bool = SettingsField(
+        False,
+        title="Show local workfiles only",
+        description=(
+            "Default setting for launcher workfiles, it hides save-as "
+            "workfiles that are not present on the local workstation."
+        ),
+    )
+
+
 def _product_types_enum():
     return [
         "action",
@@ -454,6 +465,10 @@ class GlobalToolsModel(BaseSettingsModel):
         default_factory=WorkfilesToolModel,
         title="Workfiles"
     )
+    launcher: LauncherToolModel = SettingsField(
+        default_factory=LauncherToolModel,
+        title="Launcher"
+    )
     loader: LoaderToolModel = SettingsField(
         default_factory=LoaderToolModel,
         title="Loader"
@@ -656,6 +671,9 @@ DEFAULT_TOOLS_VALUES = {
         ],
         "extra_folders": [],
         "workfile_lock_profiles": []
+    },
+    "launcher": {
+        "show_local_workfiles_only": False
     },
     "loader": {
         "product_type_filter_profiles": []


### PR DESCRIPTION
## Changelog Description
Buttons to show `Published` or `Only local` (hide the ones saved-as but not in local workdir) workfiles in launcher.

## Additional info
This follows several discussions with @iLLiCiTiT. I've been asked to make it clearer by my studio team so here is my proposal as base of contribution:
1. `Published` button to list published workfiles in the launcher UI instead of saved-as ones. A `Copy and Open` action comes with it in order to do like the `copy and open` button in the `workfiles` window.
     <img width="354" height="155" alt="Capture d’écran 2026-03-25 à 16 01 03" src="https://github.com/user-attachments/assets/d3501edb-9f76-46e8-b321-62449060e082" />
2. `Local Only` button to hide saved-as workfiles which aren't not locally available in workdir in order to avoid confusion for artists expecting a workfile which isn't available any where. It comes with a default setting on server side.
    <img width="335" height="168" alt="Capture d’écran 2026-03-25 à 16 13 31" src="https://github.com/user-attachments/assets/e102232b-a602-418f-ad57-989056a793a3" />
    <img width="344" height="169" alt="Capture d’écran 2026-03-25 à 16 13 19" src="https://github.com/user-attachments/assets/db4aeed7-277f-4267-b09e-3029990b6c44" />

## Testing notes:
1. Open launcher window
2. Toggle the buttons
3. With `Published` checked, pick a workfile and click on a host icon, it'll copy and open it.
