### PR TITLE
Loader actions: Mark base classes to be skipped during discovery

### DIFF
--- a/client/ayon_core/pipeline/actions/loader.py
+++ b/client/ayon_core/pipeline/actions/loader.py
@@ -556,6 +556,7 @@ class LoaderActionPlugin(ABC):
     """
     _log: Optional[logging.Logger] = None
     enabled: bool = True
+    skip_discovery: bool = True
 
     def __init__(self, context: "LoaderActionsContext") -> None:
         self._context = context
@@ -826,6 +827,7 @@ class LoaderSimpleActionPlugin(LoaderActionPlugin):
     order: int = 0
     group_label: Optional[str] = None
     icon: Optional[dict[str, Any]] = None
+    skip_discovery: bool = True
 
     @abstractmethod
     def is_compatible(self, selection: LoaderActionSelection) -> bool:


### PR DESCRIPTION
## Changelog Description
Mark base classes to be skipped during discovery.

## Additional info
Classes can be imported in plugin file without being reported as abstract classes.
