### PR TITLE
UILabelDef widget has browser abilities

### DIFF
--- a/client/ayon_core/tools/attribute_defs/widgets.py
+++ b/client/ayon_core/tools/attribute_defs/widgets.py
@@ -353,6 +353,9 @@ class LabelAttrWidget(_BaseAttrDefWidget):
         label = self.attr_def.label
         if label:
             input_widget.setText(str(label))
+        input_widget.setWordWrap(True)
+        input_widget.setTextInteractionFlags(QtCore.Qt.TextBrowserInteraction)
+        input_widget.setOpenExternalLinks(True)
 
         self._input_widget = input_widget
 


### PR DESCRIPTION
## Changelog Description
UILabelDef widget allows to select text or click uris.

## Testing notes:
You have to use UILabelDef to be able to test it. This is one example how it can be tested.
1. Start tray and open Browser tool.
2. Run `Delete versions` on a product.
3. Submit the first dialog, but DO NOT confirm the second.
4. Second dialog contains `UILabelDef` with `"Going to delete n versions"` where you should be able to select the text.