### PR TITLE
Collect resources: Fill originalDirname

### DIFF
--- a/client/ayon_core/plugins/publish/collect_resources_path.py
+++ b/client/ayon_core/plugins/publish/collect_resources_path.py
@@ -13,7 +13,7 @@ import copy
 
 import pyblish.api
 
-from ayon_core.pipeline.publish import get_publish_template_name
+from ayon_core.pipeline.publish import get_publish_template_name, PublishError
 
 
 class CollectResourcesPath(pyblish.api.InstancePlugin):
@@ -109,13 +109,14 @@ class CollectResourcesPath(pyblish.api.InstancePlugin):
             original_directory = instance.data.get("originalDirname")
             if not original_directory:
                 original_directory = instance.data.get("stagingDir")
-                if not original_directory:
-                    self.log.warning(
-                        "Publish template requires 'originalDirname'"
-                        " but 'originalDirname' is not set on instance"
-                        " and 'stagingDir' is not yet filled."
-                    )
-                    return
+
+            if not original_directory:
+                raise PublishError(
+                    "Publish template requires 'originalDirname'"
+                    " but 'originalDirname' is not set on instance"
+                    " and 'stagingDir' is not yet filled."
+                )
+
             template_data["originalDirname"] = original_directory
 
         publish_folder = os.path.normpath(

--- a/client/ayon_core/plugins/publish/collect_resources_path.py
+++ b/client/ayon_core/plugins/publish/collect_resources_path.py
@@ -106,7 +106,7 @@ class CollectResourcesPath(pyblish.api.InstancePlugin):
             "publish", template_name, "directory")
 
         if "{originalDirname}" in publish_template:
-            original_directory =  instance.data.get("originalDirname")
+            original_directory = instance.data.get("originalDirname")
             if not original_directory:
                 original_directory = instance.data["stagingDir"]
             template_data["originalDirname"] = original_directory

--- a/client/ayon_core/plugins/publish/collect_resources_path.py
+++ b/client/ayon_core/plugins/publish/collect_resources_path.py
@@ -105,6 +105,12 @@ class CollectResourcesPath(pyblish.api.InstancePlugin):
         publish_template = anatomy.get_template_item(
             "publish", template_name, "directory")
 
+        if "{originalDirname}" in publish_template:
+            original_directory =  instance.data.get("originalDirname")
+            if not original_directory:
+                original_directory = instance.data["stagingDir"]
+            template_data["originalDirname"] = original_directory
+
         publish_folder = os.path.normpath(
             publish_template.format_strict(template_data)
         )

--- a/client/ayon_core/plugins/publish/collect_resources_path.py
+++ b/client/ayon_core/plugins/publish/collect_resources_path.py
@@ -108,7 +108,14 @@ class CollectResourcesPath(pyblish.api.InstancePlugin):
         if "{originalDirname}" in publish_template:
             original_directory = instance.data.get("originalDirname")
             if not original_directory:
-                original_directory = instance.data["stagingDir"]
+                original_directory = instance.data.get("stagingDir")
+                if not original_directory:
+                    self.log.warning(
+                        "Publish template requires 'originalDirname'"
+                        " but 'originalDirname' is not set on instance"
+                        " and 'stagingDir' is not yet filled."
+                    )
+                    return
             template_data["originalDirname"] = original_directory
 
         publish_folder = os.path.normpath(


### PR DESCRIPTION
## Changelog Description
Fill in `originalDirname` in collect resources.

## Additional info
If publish template for the instance does have original dirname it can fail to collect resources because of missing `originalDirname` in template data.

## Testing notes:
1. Define a template which will have `{orignalDirname}` in directory template.
2. Create an instance that will use the template (settings for that are `ayon+settings://core/tools/publish/template_name_profiles`). I've used `image` product base type in traypublisher for testing.
3. Publish.
4. Collect resources path should not fail.

Resolves https://github.com/ynput/ayon-core/issues/1696