### PR TITLE
Run plug-ins regardless of hosts: Collect Audio, Extract Review, Extract Burnin and Clean Up

### DIFF
--- a/client/ayon_core/plugins/publish/cleanup.py
+++ b/client/ayon_core/plugins/publish/cleanup.py
@@ -20,24 +20,6 @@ class CleanUp(pyblish.api.InstancePlugin):
 
     order = pyblish.api.IntegratorOrder + 10
     label = "Clean Up"
-    hosts = [
-        "aftereffects",
-        "blender",
-        "celaction",
-        "flame",
-        "fusion",
-        "harmony",
-        "hiero",
-        "houdini",
-        "maya",
-        "nuke",
-        "photoshop",
-        "resolve",
-        "tvpaint",
-        "unreal",
-        "webpublisher",
-        "shell"
-    ]
     settings_category = "core"
 
     exclude_families = ["clip"]

--- a/client/ayon_core/plugins/publish/collect_audio.py
+++ b/client/ayon_core/plugins/publish/collect_audio.py
@@ -21,26 +21,6 @@ class CollectAudio(pyblish.api.ContextPlugin):
     label = "Collect Folder Audio"
     order = pyblish.api.CollectorOrder + 0.1
     families = ["review"]
-    hosts = [
-        "nuke",
-        "maya",
-        "shell",
-        "hiero",
-        "premiere",
-        "harmony",
-        "traypublisher",
-        "fusion",
-        "tvpaint",
-        "resolve",
-        "webpublisher",
-        "aftereffects",
-        "flame",
-        "unreal",
-        "blender",
-        "houdini",
-        "max",
-        "batchdelivery",
-    ]
     settings_category = "core"
 
     audio_product_name = "audioMain"

--- a/client/ayon_core/plugins/publish/extract_burnin.py
+++ b/client/ayon_core/plugins/publish/extract_burnin.py
@@ -39,28 +39,6 @@ class ExtractBurnin(publish.Extractor):
     order = pyblish.api.ExtractorOrder + 0.03
 
     families = ["review", "burnin"]
-    hosts = [
-        "nuke",
-        "maya",
-        "shell",
-        "hiero",
-        "premiere",
-        "traypublisher",
-        "harmony",
-        "fusion",
-        "aftereffects",
-        "tvpaint",
-        "webpublisher",
-        "aftereffects",
-        "photoshop",
-        "flame",
-        "houdini",
-        "max",
-        "blender",
-        "unreal",
-        "batchdelivery",
-        "workflow",
-    ]
     settings_category = "core"
 
     optional = True

--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -147,29 +147,6 @@ class ExtractReview(pyblish.api.InstancePlugin):
     label = "Extract Review"
     order = pyblish.api.ExtractorOrder + 0.02
     families = ["review"]
-    hosts = [
-        "nuke",
-        "maya",
-        "blender",
-        "houdini",
-        "max",
-        "shell",
-        "hiero",
-        "premiere",
-        "harmony",
-        "traypublisher",
-        "fusion",
-        "tvpaint",
-        "resolve",
-        "webpublisher",
-        "aftereffects",
-        "flame",
-        "unreal",
-        "batchdelivery",
-        "photoshop",
-        "substancepainter",
-        "workflow",
-    ]
 
     settings_category = "core"
     # Supported extensions


### PR DESCRIPTION
## Changelog Description

Run plug-ins regardless of hosts: Collect Audio, Extract Review, Extract Burnin and Clean Up.

## Additional info

This will most definitely have side-effects. 

Particularly because suddenly these plug-ins will trigger on hosts that previously were not in these lists.
I'd especially investigate the more esoteric hosts - like webpublisher, batch publisher or certain ones like mocha. 

Note that, except for Clean Up plug-in these changed plug-ins only target "review" family (and Extract Burnin also "burnin" family; although I know no case where we add burnin as family)

If we find one plug-in particularly dangerous to change, we can move it into a separate PR - e.g. the Clean Up one.

## Testing notes:

- Clean Up plug-in does not cause problems in:
  - [x] batchdelivery host
  - [x] traypublisher host
  - [x] (3ds)max host
- Collect Folder Audio plug-in ('review' family only) does not cause problems in:
  - [x] workflow host for 'review' family
- All these plug-ins do not cause problems in:
  - [ ] Mocha
  - [ ] 3dequalizer
  - [ ] ... and more hosts that were missing