### PR TITLE
Create/Publish: Show create plugins that failed to init

### DIFF
--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -228,6 +228,9 @@ class CreateContext:
 
         self.creator_discover_result = None
         self.convertor_discover_result = None
+
+        self.failed_init_create_plugins = []
+
         # Discovered creators
         self.creators = {}
         # Prepare categories of creators
@@ -751,6 +754,7 @@ class CreateContext:
         disabled_creators = {}
         autocreators = {}
         manual_creators = {}
+        failed_init_create_plugins = []
         report = discover_creator_plugins(return_report=True)
         self.creator_discover_result = report
         for creator_class in report.abstract_plugins:
@@ -785,6 +789,9 @@ class CreateContext:
             try:
                 creator = creator_class(project_settings, self, self.headless)
             except Exception:
+                failed_init_create_plugins.append(
+                    (creator_class, sys.exc_info())
+                )
                 self.log.error(
                     f"Failed to initialize plugin: {creator_class}",
                     exc_info=True
@@ -812,6 +819,8 @@ class CreateContext:
                 autocreators[creator_identifier] = creator
             elif isinstance(creator, Creator):
                 manual_creators[creator_identifier] = creator
+
+        self.failed_init_create_plugins = failed_init_create_plugins
 
         self.autocreators = autocreators
         self.manual_creators = manual_creators

--- a/client/ayon_core/pipeline/plugin_discover.py
+++ b/client/ayon_core/pipeline/plugin_discover.py
@@ -145,6 +145,13 @@ def discover_plugins(
                 skip_discovery = cls.__dict__.get("skip_discovery")
                 if skip_discovery is True:
                     continue
+
+                # Store filepath to classes
+                try:
+                    filepath = inspect.getfile(cls)
+                except TypeError:
+                    pass
+                setattr(cls, "__plugin_discover_path__", filepath)
                 all_plugins.append(cls)
 
     if base_class not in ignored_classes:

--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import uuid
 import copy
 import inspect
@@ -105,41 +107,46 @@ class PublishReportMaker:
 
     def __init__(
         self,
-        creator_discover_result: Optional[DiscoverResult] = None,
-        convertor_discover_result: Optional[DiscoverResult] = None,
-        publish_discover_result: Optional[DiscoverResult] = None,
-        blocking_crashed_paths: Optional[list[str]] = None,
-    ):
-        self._create_discover_result: Union[DiscoverResult, None] = None
-        self._convert_discover_result: Union[DiscoverResult, None] = None
-        self._publish_discover_result: Union[DiscoverResult, None] = None
+        creator_discover_result: DiscoverResult | None = None,
+        convertor_discover_result: DiscoverResult | None = None,
+        publish_discover_result: DiscoverResult | None = None,
+        failed_init_create_plugins: list[tuple] | None = None,
+        blocking_crashed_paths: list[str] | None = None,
+    ) -> None:
+        self._create_discover_result: DiscoverResult | None = None
+        self._convert_discover_result: DiscoverResult | None = None
+        self._publish_discover_result: DiscoverResult | None = None
 
+        self._failed_init_create_plugins: list[tuple] = []
         self._blocking_crashed_paths: list[str] = []
 
-        self._all_instances_by_id: Dict[str, pyblish.api.Instance] = {}
-        self._plugin_data_by_id: Dict[str, Any] = {}
-        self._current_plugin_id: Optional[str] = None
+        self._all_instances_by_id: dict[str, pyblish.api.Instance] = {}
+        self._plugin_data_by_id: dict[str, Any] = {}
+        self._current_plugin_id: str | None = None
 
         self.reset(
             creator_discover_result,
             convertor_discover_result,
             publish_discover_result,
+            failed_init_create_plugins,
             blocking_crashed_paths,
         )
 
     def reset(
         self,
-        creator_discover_result: Union[DiscoverResult, None],
-        convertor_discover_result: Union[DiscoverResult, None],
-        publish_discover_result: Union[DiscoverResult, None],
-        blocking_crashed_paths: list[str],
+        creator_discover_result: DiscoverResult | None = None,
+        convertor_discover_result: DiscoverResult | None = None,
+        publish_discover_result: DiscoverResult | None = None,
+        failed_init_create_plugins: list[tuple] | None = None,
+        blocking_crashed_paths: list[str] | None = None,
     ):
         """Reset report and clear all data."""
 
         self._create_discover_result = creator_discover_result
         self._convert_discover_result = convertor_discover_result
         self._publish_discover_result = publish_discover_result
-        self._blocking_crashed_paths = blocking_crashed_paths
+        self._failed_init_create_plugins = failed_init_create_plugins or []
+        self._blocking_crashed_paths = blocking_crashed_paths or []
 
         self._all_instances_by_id = {}
         self._plugin_data_by_id = {}
@@ -237,6 +244,15 @@ class PublishReportMaker:
             reports.append(self._publish_discover_result)
 
         crashed_file_paths = {}
+
+        for cls, exc_info in self._failed_init_create_plugins:
+            filepath = getattr(
+                cls, "__plugin_discover_path__", cls.__module__
+            )
+            crashed_file_paths[filepath] = "".join(
+                traceback.format_exception(*exc_info)
+            )
+
         for report in reports:
             items = report.crashed_file_paths.items()
             for filepath, exc_info in items:
@@ -977,6 +993,7 @@ class PublishModel:
             create_context.creator_discover_result,
             create_context.convertor_discover_result,
             create_context.publish_discover_result,
+            create_context.failed_init_create_plugins,
             blocking_crashed_paths,
         )
         for plugin in create_context.publish_plugins_mismatch_targets:


### PR DESCRIPTION
## Changelog Description
Show create plugins that do fail to init in Publisher report.

## Additional info
Added `failed_init_create_plugins` in `CreateContext` to store the classes. Because the classes are not in sys.modules I also had to start store the filepath of classes to `__plugin_discover_path__` attribute.

### Screenshot
<img width="794" height="711" alt="image" src="https://github.com/user-attachments/assets/55b2fb02-c905-4c4e-8ce1-18e961d809fa" />


## Testing notes:
1. Implement `apply_settings` in create plugin that throws an error.
2. The plugin should be showed in `Crashed plugins`

Partially resolves https://github.com/ynput/ayon-core/issues/819