### PR TITLE
Extract Thumbnail: Use exr instead of png for create frame from video

### DIFF
--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -630,7 +630,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         base_name = os.path.basename(video_file_path)
         filename = os.path.splitext(base_name)[0]
         output_thumb_file_path = os.path.join(
-            output_dir, "{}.png".format(filename))
+            output_dir, "{}.exr".format(filename))
 
         # Set video input attributes
         max_int = str(2147483647)


### PR DESCRIPTION
## Changelog Description
This PR is to ensure ffmpeg writing the correct image with alpha so that it can be eventually correctly transcoded into thumbnail. The purpose of this PR is the fact that the oiiotool cannot read png with alpha and we need to resolve it with exr instead.  
## Additional info
n/a

## Testing notes:
1. Create Render (with video, render sequences)
2. Publish