### PR TITLE
only use label if it is equal to the variant_label

### DIFF
--- a/client/ayon_core/tools/launcher/models/actions.py
+++ b/client/ayon_core/tools/launcher/models/actions.py
@@ -111,6 +111,8 @@ class ActionsModel:
     @staticmethod
     def calculate_full_label(label: str, variant_label: Optional[str]) -> str:
         """Calculate full label from label and variant_label."""
+        if label == variant_label:
+            return label
         if variant_label:
             return " ".join([label, variant_label])
         return label


### PR DESCRIPTION
## Changelog Description
Launcher: `full_label` no longer duplicates the label when it matches the variant label.

## Additional info
This allows admins to "ungroup" application variants by setting the `group_label = variant_label`  thus generating unique groups

## Testing notes:
1. start with this step
2. follow this step
