### PR TITLE
Burnins: Skip drawtext when text is empty

### DIFF
--- a/client/ayon_core/scripts/otio_burnin.py
+++ b/client/ayon_core/scripts/otio_burnin.py
@@ -374,6 +374,10 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
         :param int frame_start: starting frame for burnins current frame
         :param dict options: recommended to use TextOptions
         """
+        if not text:
+            # do not add empty text, eg.: if it was using an optional part
+            return
+
         if not options:
             options = ffmpeg_burnins.TextOptions(**self.options_init)
 


### PR DESCRIPTION
## Changelog Description
don't add a `drawtext` if the text content is empty, to prevent the creation of empty background boxes

## Additional info
for some reason it seems `ffmpeg` does draw a small box when using `y_align=font` is used even if the text itself is empty.

this behaviour can be seen by comparing the result of these 2 commands:
```
ffmpeg -y -i /some/file.jpg -vf "drawtext=text='':x=100:y=100:fontsize=44:fontcolor=#FFFFFF@1.0:box=1:boxcolor=#CC0000@0.5:boxborderw=30:y_align=font" /tmp/out.%04d_with_align.jpg
ffmpeg -y -i /some/file.jpg -vf "drawtext=text='':x=100:y=100:fontsize=44:fontcolor=#FFFFFF@1.0:box=1:boxcolor=#CC0000@0.5:boxborderw=30" /tmp/out.%04d_no_align.jpg
```
<img width="1308" height="371" alt="image" src="https://github.com/user-attachments/assets/76753e7f-72da-4ffa-90c3-d02749216f4d" />

## some examples from published products

<img width="999" height="269" alt="image" src="https://github.com/user-attachments/assets/1a669baf-3bd8-4089-aff2-8e4aecefe9dd" />

before (no comment)
<img width="1360" height="765" alt="image" src="https://github.com/user-attachments/assets/b177502c-324f-4eac-a378-23ae0d4e663a" />

after (no comment)
<img width="1360" height="772" alt="image" src="https://github.com/user-attachments/assets/0a438c04-241b-429c-8c77-0e3adc7744b4" />

after (with comment)
<img width="1364" height="772" alt="image" src="https://github.com/user-attachments/assets/ea9b53c0-59a5-42ba-9bbb-73b636277a59" />


## Testing notes:
1. add an optional field. eg.: `<{comment}>`
2. publish
