### PR TITLE
Settings registry: Enhancements

### DIFF
--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -529,6 +529,10 @@ class JSONSettingRegistry(ASettingRegistry):
             with open(self._registry_file, mode="w") as stream:
                 json.dump(header, stream, indent=4)
 
+    @property
+    def filepath(self) -> str:
+        return self._registry_file
+
     @lru_cache(maxsize=32)
     def _get_item(
         self, name: str, default: Any = _PLACEHOLDER

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -371,6 +371,10 @@ class IniSettingRegistry(ASettingRegistry):
 
         self._registry_file = filepath
 
+    @property
+    def filepath(self) -> str:
+        return self._registry_file
+
     def set_item_section(self, section: str, name: str, value: str) -> None:
         """Set item to specific section of ini registry.
 

--- a/client/ayon_core/lib/local_settings.py
+++ b/client/ayon_core/lib/local_settings.py
@@ -603,7 +603,7 @@ class AYONSettingsRegistry(JSONSettingRegistry):
                 DeprecationWarning,
                 stacklevel=2,
             )
-        path = get_launcher_storage_dir()
+        path = get_launcher_local_dir()
         super().__init__(name, path)
 
 


### PR DESCRIPTION
## Changelog Description
AYON registry is using local launcher dir instead of storage dir. JSON and INI settings registry also have `filepath` property.

## Additional info
Use local directory instead of storage directory which can be shared. Also gave option to get the path to the registry if it is filebased registry.

## Testing notes:
1. Validate code changes.
