### PR TITLE
USD Contribution Layers: Add task name filter to profiles 

### DIFF
--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -530,10 +530,12 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
         product_base_type = instance.data.get("productBaseType")
         if not product_base_type:
             product_base_type = instance.data["productType"]
-        profile = filter_profiles(cls.profiles, {
+        filtering_criteria = {
             "product_base_types": product_base_type,
-            "task_types": current_context_task_type
-        })
+            "task_types": current_context_task_type,
+            "task_names": create_context.get_current_task_name()
+        }
+        profile = filter_profiles(cls.profiles, filtering_criteria)
         if not profile:
             profile = {}
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -135,6 +135,10 @@ class CollectUSDLayerContributionsProfileModel(BaseSettingsModel):
             " creating from within that task type."
         ),
     )
+    task_names: list[str] = SettingsField(
+        default_factory=list,
+        title="Task names",
+    )
     contribution_enabled: bool = SettingsField(
         True,
         title="Contribution Enabled (default)",
@@ -1381,6 +1385,7 @@ DEFAULT_PUBLISH_VALUES = {
             {
                 "product_base_types": ["model"],
                 "task_types": [],
+                "task_names": [],
                 "contribution_enabled": True,
                 "contribution_layer": "model",
                 "contribution_apply_as_variant": True,
@@ -1389,6 +1394,7 @@ DEFAULT_PUBLISH_VALUES = {
             {
                 "product_base_types": ["look"],
                 "task_types": [],
+                "task_names": [],
                 "contribution_enabled": True,
                 "contribution_layer": "look",
                 "contribution_apply_as_variant": True,
@@ -1397,6 +1403,7 @@ DEFAULT_PUBLISH_VALUES = {
             {
                 "product_base_types": ["groom"],
                 "task_types": [],
+                "task_names": [],
                 "contribution_enabled": True,
                 "contribution_layer": "groom",
                 "contribution_apply_as_variant": True,
@@ -1405,6 +1412,7 @@ DEFAULT_PUBLISH_VALUES = {
             {
                 "product_base_types": ["rig"],
                 "task_types": [],
+                "task_names": [],
                 "contribution_enabled": True,
                 "contribution_layer": "rig",
                 "contribution_apply_as_variant": True,
@@ -1413,6 +1421,7 @@ DEFAULT_PUBLISH_VALUES = {
             {
                 "product_base_types": ["usd"],
                 "task_types": [],
+                "task_names": [],
                 "contribution_enabled": True,
                 "contribution_layer": "assembly",
                 "contribution_apply_as_variant": False,


### PR DESCRIPTION
## Changelog Description
- Add task name filter to USD layer contribution profiles 

## Testing notes:
1. filter by task names in USD layer contribution collector `ayon+settings://core/publish/CollectUSDLayerContributions/profiles`
2. it should work

Resolve #1797 
