### PR TITLE
Users model: Use 'get_users' from ayon api

### DIFF
--- a/client/ayon_core/tools/common_models/users.py
+++ b/client/ayon_core/tools/common_models/users.py
@@ -1,83 +1,10 @@
-import json
-import collections
 from typing import Optional
 
 import ayon_api
-from ayon_api.graphql import FIELD_VALUE, GraphQlQuery, fields_to_dict
 
 from ayon_core.lib import NestedCacheItem, get_ayon_username
 
 NOT_SET = object()
-
-
-# --- Implementation that should be in ayon-python-api ---
-# The implementation is not available in all versions of ayon-python-api.
-def users_graphql_query(fields):
-    query = GraphQlQuery("Users")
-    names_var = query.add_variable("userNames", "[String!]")
-    project_name_var = query.add_variable("projectName", "String!")
-
-    users_field = query.add_field_with_edges("users")
-    users_field.set_filter("names", names_var)
-    users_field.set_filter("projectName", project_name_var)
-
-    nested_fields = fields_to_dict(set(fields))
-
-    query_queue = collections.deque()
-    for key, value in nested_fields.items():
-        query_queue.append((key, value, users_field))
-
-    while query_queue:
-        item = query_queue.popleft()
-        key, value, parent = item
-        field = parent.add_field(key)
-        if value is FIELD_VALUE:
-            continue
-
-        for k, v in value.items():
-            query_queue.append((k, v, field))
-    return query
-
-
-def get_users(project_name=None, usernames=None, fields=None):
-    """Get Users.
-
-    Only administrators and managers can fetch all users. For other users
-        it is required to pass in 'project_name' filter.
-
-    Args:
-        project_name (Optional[str]): Project name.
-        usernames (Optional[Iterable[str]]): Filter by usernames.
-        fields (Optional[Iterable[str]]): Fields to be queried
-            for users.
-
-    Returns:
-        Generator[dict[str, Any]]: Queried users.
-
-    """
-    filters = {}
-    if usernames is not None:
-        usernames = set(usernames)
-        if not usernames:
-            return
-        filters["userNames"] = list(usernames)
-
-    if project_name is not None:
-        filters["projectName"] = project_name
-
-    con = ayon_api.get_server_api_connection()
-    if not fields:
-        fields = con.get_default_fields_for_type("user")
-
-    query = users_graphql_query(set(fields))
-    for attr, filter_value in filters.items():
-        query.set_variable_value(attr, filter_value)
-
-    for parsed_data in query.continuous_query(con):
-        for user in parsed_data["users"]:
-            user["accessGroups"] = json.loads(user["accessGroups"])
-            yield user
-# --- END of ayon-python-api implementation ---
 
 
 class UserItem:
@@ -172,5 +99,5 @@ class UsersModel:
 
         self._users_cache[project_name].update_data([
             UserItem.from_entity_data(user)
-            for user in get_users(project_name)
+            for user in ayon_api.get_users(project_name=project_name)
         ])


### PR DESCRIPTION
## Changelog Description
Users model in tools use ayon api implementation from ayon api.

## Additional info
All the missing parts are already avaialable in ayon api so the custom function is not needed anymore. Also fixes an issue if `allAttrib` are used instead of `attrib`.

## Testing notes:
1. Workfiles tool works with https://github.com/ynput/ayon-launcher/pull/299 .
