### PR TITLE
Launcher: Workfile tab improvements

### DIFF
--- a/client/ayon_core/tools/launcher/abstract.py
+++ b/client/ayon_core/tools/launcher/abstract.py
@@ -158,6 +158,14 @@ class AbstractLauncherBackend(AbstractLauncherCommon):
 
 
 class AbstractLauncherFrontEnd(AbstractLauncherCommon):
+    @abstractmethod
+    def get_grouped_host_names(self) -> list[str | None]:
+        """Get list of host names that will group workfiles."""
+
+    @abstractmethod
+    def set_grouped_host_names(self, host_names: list[str | None]):
+        """Set list of host names that will group workfiles."""
+
     # Entity items for UI
     @abstractmethod
     def get_project_items(

--- a/client/ayon_core/tools/launcher/abstract.py
+++ b/client/ayon_core/tools/launcher/abstract.py
@@ -63,6 +63,7 @@ class WorkfileItem:
     workfile_id: str
     filename: str
     exists: bool
+    host_name: str | None
     icon: str | None
     version: int | None
     updated_at_time: float | None

--- a/client/ayon_core/tools/launcher/abstract.py
+++ b/client/ayon_core/tools/launcher/abstract.py
@@ -63,8 +63,9 @@ class WorkfileItem:
     workfile_id: str
     filename: str
     exists: bool
-    icon: Optional[str]
-    version: Optional[int]
+    icon: str | None
+    version: int | None
+    updated_at_time: float | None
 
 
 class AbstractLauncherCommon(ABC):

--- a/client/ayon_core/tools/launcher/control.py
+++ b/client/ayon_core/tools/launcher/control.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from typing import Optional
 

--- a/client/ayon_core/tools/launcher/control.py
+++ b/client/ayon_core/tools/launcher/control.py
@@ -90,10 +90,15 @@ class BaseLauncherController(
         return self._addons_manager
 
     def get_grouped_host_names(self) -> list[str | None]:
-        value = self._launcher_registry.get_item(
-            "grouped_hosts", default="[]"
-        )
-        return json.loads(value)
+        try:
+            value = self._launcher_registry.get_item(
+                "grouped_hosts", default="[]"
+            )
+            return json.loads(value)
+        except Exception:
+            # NOTE This is future-guarding in case we'd change the stored data
+            self.log.warning("Failed to get grouped hosts", exc_info=True)
+            return []
 
     def set_grouped_host_names(self, host_names: list[str | None]):
         value = json.dumps(host_names)

--- a/client/ayon_core/tools/launcher/control.py
+++ b/client/ayon_core/tools/launcher/control.py
@@ -1,6 +1,7 @@
+import json
 from typing import Optional
 
-from ayon_core.lib import Logger
+from ayon_core.lib import Logger, JSONSettingRegistry, get_launcher_local_dir
 from ayon_core.lib.events import QueuedEventSystem
 from ayon_core.addon import AddonsManager
 from ayon_core.settings import get_project_settings, get_studio_settings
@@ -31,6 +32,11 @@ class BaseLauncherController(
         self._project_settings = {}
         self._event_system = None
         self._log = None
+
+        self._launcher_registry = JSONSettingRegistry(
+            "launcher",
+            get_launcher_local_dir("tools")
+        )
 
         self._addons_manager = None
 
@@ -80,6 +86,16 @@ class BaseLauncherController(
         if self._addons_manager is None:
             self._addons_manager = AddonsManager()
         return self._addons_manager
+
+    def get_grouped_host_names(self) -> list[str | None]:
+        value = self._launcher_registry.get_item(
+            "grouped_hosts", default="[]"
+        )
+        return json.loads(value)
+
+    def set_grouped_host_names(self, host_names: list[str | None]):
+        value = json.dumps(host_names)
+        self._launcher_registry.set_item("grouped_hosts", value)
 
     # Entity items for UI
     def get_project_items(self, sender=None):

--- a/client/ayon_core/tools/launcher/models/workfiles.py
+++ b/client/ayon_core/tools/launcher/models/workfiles.py
@@ -82,6 +82,7 @@ class WorkfilesModel:
                 workfile_id=workfile_entity["id"],
                 filename=os.path.basename(rootless_path),
                 exists=exists,
+                host_name=host_name,
                 icon=self._get_host_icon(host_name),
                 version=version,
                 updated_at_time=mod_time,

--- a/client/ayon_core/tools/launcher/models/workfiles.py
+++ b/client/ayon_core/tools/launcher/models/workfiles.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import os
 from typing import Optional, Any
 
+import arrow
 import ayon_api
 
 from ayon_core.lib import (
@@ -44,10 +47,13 @@ class WorkfilesModel:
         anatomy = Anatomy(project_name, project_entity=project_entity)
         items = []
         for workfile_entity in ayon_api.get_workfiles_info(
-            project_name, task_ids={task_id}, fields={"id", "path", "data"}
+            project_name,
+            task_ids={task_id},
+            fields={"id", "path", "data", "updatedAt"},
         ):
             rootless_path = workfile_entity["path"]
             exists = False
+            path = None
             try:
                 path = anatomy.fill_root(rootless_path)
                 exists = os.path.exists(path)
@@ -56,6 +62,18 @@ class WorkfilesModel:
                     "Failed to fill root for workfile path",
                     exc_info=True,
                 )
+
+            mod_time = None
+            if path and exists:
+                mod_time = os.path.getmtime(path)
+
+            else:
+                updated_at = workfile_entity["updatedAt"]
+                if updated_at:
+                    mod_time = float(
+                        arrow.get(updated_at).to("local").timestamp
+                    )
+
             workfile_data = workfile_entity["data"]
             host_name = workfile_data.get("host_name")
             version = workfile_data.get("version")
@@ -66,13 +84,14 @@ class WorkfilesModel:
                 exists=exists,
                 icon=self._get_host_icon(host_name),
                 version=version,
+                updated_at_time=mod_time,
             ))
         cache.update_data(items)
         return items
 
     def _get_host_icon(
         self, host_name: Optional[str]
-    ) -> Optional[dict[str, Any]]:
+    ) -> str | None:
         if self._host_icons is None:
             host_icons = {}
             try:

--- a/client/ayon_core/tools/launcher/ui/workfiles_page.py
+++ b/client/ayon_core/tools/launcher/ui/workfiles_page.py
@@ -8,6 +8,7 @@ from ayon_core.tools.launcher.abstract import AbstractLauncherFrontEnd
 
 VERSION_ROLE = QtCore.Qt.UserRole + 1
 WORKFILE_ID_ROLE = QtCore.Qt.UserRole + 2
+UPDATED_AT_ROLE = QtCore.Qt.UserRole + 3
 
 
 class WorkfilesModel(QtGui.QStandardItemModel):
@@ -55,6 +56,7 @@ class WorkfilesModel(QtGui.QStandardItemModel):
             item.setData(icon, QtCore.Qt.DecorationRole)
             item.setData(workfile_item.version, VERSION_ROLE)
             item.setData(workfile_item.workfile_id, WORKFILE_ID_ROLE)
+            item.setData(workfile_item.updated_at_time, UPDATED_AT_ROLE)
             flags = QtCore.Qt.NoItemFlags
             if workfile_item.exists:
                 flags = QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable

--- a/client/ayon_core/tools/launcher/ui/workfiles_page.py
+++ b/client/ayon_core/tools/launcher/ui/workfiles_page.py
@@ -152,9 +152,6 @@ class WorkfilesView(DeselectableTreeView):
 
 
 class WorkfilesDelegate(QtWidgets.QStyledItemDelegate):
-    def __init__(self, parent=None):
-        super().__init__(parent)
-
     def paint(self, painter, option, index):
         option.textElideMode = QtCore.Qt.ElideMiddle
         super().paint(painter, option, index)

--- a/client/ayon_core/tools/launcher/ui/workfiles_page.py
+++ b/client/ayon_core/tools/launcher/ui/workfiles_page.py
@@ -4,6 +4,7 @@ import ayon_api
 from qtpy import QtCore, QtWidgets, QtGui
 
 from ayon_core.tools.utils import get_qt_icon, DeselectableTreeView
+from ayon_core.tools.utils.delegates import PrettyTimeDelegate
 from ayon_core.tools.launcher.abstract import AbstractLauncherFrontEnd
 
 VERSION_ROLE = QtCore.Qt.UserRole + 1
@@ -17,8 +18,9 @@ class WorkfilesModel(QtGui.QStandardItemModel):
     def __init__(self, controller: AbstractLauncherFrontEnd) -> None:
         super().__init__()
 
-        self.setColumnCount(1)
+        self.setColumnCount(2)
         self.setHeaderData(0, QtCore.Qt.Horizontal, "Workfiles")
+        self.setHeaderData(1, QtCore.Qt.Horizontal, "Modified")
 
         controller.register_event_callback(
             "selection.project.changed",
@@ -78,6 +80,21 @@ class WorkfilesModel(QtGui.QStandardItemModel):
 
         self.refreshed.emit()
 
+    def flags(self, index):
+        if index.column() != 0:
+            index = self.index(index.row(), 0, index.parent())
+        return super().flags(index)
+
+    def data(self, index, role=QtCore.Qt.DisplayRole):
+        if index.column() == 1:
+            if role != QtCore.Qt.DisplayRole:
+                return None
+
+            role = UPDATED_AT_ROLE
+
+            index = self.index(index.row(), 0, index.parent())
+        return super().data(index, role)
+
     def _on_selection_project_changed(self, event) -> None:
         self._selected_project_name = event["project_name"]
         self._selected_folder_id = None
@@ -134,6 +151,15 @@ class WorkfilesView(DeselectableTreeView):
         return
 
 
+class WorkfilesDelegate(QtWidgets.QStyledItemDelegate):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def paint(self, painter, option, index):
+        option.textElideMode = QtCore.Qt.ElideMiddle
+        super().paint(painter, option, index)
+
+
 class WorkfilesPage(QtWidgets.QWidget):
     def __init__(
         self,
@@ -144,9 +170,19 @@ class WorkfilesPage(QtWidgets.QWidget):
 
         workfiles_view = WorkfilesView(self)
         workfiles_view.setIndentation(0)
+        workfiles_view.setSortingEnabled(True)
+
         workfiles_model = WorkfilesModel(controller)
         workfiles_proxy = QtCore.QSortFilterProxyModel()
         workfiles_proxy.setSourceModel(workfiles_model)
+
+        workfiles_delegate = WorkfilesDelegate()
+        updated_at_delegate = PrettyTimeDelegate(
+            default="N/A", parent=workfiles_view
+        )
+
+        workfiles_view.setItemDelegateForColumn(0, workfiles_delegate)
+        workfiles_view.setItemDelegateForColumn(1, updated_at_delegate)
 
         workfiles_view.setModel(workfiles_proxy)
 
@@ -154,15 +190,26 @@ class WorkfilesPage(QtWidgets.QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(workfiles_view, 1)
 
+        resize_timer = QtCore.QTimer()
+
         workfiles_view.selectionModel().selectionChanged.connect(
             self._on_selection_changed
         )
-        workfiles_model.refreshed.connect(self._on_refresh)
+        resize_timer.timeout.connect(self._on_resize_timer)
 
         self._controller = controller
         self._workfiles_view = workfiles_view
+        self._workfiles_delegate = workfiles_delegate
+        self._updated_at_delegate = updated_at_delegate
         self._workfiles_model = workfiles_model
         self._workfiles_proxy = workfiles_proxy
+        self._resize_timer = resize_timer
+        self._resize_counter = 0
+
+    def showEvent(self, event) -> None:
+        super().showEvent(event)
+
+        self._resize_timer.start()
 
     def refresh(self) -> None:
         self._workfiles_model.refresh()
@@ -171,8 +218,41 @@ class WorkfilesPage(QtWidgets.QWidget):
         sel_model = self._workfiles_view.selectionModel()
         sel_model.clearSelection()
 
-    def _on_refresh(self) -> None:
-        self._workfiles_proxy.sort(0, QtCore.Qt.DescendingOrder)
+    def _on_resize_timer(self):
+        # --- NOTE ---
+        # Because the date column does not store string value to display
+        #   but float value then displayed using delegate we're not
+        #   able to get the width of the column using standard methods.
+        # For that a default width of date column is set to 160 but resizing
+        #   second column is not allowed, instead we can resize the first
+        #   column. For that we need size of the view which is known only
+        #   after 2 Qt app loops.
+
+        # Make sure the logic happens only once
+        if self._resize_counter == 2:
+            self._resize_timer.stop()
+            return
+
+        self._resize_counter += 1
+        if self._resize_counter < 2:
+            return
+
+        # NOTE changing resize mode during initialization crashes application
+        view_header = self._workfiles_view.header()
+        view_header.setSectionResizeMode(
+            0, QtWidgets.QHeaderView.ResizeMode.Interactive
+        )
+        view_header.setSectionResizeMode(
+            1, QtWidgets.QHeaderView.ResizeMode.Interactive
+        )
+
+        # Resize workfiles column
+        view_size = self._workfiles_view.size()
+        col_1_width = view_size.width() - 160
+        if col_1_width < 120:
+            col_1_width = 120
+        view_header = self._workfiles_view.header()
+        view_header.resizeSection(view_header.logicalIndex(0), col_1_width)
 
     def _on_selection_changed(self, selected, _deselected) -> None:
         workfile_id = None

--- a/client/ayon_core/tools/launcher/ui/workfiles_page.py
+++ b/client/ayon_core/tools/launcher/ui/workfiles_page.py
@@ -10,6 +10,7 @@ from ayon_core.tools.launcher.abstract import AbstractLauncherFrontEnd
 VERSION_ROLE = QtCore.Qt.UserRole + 1
 WORKFILE_ID_ROLE = QtCore.Qt.UserRole + 2
 UPDATED_AT_ROLE = QtCore.Qt.UserRole + 3
+HOST_NAME_ROLE = QtCore.Qt.UserRole + 4
 
 
 class WorkfilesModel(QtGui.QStandardItemModel):
@@ -54,11 +55,14 @@ class WorkfilesModel(QtGui.QStandardItemModel):
         new_items = []
         for workfile_item in workfile_items:
             icon = self._get_icon(workfile_item.icon)
+            host_name = workfile_item.host_name
+
             item = QtGui.QStandardItem(workfile_item.filename)
             item.setData(icon, QtCore.Qt.DecorationRole)
             item.setData(workfile_item.version, VERSION_ROLE)
             item.setData(workfile_item.workfile_id, WORKFILE_ID_ROLE)
             item.setData(workfile_item.updated_at_time, UPDATED_AT_ROLE)
+            item.setData(host_name, HOST_NAME_ROLE)
             flags = QtCore.Qt.NoItemFlags
             if workfile_item.exists:
                 flags = QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
@@ -146,6 +150,21 @@ class WorkfilesModel(QtGui.QStandardItemModel):
         return icon
 
 
+class WorkfileSortFilterProxy(QtCore.QSortFilterProxyModel):
+    def lessThan(self, source_left, source_right):
+        l_host = source_left.data(HOST_NAME_ROLE)
+        r_host = source_right.data(HOST_NAME_ROLE)
+        if l_host != r_host:
+            if l_host is None:
+                return True
+            if r_host is None:
+                return False
+            if self.sortOrder() == QtCore.Qt.DescendingOrder:
+                return l_host > r_host
+            return l_host < r_host
+        return super().lessThan(source_left, source_right)
+
+
 class WorkfilesView(DeselectableTreeView):
     def drawBranches(self, painter, rect, index):
         return
@@ -170,8 +189,10 @@ class WorkfilesPage(QtWidgets.QWidget):
         workfiles_view.setSortingEnabled(True)
 
         workfiles_model = WorkfilesModel(controller)
-        workfiles_proxy = QtCore.QSortFilterProxyModel()
+        workfiles_proxy = WorkfileSortFilterProxy()
         workfiles_proxy.setSourceModel(workfiles_model)
+
+        workfiles_view.setModel(workfiles_proxy)
 
         workfiles_delegate = WorkfilesDelegate()
         updated_at_delegate = PrettyTimeDelegate(
@@ -180,8 +201,6 @@ class WorkfilesPage(QtWidgets.QWidget):
 
         workfiles_view.setItemDelegateForColumn(0, workfiles_delegate)
         workfiles_view.setItemDelegateForColumn(1, updated_at_delegate)
-
-        workfiles_view.setModel(workfiles_proxy)
 
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)

--- a/client/ayon_core/tools/launcher/ui/workfiles_page.py
+++ b/client/ayon_core/tools/launcher/ui/workfiles_page.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import collections
+
 from typing import Optional
 
 import ayon_api
@@ -11,6 +15,7 @@ VERSION_ROLE = QtCore.Qt.UserRole + 1
 WORKFILE_ID_ROLE = QtCore.Qt.UserRole + 2
 UPDATED_AT_ROLE = QtCore.Qt.UserRole + 3
 HOST_NAME_ROLE = QtCore.Qt.UserRole + 4
+ITEM_TYPE_ROLE = QtCore.Qt.UserRole + 5
 
 
 class WorkfilesModel(QtGui.QStandardItemModel):
@@ -36,23 +41,31 @@ class WorkfilesModel(QtGui.QStandardItemModel):
             self._on_selection_task_changed,
         )
 
+        self._group_host_names = set()
+
         self._controller = controller
         self._selected_project_name = None
         self._selected_folder_id = None
         self._selected_task_id = None
 
+        # Cache
         self._transparent_icon = None
-
         self._cached_icons = {}
+        self._host_items_by_name = {}
+        self._items_by_host_name = collections.defaultdict(list)
 
     def refresh(self) -> None:
+        self._group_host_names = set(
+            self._controller.get_grouped_host_names()
+        )
+
         root_item = self.invisibleRootItem()
         root_item.removeRows(0, root_item.rowCount())
 
         workfile_items = self._controller.get_workfile_items(
             self._selected_project_name, self._selected_task_id
         )
-        new_items = []
+        items_by_host_name = collections.defaultdict(list)
         for workfile_item in workfile_items:
             icon = self._get_icon(workfile_item.icon)
             host_name = workfile_item.host_name
@@ -63,11 +76,36 @@ class WorkfilesModel(QtGui.QStandardItemModel):
             item.setData(workfile_item.workfile_id, WORKFILE_ID_ROLE)
             item.setData(workfile_item.updated_at_time, UPDATED_AT_ROLE)
             item.setData(host_name, HOST_NAME_ROLE)
+            item.setData(0, ITEM_TYPE_ROLE)
+            item.setColumnCount(2)
             flags = QtCore.Qt.NoItemFlags
             if workfile_item.exists:
                 flags = QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
             item.setFlags(flags)
-            new_items.append(item)
+
+            items_by_host_name[host_name].append(item)
+
+        new_items = []
+        host_items_by_name = {}
+        for host_name, items in items_by_host_name.items():
+            icon = next(
+                (item.data(QtCore.Qt.DecorationRole) for item in items),
+                None
+            )
+
+            host_item = QtGui.QStandardItem(
+                host_name or "<Unknown Host>"
+            )
+            host_item.setData(icon, QtCore.Qt.DecorationRole)
+            host_item.setData(host_name, HOST_NAME_ROLE)
+            host_item.setData(1, ITEM_TYPE_ROLE)
+            host_item.setFlags(QtCore.Qt.ItemIsEnabled)
+            host_item.setColumnCount(2)
+            host_items_by_name[host_name] = host_item
+            if host_name in self._group_host_names:
+                new_items.append(host_item)
+            else:
+                new_items.extend(items)
 
         if not new_items:
             title = "< No workfiles >"
@@ -79,10 +117,46 @@ class WorkfilesModel(QtGui.QStandardItemModel):
                 title = "< Select a task >"
             item = QtGui.QStandardItem(title)
             item.setFlags(QtCore.Qt.NoItemFlags)
-            new_items.append(item)
+            new_items = [item]
+
         root_item.appendRows(new_items)
 
+        self._host_items_by_name = host_items_by_name
+        self._items_by_host_name = items_by_host_name
+
         self.refreshed.emit()
+
+    def set_group_by_host_name(
+        self,
+        host_name: str | None,
+        group: bool | None = None,
+    ) -> None:
+        if group is None:
+            group = host_name not in self._group_host_names
+
+        if group and host_name in self._group_host_names:
+            return
+
+        if not group and host_name not in self._group_host_names:
+            return
+
+        host_item = self._host_items_by_name.get(host_name)
+        items = self._items_by_host_name.get(host_name)
+        if host_item is None or not items:
+            return
+
+        root_item = self.invisibleRootItem()
+        if group:
+            for item in items:
+                root_item.takeRow(item.row())
+            root_item.appendRow(host_item)
+            self._group_host_names.add(host_name)
+        else:
+            root_item.takeRow(host_item.row())
+            root_item.appendRows(items)
+            self._group_host_names.discard(host_name)
+
+        self._controller.set_grouped_host_names(list(self._group_host_names))
 
     def flags(self, index):
         if index.column() != 0:
@@ -91,10 +165,11 @@ class WorkfilesModel(QtGui.QStandardItemModel):
 
     def data(self, index, role=QtCore.Qt.DisplayRole):
         if index.column() == 1:
-            if role != QtCore.Qt.DisplayRole:
-                return None
+            if role == QtCore.Qt.DisplayRole:
+                role = UPDATED_AT_ROLE
 
-            role = UPDATED_AT_ROLE
+            elif role not in (HOST_NAME_ROLE, ITEM_TYPE_ROLE):
+                return None
 
             index = self.index(index.row(), 0, index.parent())
         return super().data(index, role)
@@ -187,6 +262,7 @@ class WorkfilesPage(QtWidgets.QWidget):
         workfiles_view = WorkfilesView(self)
         workfiles_view.setIndentation(0)
         workfiles_view.setSortingEnabled(True)
+        workfiles_view.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
 
         workfiles_model = WorkfilesModel(controller)
         workfiles_proxy = WorkfileSortFilterProxy()
@@ -210,6 +286,10 @@ class WorkfilesPage(QtWidgets.QWidget):
 
         workfiles_view.selectionModel().selectionChanged.connect(
             self._on_selection_changed
+        )
+        workfiles_view.doubleClicked.connect(self._on_view_clicked)
+        workfiles_view.customContextMenuRequested.connect(
+            self._on_custom_menu_request
         )
         resize_timer.timeout.connect(self._on_resize_timer)
 
@@ -275,3 +355,36 @@ class WorkfilesPage(QtWidgets.QWidget):
         for index in selected.indexes():
             workfile_id = index.data(WORKFILE_ID_ROLE)
         self._controller.set_selected_workfile(workfile_id)
+
+    def _on_view_clicked(self, index) -> None:
+        if not index.isValid() or index.data(ITEM_TYPE_ROLE) != 1:
+            return
+        host_name = index.data(HOST_NAME_ROLE)
+        self._workfiles_model.set_group_by_host_name(host_name)
+
+    def _on_custom_menu_request(self, point):
+        index = self._workfiles_view.indexAt(point)
+        if not index.isValid():
+            return
+
+        item_type = index.data(ITEM_TYPE_ROLE)
+        if item_type is None:
+            return
+
+        action_title = None
+        if item_type == 0:
+            action_title = "Group by host"
+        elif item_type == 1:
+            action_title = "Ungroup (double-click)"
+
+        if action_title is None:
+            return
+
+        menu = QtWidgets.QMenu(self._workfiles_view)
+        menu.addAction(action_title)
+
+        global_pos = self._workfiles_view.viewport().mapToGlobal(point)
+        action = menu.exec_(global_pos)
+        if action is not None:
+            host_name = index.data(HOST_NAME_ROLE)
+            self._workfiles_model.set_group_by_host_name(host_name)

--- a/client/ayon_core/tools/utils/delegates.py
+++ b/client/ayon_core/tools/utils/delegates.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from datetime import datetime
 import logging
@@ -49,7 +51,7 @@ def pretty_date(t, now=None, strftime="%b %d %Y %H:%M"):
         if second_diff < 86400:
             minutes = (second_diff % 3600) // 60
             hours = second_diff // 3600
-            return "{0}:{1:02d} hours ago".format(hours, minutes)
+            return f"{hours}:{minutes:02d} hours ago"
 
     return t.strftime(strftime)
 
@@ -103,9 +105,21 @@ class PrettyTimeDelegate(QtWidgets.QStyledItemDelegate):
 
     """
 
+    def __init__(
+        self,
+        *,
+        default: str | None = None,
+        parent: QtCore.QObject | None = None,
+    ) -> None:
+        self._default_value = default
+        super().__init__(parent)
+
     def displayText(self, value, locale):
         if value is not None:
-            return pretty_timestamp(value)
+            value = pretty_timestamp(value)
+            if value is not None:
+                return value
+        return self._default_value
 
 
 class StatusDelegate(QtWidgets.QStyledItemDelegate):


### PR DESCRIPTION
## Changelog Description
Added modified date to workfiles.

### Additional information
This PR adds modified date of workfiles.
Also adds grouping of workfiles by host. The tool remembers grouped host names for future sessions.

## Screenshots
<img width="670" height="369" alt="image" src="https://github.com/user-attachments/assets/e3c07f5c-a035-4594-9978-d6e87edb294f" />

<img width="553" height="191" alt="image" src="https://github.com/user-attachments/assets/ba3a004f-fdbc-4481-a1ba-001b03377c43" />

Asking for help with UX enhancements. The grouping is somewhat hidden feature you have to know about.

## Testing notes:
1. Launcher does show workfiles with modified date.
2. Right click on workfiles should show option to group them, or to ungroup host item.

Resolves https://github.com/ynput/ayon-core/issues/1559 .