### PR TITLE
Publisher instances sort by folder path and product name and fix shif…

### DIFF
--- a/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
@@ -816,12 +816,10 @@ class InstanceCardView(AbstractInstanceView):
 
             widget_idx += 1
 
-            instances = sorted(
+            for instance in sorted(
                instances_by_group[group_name],
-               key=lambda i: (i.get_folder_path(), getattr(i, "product_name", ""))
-            )
-
-            for instance in instances:
+               key=lambda i: (i.get_folder_path() or "", i.product_name))
+            ):
                 group_by_instance_id[instance.id] = group_name
                 instance_ids_by_group_name[group_name].append(instance.id)
 

--- a/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
@@ -816,7 +816,11 @@ class InstanceCardView(AbstractInstanceView):
 
             widget_idx += 1
 
-            instances = instances_by_group[group_name]
+            instances = sorted(
+               instances_by_group[group_name],
+               key=lambda i: (i.get_folder_path(), getattr(i, "product_name", ""))
+            )
+
             for instance in instances:
                 group_by_instance_id[instance.id] = group_name
                 instance_ids_by_group_name[group_name].append(instance.id)
@@ -891,37 +895,34 @@ class InstanceCardView(AbstractInstanceView):
         ) - set(instances_by_id)
         group_widget.take_widgets(to_remove_ids)
 
-        # Sort instances by product name
-        sorted_product_names = list(sorted(instances_by_product_name.keys()))
-
         # Add new instances to widget
         ordered_ids = []
         widgets_by_id = {}
-        for product_names in sorted_product_names:
-            for instance in instances_by_product_name[product_names]:
-                context_info = context_info_by_id[instance.id]
-                is_parent_active = parent_active_by_id[instance.id]
-                if instance.id in self._widgets_by_id:
-                    widget = self._widgets_by_id[instance.id]
-                    widget.update_instance(
-                        instance, context_info, is_parent_active
-                    )
-                else:
-                    group_icon = group_icons[instance.creator_identifier]
-                    widget = InstanceCardWidget(
-                        instance,
-                        context_info,
-                        is_parent_active,
-                        group_icon,
-                        group_widget,
-                    )
-                    widget.selected.connect(self._on_widget_selection)
-                    widget.active_changed.connect(self._on_active_changed)
-                    widget.double_clicked.connect(self.double_clicked)
-                    self._widgets_by_id[instance.id] = widget
 
-                ordered_ids.append(instance.id)
-                widgets_by_id[instance.id] = widget
+        for instance in instances:
+            context_info = context_info_by_id[instance.id]
+            is_parent_active = parent_active_by_id[instance.id]
+            if instance.id in self._widgets_by_id:
+                widget = self._widgets_by_id[instance.id]
+                widget.update_instance(
+                    instance, context_info, is_parent_active
+                )
+            else:
+                group_icon = group_icons[instance.creator_identifier]
+                widget = InstanceCardWidget(
+                    instance,
+                    context_info,
+                    is_parent_active,
+                    group_icon,
+                    group_widget,
+                )
+                widget.selected.connect(self._on_widget_selection)
+                widget.active_changed.connect(self._on_active_changed)
+                widget.double_clicked.connect(self.double_clicked)
+                self._widgets_by_id[instance.id] = widget
+
+            ordered_ids.append(instance.id)
+            widgets_by_id[instance.id] = widget
 
         group_widget.set_widgets(widgets_by_id, ordered_ids)
 


### PR DESCRIPTION
## Changelog Description
Hello, I noticed a  bug on the Publisher regarding the order of instances and the mutlitple selection in the case of  multishot workflow.  
I did not saw any issue regarding this, so I created this MR directly  
here is the bug ( you can see the selection is messed up)  
<img width="687" height="890" alt="Peek 2026-04-15 09-20" src="https://github.com/user-attachments/assets/7f33bd58-1952-4525-b375-ee85b73dc647" />

and after this fix
<img width="687" height="890" alt="Peek 2026-04-15 09-44" src="https://github.com/user-attachments/assets/7b94665f-419d-4043-ab22-f7d6dbbf4a05" />

I also sorted the instances by shot and then product name so it is easier for the artists.  

## Testing notes:
1. Open a DCC (gaffer in my case) with multiple shot publisher nodes containing different shots 
2. ctrl+click select the instances
