### PR TITLE
SiteSync: Added tooltips to sitesync site icons

### DIFF
--- a/client/ayon_core/tools/loader/abstract.py
+++ b/client/ayon_core/tools/loader/abstract.py
@@ -1169,7 +1169,7 @@ class FrontendLoaderController(_BaseLoaderController):
         pass
 
     @abstractmethod
-    def get_active_site(self, project_name):
+    def get_active_site(self, project_name: str) -> str | None:
         """Active site name.
 
         Args:
@@ -1177,12 +1177,12 @@ class FrontendLoaderController(_BaseLoaderController):
 
         Returns:
             Union[str, None]: Site name or None if site sync is not enabled.
-        """
 
+        """
         pass
 
     @abstractmethod
-    def get_remote_site(self, project_name):
+    def get_remote_site(self, project_name: str) -> str | None:
         """Remote site name.
 
         Args:

--- a/client/ayon_core/tools/loader/abstract.py
+++ b/client/ayon_core/tools/loader/abstract.py
@@ -1190,6 +1190,7 @@ class FrontendLoaderController(_BaseLoaderController):
 
         Returns:
             Union[str, None]: Site name or None if site sync is not enabled.
+
         """
 
         pass

--- a/client/ayon_core/tools/loader/abstract.py
+++ b/client/ayon_core/tools/loader/abstract.py
@@ -1169,6 +1169,32 @@ class FrontendLoaderController(_BaseLoaderController):
         pass
 
     @abstractmethod
+    def get_active_site(self, project_name):
+        """Active site name.
+
+        Args:
+            project_name (str): Project name.
+
+        Returns:
+            Union[str, None]: Site name or None if site sync is not enabled.
+        """
+
+        pass
+
+    @abstractmethod
+    def get_remote_site(self, project_name):
+        """Remote site name.
+
+        Args:
+            project_name (str): Project name.
+
+        Returns:
+            Union[str, None]: Site name or None if site sync is not enabled.
+        """
+
+        pass
+
+    @abstractmethod
     def get_version_sync_availability(self, project_name, version_ids):
         """Version sync availability.
 

--- a/client/ayon_core/tools/loader/control.py
+++ b/client/ayon_core/tools/loader/control.py
@@ -486,6 +486,12 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
     def get_remote_site_icon_def(self, project_name):
         return self._sitesync_model.get_remote_site_icon_def(project_name)
 
+    def get_active_site(self, project_name):
+        return self._sitesync_model.get_active_site(project_name)
+
+    def get_remote_site(self, project_name):
+        return self._sitesync_model.get_remote_site(project_name)
+
     def get_version_sync_availability(self, project_name, version_ids):
         return self._sitesync_model.get_version_sync_availability(
             project_name, version_ids

--- a/client/ayon_core/tools/loader/ui/products_delegates.py
+++ b/client/ayon_core/tools/loader/ui/products_delegates.py
@@ -500,7 +500,7 @@ class SiteSyncDelegate(QtWidgets.QStyledItemDelegate):
             )
 
     def editorEvent(self, event, model, option, index):
-        result = super(SiteSyncDelegate, self).editorEvent(
+        result = super().editorEvent(
             event, model, option, index
         )
         if event.type() == QtCore.QEvent.MouseMove:

--- a/client/ayon_core/tools/loader/ui/products_delegates.py
+++ b/client/ayon_core/tools/loader/ui/products_delegates.py
@@ -506,7 +506,7 @@ class SiteSyncDelegate(QtWidgets.QStyledItemDelegate):
         if event.type() == QtCore.QEvent.MouseMove:
             mouse_pos = event.pos()
             tooltip = ""
-            for item_rect, site_name in getattr(self, "_items_rects", []):
+            for item_rect, site_name in self._items_rects:
                 if item_rect.contains(mouse_pos) and site_name:
                     tooltip = site_name
                     break

--- a/client/ayon_core/tools/loader/ui/products_delegates.py
+++ b/client/ayon_core/tools/loader/ui/products_delegates.py
@@ -507,7 +507,7 @@ class SiteSyncDelegate(QtWidgets.QStyledItemDelegate):
             mouse_pos = event.pos()
             tooltip = ""
             for item_rect, site_name in self._items_rects:
-                if item_rect.contains(mouse_pos) and site_name:
+                if item_rect.contains(mouse_pos):
                     tooltip = site_name
                     break
             if tooltip:

--- a/client/ayon_core/tools/loader/ui/products_delegates.py
+++ b/client/ayon_core/tools/loader/ui/products_delegates.py
@@ -17,6 +17,8 @@ from .products_model import (
     REPRESENTATIONS_COUNT_ROLE,
     SYNC_ACTIVE_SITE_AVAILABILITY,
     SYNC_REMOTE_SITE_AVAILABILITY,
+    ACTIVE_SITE_NAME_ROLE,
+    REMOTE_SITE_NAME_ROLE,
 )
 
 COMBO_VERSION_ID_ROLE = QtCore.Qt.UserRole + 1
@@ -432,6 +434,8 @@ class SiteSyncDelegate(QtWidgets.QStyledItemDelegate):
 
         active_icon = index.data(ACTIVE_SITE_ICON_ROLE)
         remote_icon = index.data(REMOTE_SITE_ICON_ROLE)
+        active_site_name = index.data(ACTIVE_SITE_NAME_ROLE)
+        remote_site_name = index.data(REMOTE_SITE_NAME_ROLE)
 
         availability_active = "{}/{}".format(
             index.data(SYNC_ACTIVE_SITE_AVAILABILITY),
@@ -446,10 +450,10 @@ class SiteSyncDelegate(QtWidgets.QStyledItemDelegate):
             return
 
         items_to_draw = [
-            (value, icon)
-            for value, icon in (
-                (availability_active, active_icon),
-                (availability_remote, remote_icon),
+            (value, icon, site_name)
+            for value, icon, site_name in (
+                (availability_active, active_icon, active_site_name),
+                (availability_remote, remote_icon, remote_site_name),
             )
             if icon
         ]
@@ -464,13 +468,15 @@ class SiteSyncDelegate(QtWidgets.QStyledItemDelegate):
         if item_width < 1:
             item_width = 0
 
-        for value, icon in items_to_draw:
+        self._items_rects = []
+        for value, icon, site_name in items_to_draw:
             item_rect = QtCore.QRect(
                 pos_x,
                 option.rect.y(),
                 item_width,
                 option.rect.height()
             )
+            self._items_rects.append((item_rect, site_name))
             # Prepare pos_x for next item
             pos_x = item_rect.x() + item_rect.width()
 
@@ -492,6 +498,25 @@ class SiteSyncDelegate(QtWidgets.QStyledItemDelegate):
                 option.displayAlignment,
                 value
             )
+
+    def editorEvent(self, event, model, option, index):
+        result = super(SiteSyncDelegate, self).editorEvent(
+            event, model, option, index
+        )
+        if event.type() == QtCore.QEvent.MouseMove:
+            mouse_pos = event.pos()
+            tooltip = ""
+            for item_rect, site_name in getattr(self, "_items_rects", []):
+                if item_rect.contains(mouse_pos) and site_name:
+                    tooltip = site_name
+                    break
+            if tooltip:
+                QtWidgets.QToolTip.showText(event.globalPos(), tooltip)
+            else:
+                QtWidgets.QToolTip.hideText()
+        elif event.type() == QtCore.QEvent.Leave:
+            QtWidgets.QToolTip.hideText()
+        return result
 
     def displayText(self, value, locale):
         pass

--- a/client/ayon_core/tools/loader/ui/products_delegates.py
+++ b/client/ayon_core/tools/loader/ui/products_delegates.py
@@ -427,8 +427,13 @@ class LoadedInSceneDelegate(QtWidgets.QStyledItemDelegate):
 class SiteSyncDelegate(QtWidgets.QStyledItemDelegate):
     """Paints icons and downloaded representation ration for both sites."""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._items_rects = []
+
     def paint(self, painter, option, index):
-        super(SiteSyncDelegate, self).paint(painter, option, index)
+        super().paint(painter, option, index)
+        self._items_rects = []
         option = QtWidgets.QStyleOptionViewItem(option)
         option.showDecorationSelected = True
 
@@ -468,7 +473,6 @@ class SiteSyncDelegate(QtWidgets.QStyledItemDelegate):
         if item_width < 1:
             item_width = 0
 
-        self._items_rects = []
         for value, icon, site_name in items_to_draw:
             item_rect = QtCore.QRect(
                 pos_x,

--- a/client/ayon_core/tools/loader/ui/products_model.py
+++ b/client/ayon_core/tools/loader/ui/products_model.py
@@ -39,6 +39,8 @@ REMOTE_SITE_ICON_ROLE = QtCore.Qt.UserRole + 29
 REPRESENTATIONS_COUNT_ROLE = QtCore.Qt.UserRole + 30
 SYNC_ACTIVE_SITE_AVAILABILITY = QtCore.Qt.UserRole + 31
 SYNC_REMOTE_SITE_AVAILABILITY = QtCore.Qt.UserRole + 32
+ACTIVE_SITE_NAME_ROLE = QtCore.Qt.UserRole + 33
+REMOTE_SITE_NAME_ROLE = QtCore.Qt.UserRole + 34
 
 STATUS_NAME_FILTER_ROLE = QtCore.Qt.UserRole + 33
 TASK_TAGS_FILTER_ROLE = QtCore.Qt.UserRole + 34
@@ -425,6 +427,8 @@ class ProductsModel(QtGui.QStandardItemModel):
         product_item,
         active_site_icon,
         remote_site_icon,
+        active_site_name,
+        remote_site_name,
         repre_count_by_version_id,
         sync_availability_by_version_id,
         last_version_by_product_id,
@@ -473,6 +477,8 @@ class ProductsModel(QtGui.QStandardItemModel):
 
         model_item.setData(active_site_icon, ACTIVE_SITE_ICON_ROLE)
         model_item.setData(remote_site_icon, REMOTE_SITE_ICON_ROLE)
+        model_item.setData(active_site_name, ACTIVE_SITE_NAME_ROLE)
+        model_item.setData(remote_site_name, REMOTE_SITE_NAME_ROLE)
 
         self._set_version_data_to_product_item(
             model_item,
@@ -511,6 +517,8 @@ class ProductsModel(QtGui.QStandardItemModel):
         remote_site_icon_def = self._controller.get_remote_site_icon_def(
             project_name
         )
+        active_site_name = self._controller.get_active_site(project_name)
+        remote_site_name = self._controller.get_remote_site(project_name)
         active_site_icon = get_qt_icon(active_site_icon_def)
         remote_site_icon = get_qt_icon(remote_site_icon_def)
 
@@ -614,6 +622,8 @@ class ProductsModel(QtGui.QStandardItemModel):
                     product_item,
                     active_site_icon,
                     remote_site_icon,
+                    active_site_name,
+                    remote_site_name,
                     repre_count_by_version_id,
                     sync_availability_by_version_id,
                     last_version_by_product_id,
@@ -639,6 +649,8 @@ class ProductsModel(QtGui.QStandardItemModel):
                         product_item,
                         active_site_icon,
                         remote_site_icon,
+                        active_site_name,
+                        remote_site_name,
                         repre_count_by_version_id,
                         sync_availability_by_version_id,
                         last_version_by_product_id,

--- a/client/ayon_core/tools/loader/ui/repres_widget.py
+++ b/client/ayon_core/tools/loader/ui/repres_widget.py
@@ -85,12 +85,10 @@ class RepresentationsModel(QtGui.QStandardItemModel):
                     return None
 
             if role == QtCore.Qt.ToolTipRole:
-                if col == 3:
+                if col == self.active_site_column :
                     role = ACTIVE_SITE_NAME_ROLE
-                elif col == 4:
+                elif col == self.remote_site_column :
                     role = REMOTE_SITE_NAME_ROLE
-                else:
-                    return None
 
             if role == QtCore.Qt.DisplayRole:
                 if col == 1:

--- a/client/ayon_core/tools/loader/ui/repres_widget.py
+++ b/client/ayon_core/tools/loader/ui/repres_widget.py
@@ -85,9 +85,9 @@ class RepresentationsModel(QtGui.QStandardItemModel):
                     return None
 
             if role == QtCore.Qt.ToolTipRole:
-                if col == self.active_site_column :
+                if col == self.active_site_column:
                     role = ACTIVE_SITE_NAME_ROLE
-                elif col == self.remote_site_column :
+                elif col == self.remote_site_column:
                     role = REMOTE_SITE_NAME_ROLE
 
             if role == QtCore.Qt.DisplayRole:

--- a/client/ayon_core/tools/loader/ui/repres_widget.py
+++ b/client/ayon_core/tools/loader/ui/repres_widget.py
@@ -18,6 +18,8 @@ ACTIVE_SITE_ICON_ROLE = QtCore.Qt.UserRole + 6
 REMOTE_SITE_ICON_ROLE = QtCore.Qt.UserRole + 7
 SYNC_ACTIVE_SITE_PROGRESS = QtCore.Qt.UserRole + 8
 SYNC_REMOTE_SITE_PROGRESS = QtCore.Qt.UserRole + 9
+ACTIVE_SITE_NAME_ROLE = QtCore.Qt.UserRole + 10
+REMOTE_SITE_NAME_ROLE = QtCore.Qt.UserRole + 11
 
 
 class RepresentationsModel(QtGui.QStandardItemModel):
@@ -82,6 +84,14 @@ class RepresentationsModel(QtGui.QStandardItemModel):
                 else:
                     return None
 
+            if role == QtCore.Qt.ToolTipRole:
+                if col == 3:
+                    role = ACTIVE_SITE_NAME_ROLE
+                elif col == 4:
+                    role = REMOTE_SITE_NAME_ROLE
+                else:
+                    return None
+
             if role == QtCore.Qt.DisplayRole:
                 if col == 1:
                     role = PRODUCT_NAME_ROLE
@@ -110,6 +120,8 @@ class RepresentationsModel(QtGui.QStandardItemModel):
         repre_item,
         active_site_icon,
         remote_site_icon,
+        active_site_name,
+        remote_site_name,
         repres_sync_status
     ):
         repre_id = repre_item.representation_id
@@ -139,6 +151,8 @@ class RepresentationsModel(QtGui.QStandardItemModel):
         item.setData(repre_item.folder_label, FOLDER_LABEL_ROLE)
         item.setData(active_site_icon, ACTIVE_SITE_ICON_ROLE)
         item.setData(remote_site_icon, REMOTE_SITE_ICON_ROLE)
+        item.setData(active_site_name, ACTIVE_SITE_NAME_ROLE)
+        item.setData(remote_site_name, REMOTE_SITE_NAME_ROLE)
         item.setData(active_site_progress, SYNC_ACTIVE_SITE_PROGRESS)
         item.setData(remote_site_progress, SYNC_REMOTE_SITE_PROGRESS)
         return is_new_item, item
@@ -173,6 +187,8 @@ class RepresentationsModel(QtGui.QStandardItemModel):
         remote_site_icon_def = self._controller.get_remote_site_icon_def(
             project_name
         )
+        active_site_name = self._controller.get_active_site(project_name)
+        remote_site_name = self._controller.get_remote_site(project_name)
         active_site_icon = get_qt_icon(active_site_icon_def)
         remote_site_icon = get_qt_icon(remote_site_icon_def)
 
@@ -215,6 +231,8 @@ class RepresentationsModel(QtGui.QStandardItemModel):
                     repre_item,
                     active_site_icon,
                     remote_site_icon,
+                    active_site_name,
+                    remote_site_name,
                     repres_sync_status
                 )
                 item_parent = item.parent()


### PR DESCRIPTION
## Changelog Description
SiteSync icons didnt have any tooltip which caused confusion in case where both sides have provider, eg same icon.

This adds tooltip with site name to the icons.

<img width="277" height="136" alt="image" src="https://github.com/user-attachments/assets/3e91c824-46b4-4491-99d0-72e22095149c" />


## Testing notes:
1. enable SiteSync
2. check AYON Browser (Availability on products and site progress on representations)
