### PR TITLE
Copyfile: Don't use speedcopy on macOs

### DIFF
--- a/client/ayon_core/lib/file_transaction.py
+++ b/client/ayon_core/lib/file_transaction.py
@@ -2,6 +2,7 @@ import concurrent.futures
 import os
 import logging
 import errno
+import platform
 import shutil
 from concurrent.futures import ThreadPoolExecutor, Future
 from typing import List, Optional
@@ -9,6 +10,8 @@ from typing import List, Optional
 from ayon_core.lib import create_hard_link
 
 import speedcopy
+
+_IS_MACOS = platform.system().lower() == "darwin"
 
 
 def copyfile(src, dst):
@@ -22,7 +25,11 @@ def copyfile(src, dst):
         src (str): Source path.
         dst (str): Destination path.
     """
-    if os.getenv("AYON_COPY_FILE_DISABLE_SPEEDCOPY") != "1":
+    # NOTE speedcopy has a bug that causes failure on macOs.
+    # TODO find out if speedcopy is still needed and remove if not.
+    if _IS_MACOS:
+        shutil.copyfile(src, dst)
+    elif os.getenv("AYON_COPY_FILE_DISABLE_SPEEDCOPY") != "1":
         speedcopy.copyfile(src, dst)
     else:
         shutil.copyfile(src, dst)


### PR DESCRIPTION
## Changelog Description
Don't use speedcopy on macOs to avoid crashes.

## Additional info
At this moment speedcopy causes crashes on macOs. This PR is created to avoid the issue and avoid need to set up 'AYON_COPY_FILE_DISABLE_SPEEDCOPY'.

Next step would be to validate if we still need to use speedcopy, if yes, then fix the issue in speedcopy module, update it in ayon-core dependencies and then revert changes in this PR.

## Testing notes:
1. macOs has no issues with coping files even if 'AYON_COPY_FILE_DISABLE_SPEEDCOPY' is not set.

Resolves https://github.com/ynput/ayon-core/issues/1773