### PR TITLE
Chore: Bump required AYON launcher

### DIFF
--- a/client/ayon_core/plugins/publish/collect_addons.py
+++ b/client/ayon_core/plugins/publish/collect_addons.py
@@ -3,6 +3,7 @@
 import os
 
 import pyblish.api
+import ayon_api
 
 from ayon_core.lib.ayon_info import (
     get_settings_variant,
@@ -43,11 +44,14 @@ class CollectAddons(pyblish.api.ContextPlugin):
         else:
             settings_variant = get_settings_variant()
 
+        server_version = ayon_api.get_server_version()
+
         ayon_info = get_ayon_info()
         launcher_version = ayon_info["ayon_launcher_version"]
         launcher_type = ayon_info["version_type"]
         lines = [
             "Basic AYON information:",
+            f"AYON server: {server_version}",
             f"Bundle: {bundle_name} ({settings_variant})",
             f"AYON launcher: {launcher_version} ({launcher_type})",
             "Addons:",

--- a/client/ayon_core/plugins/publish/integrate_review.py
+++ b/client/ayon_core/plugins/publish/integrate_review.py
@@ -2,8 +2,6 @@ import os
 import time
 
 import ayon_api
-from ayon_api import TransferProgress
-from ayon_api.server_api import RequestTypes
 import pyblish.api
 
 from ayon_core.lib import get_media_mime_type, format_file_size
@@ -11,7 +9,6 @@ from ayon_core.pipeline.publish import (
     PublishXmlValidationError,
     get_publish_repre_path,
 )
-import requests.exceptions
 
 
 class IntegrateAYONReview(pyblish.api.InstancePlugin):
@@ -73,22 +70,38 @@ class IntegrateAYONReview(pyblish.api.InstancePlugin):
                 continue
 
             label = self._get_review_label(repre, uploaded_labels)
-            query = ""
-            if label:
-                query = f"?label={label}"
 
-            endpoint = (
-                f"/projects/{project_name}"
-                f"/versions/{version_id}/reviewables{query}"
+            size = os.path.getsize(repre_path)
+            start = time.time()
+            self.log.info(
+                f"Uploading '{repre_path}' (size: {format_file_size(size)})"
             )
-            self.log.info(f"Uploading reviewable {repre_path}")
-            # Upload with retries and clear help if it keeps failing
-            self._upload_with_retries(
-                ayon_con,
-                endpoint,
-                repre_path,
-                content_type,
-            )
+            try:
+                ayon_api.upload_reviewable(
+                    project_name,
+                    version_id,
+                    repre_path,
+                    content_type=content_type,
+                    label=label,
+                )
+            except Exception as exc:
+                self.log.warning(
+                    f"Review upload failed after {time.time() - start}s.",
+                    exc_info=True,
+                )
+                raise PublishXmlValidationError(
+                    self,
+                    (
+                        "Upload of reviewable timed out or failed after"
+                        " multiple attempts. Please try publishing again."
+                    ),
+                    formatting_data={
+                        "upload_type": "Review",
+                        "file": repre_path,
+                        "error": str(exc),
+                    },
+                    help_filename="upload_file.xml",
+                )
 
     def _get_review_label(self, repre, uploaded_labels):
         # Use output name as label if available
@@ -101,74 +114,3 @@ class IntegrateAYONReview(pyblish.api.InstancePlugin):
             idx += 1
             label = f"{orig_label}_{idx}"
         return label
-
-    def _upload_with_retries(
-        self,
-        ayon_con: ayon_api.ServerAPI,
-        endpoint: str,
-        repre_path: str,
-        content_type: str,
-    ):
-        """Upload file with simple retries."""
-        filename = os.path.basename(repre_path)
-
-        headers = ayon_con.get_headers(content_type)
-        headers["x-file-name"] = filename
-        max_retries = ayon_con.get_default_max_retries()
-        # Retries are already implemented in 'ayon_api.upload_file'
-        # - added in ayon api 1.2.7
-        if hasattr(TransferProgress, "get_attempt"):
-            max_retries = 1
-
-        size = os.path.getsize(repre_path)
-        self.log.info(
-            f"Uploading '{repre_path}' (size: {format_file_size(size)})"
-        )
-
-        # How long to sleep before next attempt
-        wait_time = 1
-        last_error = None
-        for attempt in range(max_retries):
-            attempt += 1
-            start = time.time()
-            try:
-                output = ayon_con.upload_file(
-                    endpoint,
-                    repre_path,
-                    headers=headers,
-                    request_type=RequestTypes.post,
-                )
-                self.log.debug(f"Uploaded in {time.time() - start}s.")
-                return output
-
-            except (
-                requests.exceptions.Timeout,
-                requests.exceptions.ConnectionError
-            ) as exc:
-                # Log and retry with backoff if attempts remain
-                if attempt >= max_retries:
-                    last_error = exc
-                    break
-
-                self.log.warning(
-                    f"Review upload failed ({attempt}/{max_retries})"
-                    f" after {time.time() - start}s."
-                    f" Retrying in {wait_time}s...",
-                    exc_info=True,
-                )
-                time.sleep(wait_time)
-
-        # Exhausted retries - raise a user-friendly validation error with help
-        raise PublishXmlValidationError(
-            self,
-            (
-                "Upload of reviewable timed out or failed after multiple"
-                " attempts. Please try publishing again."
-            ),
-            formatting_data={
-                "upload_type": "Review",
-                "file": repre_path,
-                "error": str(last_error),
-            },
-            help_filename="upload_file.xml",
-        )

--- a/client/ayon_core/plugins/publish/integrate_review.py
+++ b/client/ayon_core/plugins/publish/integrate_review.py
@@ -31,15 +31,6 @@ class IntegrateAYONReview(pyblish.api.InstancePlugin):
             self._upload_reviewable(project_name, version_id, instance)
 
     def _upload_reviewable(self, project_name, version_id, instance):
-        ayon_con = ayon_api.get_server_api_connection()
-        major, minor, _, _, _ = ayon_con.get_server_version_tuple()
-        if (major, minor) < (1, 3):
-            self.log.info(
-                "Skipping reviewable upload, supported from server 1.3.x."
-                f" Current server version {ayon_con.get_server_version()}"
-            )
-            return
-
         uploaded_labels = set()
         for repre in instance.data["representations"]:
             repre_tags = repre.get("tags") or []

--- a/client/ayon_core/plugins/publish/integrate_review.py
+++ b/client/ayon_core/plugins/publish/integrate_review.py
@@ -74,6 +74,8 @@ class IntegrateAYONReview(pyblish.api.InstancePlugin):
                     repre_path,
                     content_type=content_type,
                     label=label,
+                    # Pass headers to fix bug in ayon-api (fixed in 1.2.15)
+                    headers={},
                 )
             except Exception as exc:
                 self.log.warning(

--- a/client/ayon_core/plugins/publish/integrate_thumbnail.py
+++ b/client/ayon_core/plugins/publish/integrate_thumbnail.py
@@ -188,7 +188,6 @@ class IntegrateThumbnailsAYON(pyblish.api.ContextPlugin):
                 exc_info=True,
             )
 
-
         # Exhausted retries - raise a user-friendly validation error with help
         raise PublishXmlValidationError(
             self,

--- a/client/ayon_core/plugins/publish/integrate_thumbnail.py
+++ b/client/ayon_core/plugins/publish/integrate_thumbnail.py
@@ -27,12 +27,10 @@ import collections
 import time
 
 import ayon_api
-from ayon_api import RequestTypes, TransferProgress
 from ayon_api.operations import OperationsSession
 import pyblish.api
-import requests
 
-from ayon_core.lib import get_media_mime_type, format_file_size
+from ayon_core.lib import format_file_size
 from ayon_core.pipeline.publish import PublishXmlValidationError
 
 
@@ -170,19 +168,41 @@ class IntegrateThumbnailsAYON(pyblish.api.ContextPlugin):
 
     def _create_thumbnail(self, project_name: str, src_filepath: str) -> str:
         """Upload thumbnail to AYON and return its id."""
-        mime_type = get_media_mime_type(src_filepath)
-        if mime_type is None:
-            return ayon_api.create_thumbnail(
+        size = os.path.getsize(src_filepath)
+        self.log.info(
+            f"Uploading '{src_filepath}' (size: {format_file_size(size)})"
+        )
+
+        start = time.time()
+        try:
+            thubmnail_id = ayon_api.create_thumbnail(
                 project_name, src_filepath
             )
+            self.log.debug(f"Uploaded in {time.time() - start}s.")
+            return thubmnail_id
 
-        response = self._upload_with_retries(
-            f"projects/{project_name}/thumbnails",
-            src_filepath,
-            mime_type,
+        except Exception as exc:
+            last_error = exc
+            self.log.warning(
+                f"Review upload failed after {time.time() - start}s.",
+                exc_info=True,
+            )
+
+
+        # Exhausted retries - raise a user-friendly validation error with help
+        raise PublishXmlValidationError(
+            self,
+            (
+                "Upload of thumbnail timed out or failed after multiple"
+                " attempts. Please try publishing again."
+            ),
+            formatting_data={
+                "upload_type": "Thumbnail",
+                "file": src_filepath,
+                "error": str(last_error),
+            },
+            help_filename="upload_file.xml",
         )
-        response.raise_for_status()
-        return response.json()["id"]
 
     def _integrate_thumbnails(
         self,
@@ -244,72 +264,4 @@ class IntegrateThumbnailsAYON(pyblish.api.ContextPlugin):
             instance.data.get("label")
             or instance.data.get("name")
             or "N/A"
-        )
-
-    def _upload_with_retries(
-        self,
-        endpoint: str,
-        repre_path: str,
-        content_type: str,
-    ):
-        """Upload file with simple retries."""
-        ayon_con = ayon_api.get_server_api_connection()
-        headers = ayon_con.get_headers(content_type)
-        max_retries = ayon_con.get_default_max_retries()
-        # Retries are already implemented in 'ayon_api.upload_file'
-        # - added in ayon api 1.2.7
-        if hasattr(TransferProgress, "get_attempt"):
-            max_retries = 1
-
-        size = os.path.getsize(repre_path)
-        self.log.info(
-            f"Uploading '{repre_path}' (size: {format_file_size(size)})"
-        )
-
-        # How long to sleep before next attempt
-        wait_time = 1
-        last_error = None
-        for attempt in range(max_retries):
-            attempt += 1
-            start = time.time()
-            try:
-                output = ayon_con.upload_file(
-                    endpoint,
-                    repre_path,
-                    headers=headers,
-                    request_type=RequestTypes.post,
-                )
-                self.log.debug(f"Uploaded in {time.time() - start}s.")
-                return output
-
-            except (
-                requests.exceptions.Timeout,
-                requests.exceptions.ConnectionError
-            ) as exc:
-                # Log and retry with backoff if attempts remain
-                if attempt >= max_retries:
-                    last_error = exc
-                    break
-
-                self.log.warning(
-                    f"Review upload failed ({attempt}/{max_retries})"
-                    f" after {time.time() - start}s."
-                    f" Retrying in {wait_time}s...",
-                    exc_info=True,
-                )
-                time.sleep(wait_time)
-
-        # Exhausted retries - raise a user-friendly validation error with help
-        raise PublishXmlValidationError(
-            self,
-            (
-                "Upload of thumbnail timed out or failed after multiple"
-                " attempts. Please try publishing again."
-            ),
-            formatting_data={
-                "upload_type": "Thumbnail",
-                "file": repre_path,
-                "error": str(last_error),
-            },
-            help_filename="upload_file.xml",
         )

--- a/client/ayon_core/settings/lib.py
+++ b/client/ayon_core/settings/lib.py
@@ -69,22 +69,11 @@ def _get_addons_settings(
 
 
 class _AyonSettingsCache:
-    use_bundles = None
     variant = None
     addon_versions = CacheItem.create_outdated()
     studio_settings = CacheItem.create_outdated()
     cache_by_project_name = collections.defaultdict(
         CacheItem.create_outdated)
-
-    @classmethod
-    def _use_bundles(cls):
-        if _AyonSettingsCache.use_bundles is None:
-            major, minor, _, _, _ = ayon_api.get_server_version_tuple()
-            use_bundles = True
-            if (major, minor) < (0, 3):
-                use_bundles = False
-            _AyonSettingsCache.use_bundles = use_bundles
-        return _AyonSettingsCache.use_bundles
 
     @classmethod
     def _get_variant(cls):

--- a/package.py
+++ b/package.py
@@ -9,7 +9,7 @@ plugin_for = ["ayon_server"]
 project_can_override_addon_version = True
 
 ayon_server_version = ">=1.8.4,<2.0.0"
-ayon_launcher_version = ">=1.0.2"
+ayon_launcher_version = ">=1.5.3"
 ayon_required_addons = {}
 ayon_compatible_addons = {
     "ayon_third_party": ">=1.3.0",


### PR DESCRIPTION
## Changelog Description
Recent changes server side and few fixes in AYON launcher and ayon api do require to bump compatible AYON launcher.

## Additional info
We can rely on changes from latest ayon api -> and server. This should fully change support of product base types.

Download/upload functions are more reliable. Upload thumbnail and review use correct endpoints.

## Testing notes:
- Upload of thumbnail and review should not report wrong endpoint.
