### PR TITLE
Validate Product Name Uniqueness: allow it if instances target different versions

### DIFF
--- a/client/ayon_core/plugins/publish/validate_unique_subsets.py
+++ b/client/ayon_core/plugins/publish/validate_unique_subsets.py
@@ -56,28 +56,39 @@ class ValidateProductUniqueness(pyblish.api.ContextPlugin):
                 ).format(instance.name))
                 continue
 
-            instance_per_folder_product[(folder_path, product_name)].append(
-                instance
+            # Note: version may be optionally set, but when set that will be
+            #  the resulting target version. If two instances target the same
+            #  product but a different version we will allow it.
+            # TODO: This may have the caveat where one instance *may* target
+            #  None (next version) and that next version matching exactly an
+            #  explicitly set version but that would really be an edge case.
+            version = instance.data.get("version")
+            key = (
+                folder_path,
+                product_name,
+                version
             )
+            instance_per_folder_product[key].append(instance)
 
         non_unique = []
-        for (folder_path, product_name), instances in (
+        for (folder_path, product_name, version), instances in (
             instance_per_folder_product.items()
         ):
             # A single instance per folder, product is fine
             if len(instances) < 2:
                 continue
 
-            non_unique.append(
-                "{} > {}".format(folder_path, product_name)
-            )
+            label = f"{folder_path} > {product_name}"
+            if version is not None:
+                label += f" (version {version})"
+            non_unique.append(label)
 
         if not non_unique:
             # All is ok
             return
 
         msg = (
-            f"Instance product names {non_unique} are not unique."
+            f"Instance products {non_unique} are not unique."
             " Please remove or rename duplicates."
         )
         formatting_data = {

--- a/client/ayon_core/plugins/publish/validate_unique_subsets.py
+++ b/client/ayon_core/plugins/publish/validate_unique_subsets.py
@@ -44,24 +44,21 @@ class ValidateProductUniqueness(pyblish.api.ContextPlugin):
             # Ignore instance without folder data
             folder_path = instance.data.get("folderPath")
             if folder_path is None:
-                self.log.warning("Instance found without `folderPath` data: "
-                                 "{}".format(instance.name))
+                self.log.warning(
+                    "Instance found without `folderPath` data: "
+                    f"{instance.name}"
+                )
                 continue
 
             # Ignore instance without product data
             product_name = instance.data.get("productName")
             if product_name is None:
-                self.log.warning((
-                    "Instance found without `productName` in data: {}"
-                ).format(instance.name))
+                self.log.warning(
+                    "Instance found without `productName` in data: "
+                    f"{instance.name}"
+                )
                 continue
 
-            # Note: version may be optionally set, but when set that will be
-            #  the resulting target version. If two instances target the same
-            #  product but a different version we will allow it.
-            # TODO: This may have the caveat where one instance *may* target
-            #  None (next version) and that next version matching exactly an
-            #  explicitly set version but that would really be an edge case.
             version = instance.data.get("version")
             key = (
                 folder_path,
@@ -74,11 +71,26 @@ class ValidateProductUniqueness(pyblish.api.ContextPlugin):
         for (folder_path, product_name, version), instances in (
             instance_per_folder_product.items()
         ):
+            label = f"{folder_path} > {product_name}"
+
+            # If this has an explicit version, but there is also a non-explicit
+            # version instance than disallow it.
+            versionless_key = (folder_path, product_name, None)
+            if (
+                version is not None
+                and versionless_key in instance_per_folder_product
+            ):
+                non_unique.append(label)
+                self.log.error(
+                    f"Instance with explicit version {version} found for "
+                    f"product {label}, but there is also an instance without "
+                    f"explicit version. This is not allowed."
+                )
+
             # A single instance per folder, product is fine
             if len(instances) < 2:
                 continue
 
-            label = f"{folder_path} > {product_name}"
             if version is not None:
                 label += f" (version {version})"
             non_unique.append(label)

--- a/client/ayon_core/plugins/publish/validate_unique_subsets.py
+++ b/client/ayon_core/plugins/publish/validate_unique_subsets.py
@@ -74,7 +74,7 @@ class ValidateProductUniqueness(pyblish.api.ContextPlugin):
             label = f"{folder_path} > {product_name}"
 
             # If this has an explicit version, but there is also a non-explicit
-            # version instance than disallow it.
+            # version instance then disallow it.
             versionless_key = (folder_path, product_name, None)
             if (
                 version is not None


### PR DESCRIPTION
## Changelog Description

Allow multiple instances targeting the same product but a different (explicit) version number to be published from a single context

## Additional info

Fix https://github.com/ynput/ayon-core/issues/1815

Required for things like CSV ingests where multiple instances may be explicitly targeting different versions.

Note that [ValidateVersion](https://github.com/ynput/ayon-core/blob/32ea97af45bef30951c65e235f541cc2f2827e46/client/ayon_core/plugins/publish/validate_version.py#L11) would still trigger if configured with the profile disallowing not publishing a 'latest' version, etc. but that's a correct separate validation from this case. Currently it'd even still allow it if e.g. both instances, represent newer versions than the current existing one which I think is perfect too.

## Testing notes:

1. Publish multiple instances to same target context+product with different `version` data should be allowed.