### PR TITLE
Fix API endpoint format for project reviews

### DIFF
--- a/client/ayon_core/plugins/publish/integrate_review.py
+++ b/client/ayon_core/plugins/publish/integrate_review.py
@@ -78,7 +78,7 @@ class IntegrateAYONReview(pyblish.api.InstancePlugin):
                 query = f"?label={label}"
 
             endpoint = (
-                f"/projects/{project_name}"
+                f"/api/projects/{project_name}"
                 f"/versions/{version_id}/reviewables{query}"
             )
             self.log.info(f"Uploading reviewable {repre_path}")


### PR DESCRIPTION
for some reason /api/ is missing so deadline publishing is failing trying not working endpoint, but local publish is ok by the way.

I saw api autofix for thumbsnail but i assume its not working for review.

