### PR TITLE
Extract USD layer: Backup profile has filled values

### DIFF
--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -537,20 +537,20 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
         }
         profile = filter_profiles(cls.profiles, filtering_criteria)
         if not profile:
-            profile = {}
+            profile = {
+                "contribution_enabled": True,
+                "contribution_layer": None,
+                "contribution_apply_as_variant": False,
+                "contribution_target_product": "usdAsset",
+            }
 
         # Define defaults
-        default_enabled: bool = profile.get("contribution_enabled", True)
-        default_contribution_layer = profile.get(
-            "contribution_layer", None)
-        default_apply_as_variant: bool = profile.get(
-            "contribution_apply_as_variant", False)
-        default_target_product: str = profile.get(
-            "contribution_target_product", "usdAsset")
+        default_target_product: str = profile["contribution_target_product"]
         default_init_as: str = (
             "asset"
-            if profile.get("contribution_target_product") == "usdAsset"
-            else "shot")
+            if default_target_product == "usdAsset"
+            else "shot"
+        )
         init_as_visible = True
 
         # Attributes logic
@@ -581,7 +581,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                         "In both cases the USD data itself is free to have "
                         "references and sublayers of its own."
                     ),
-                    default=default_enabled),
+                    default=profile["contribution_enabled"]),
             TextDef("contribution_target_product",
                     label="Target product",
                     tooltip=(
@@ -616,7 +616,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                         "the list) will contribute as a stronger opinion."
                     ),
                     items=list(contribution_layers.keys()),
-                    default=default_contribution_layer,
+                    default=profile["contribution_layer"],
                     visible=visible),
             # TODO: We may want to make the visibility of this optional
             #  based on studio preference, to avoid complexity when not needed
@@ -641,7 +641,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                         "appended to as a sublayer to the department layer "
                         "instead."
                     ),
-                    default=default_apply_as_variant,
+                    default=profile["contribution_apply_as_variant"],
                     visible=visible),
             TextDef("contribution_variant_set_name",
                     label="Variant Set Name",


### PR DESCRIPTION
## Changelog Description
If no profile is matched then define profile with all keys that should be available in profile from settings.

## Additional info
It is better to know what actually should be in the profile is none is available. Avoid having `.get(..., <default>)` which might potentially hide a bug in key vs. attribute difference.

## Testing notes:
1. Extract USD layer should show it's attributes, if there is matching profile and if there is no matching profile.
