### PR TITLE
Tools: Sort tasks by task type

### DIFF
--- a/client/ayon_core/tools/common_models/hierarchy.py
+++ b/client/ayon_core/tools/common_models/hierarchy.py
@@ -176,14 +176,14 @@ def _get_task_items_from_tasks(
         TaskItem: Task item.
 
     """
-    task_types = [
-        task_type.name
-        for task_type in task_type_items
-    ]
+    task_types = {
+        task_type.name: index
+        for index, task_type in enumerate(task_type_items)
+    }
     output = []
     for task in tasks:
         folder_id = task["folderId"]
-        task_type_order = task_types.index(task["type"])
+        task_type_order = task_types[task["type"]]
         output.append(TaskItem(
             task["id"],
             task["name"],

--- a/client/ayon_core/tools/common_models/hierarchy.py
+++ b/client/ayon_core/tools/common_models/hierarchy.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 import collections
 import contextlib
-import typing
 import time
 from typing import Any
 

--- a/client/ayon_core/tools/common_models/hierarchy.py
+++ b/client/ayon_core/tools/common_models/hierarchy.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-import time
+from abc import ABC, abstractmethod
 import collections
 import contextlib
 import typing
-from abc import ABC, abstractmethod
+import time
+from typing import Any
 
 import ayon_api
 
 from ayon_core.lib import NestedCacheItem
 
-if typing.TYPE_CHECKING:
-    from typing import Union
+from .projects import TaskTypeItem
 
 HIERARCHY_MODEL_SENDER = "hierarchy.model"
 
@@ -29,12 +29,12 @@ class FolderItem:
 
     Args:
         entity_id (str): Folder id.
-        parent_id (Union[str, None]): Parent folder id. If 'None' then project
+        parent_id (str | None): Parent folder id. If 'None' then project
             is parent.
         name (str): Name of folder.
         path (str): Folder path.
         folder_type (str): Type of folder.
-        label (Union[str, None]): Folder label.
+        label (str | None): Folder label.
     """
 
     def __init__(
@@ -88,7 +88,7 @@ class TaskItem:
     Args:
         task_id (str): Task id.
         name (str): Name of task.
-        name (Union[str, None]): Task label.
+        name (str | None): Task label.
         task_type (str): Type of task.
         parent_id (str): Parent folder id.
     """
@@ -97,8 +97,9 @@ class TaskItem:
         self,
         task_id: str,
         name: str,
-        label: Union[str, None],
+        label: str | None,
         task_type: str,
+        task_type_order: int,
         parent_id: str,
         tags: list[str],
     ):
@@ -106,6 +107,7 @@ class TaskItem:
         self.name = name
         self.label = label
         self.task_type = task_type
+        self.task_type_order = task_type_order
         self.parent_id = parent_id
         self.tags = tags
 
@@ -147,6 +149,7 @@ class TaskItem:
             "label": self.label,
             "parent_id": self.parent_id,
             "task_type": self.task_type,
+            "task_type_order": self.task_type_order,
             "tags": self.tags,
         }
 
@@ -164,21 +167,30 @@ class TaskItem:
         return cls(**data)
 
 
-def _get_task_items_from_tasks(tasks):
+def _get_task_items_from_tasks(
+    task_type_items: list[TaskTypeItem],
+    tasks: list[dict[str, Any]]
+) -> list[TaskItem]:
     """
 
     Returns:
         TaskItem: Task item.
-    """
 
+    """
+    task_types = [
+        task_type.name
+        for task_type in task_type_items
+    ]
     output = []
     for task in tasks:
         folder_id = task["folderId"]
+        task_type_order = task_types.index(task["type"])
         output.append(TaskItem(
             task["id"],
             task["name"],
             task["label"],
             task["type"],
+            task_type_order,
             folder_id,
             task["tags"],
         ))
@@ -651,4 +663,5 @@ class HierarchyModel(object):
             folder_ids=[folder_id],
             fields={"id", "name", "label", "folderId", "type", "tags"}
         ))
-        return _get_task_items_from_tasks(tasks)
+        task_type_items = self._controller.get_task_type_items(project_name)
+        return _get_task_items_from_tasks(task_type_items, tasks)

--- a/client/ayon_core/tools/push_to_project/control.py
+++ b/client/ayon_core/tools/push_to_project/control.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import threading
 from typing import Dict
 
@@ -7,7 +9,11 @@ from ayon_core.settings import get_project_settings
 from ayon_core.lib import prepare_template_data
 from ayon_core.lib.events import QueuedEventSystem
 from ayon_core.pipeline.create import get_product_name_template
-from ayon_core.tools.common_models import ProjectsModel, HierarchyModel
+from ayon_core.tools.common_models import (
+    ProjectsModel,
+    HierarchyModel,
+    TaskTypeItem,
+)
 
 from .models import (
     PushToProjectSelectionModel,
@@ -147,6 +153,13 @@ class PushToContextController:
 
     def get_project_items(self, sender=None):
         return self._projects_model.get_project_items(sender)
+
+    def get_task_type_items(
+        self, project_name: str, sender: str | None = None
+    ) -> list[TaskTypeItem]:
+        return self._projects_model.get_task_type_items(
+            project_name, sender=sender
+        )
 
     def get_folder_items(self, project_name, sender=None):
         return self._hierarchy_model.get_folder_items(project_name, sender)

--- a/client/ayon_core/tools/utils/tasks_widget.py
+++ b/client/ayon_core/tools/utils/tasks_widget.py
@@ -16,7 +16,7 @@ ITEM_ID_ROLE = QtCore.Qt.UserRole + 1
 PARENT_ID_ROLE = QtCore.Qt.UserRole + 2
 ITEM_NAME_ROLE = QtCore.Qt.UserRole + 3
 TASK_TYPE_ROLE = QtCore.Qt.UserRole + 4
-TASK_SORT_ROLE = QtCore.Qt.UserRole + 5
+TASK_TYPE_ORDER_ROLE = QtCore.Qt.UserRole + 5
 
 
 class TasksQtModel(QtGui.QStandardItemModel):
@@ -286,7 +286,7 @@ class TasksQtModel(QtGui.QStandardItemModel):
             item.setData(task_item.id, ITEM_ID_ROLE)
             item.setData(task_item.task_type, TASK_TYPE_ROLE)
             item.setData(task_item.parent_id, PARENT_ID_ROLE)
-            item.setData(task_item.task_type_order, TASK_SORT_ROLE)
+            item.setData(task_item.task_type_order, TASK_TYPE_ORDER_ROLE)
             item.setData(icon, QtCore.Qt.DecorationRole)
 
         root_item = self.invisibleRootItem()
@@ -362,8 +362,8 @@ class TasksProxyModel(QtCore.QSortFilterProxyModel):
         self.invalidateFilter()
 
     def lessThan(self, source_left, source_right):
-        left_sort = source_left.data(TASK_SORT_ROLE)
-        right_sort = source_right.data(TASK_SORT_ROLE)
+        left_sort = source_left.data(TASK_TYPE_ORDER_ROLE)
+        right_sort = source_right.data(TASK_TYPE_ORDER_ROLE)
         if left_sort is not None and right_sort is not None:
             return left_sort < right_sort
         return super().lessThan(source_left, source_right)

--- a/client/ayon_core/tools/utils/tasks_widget.py
+++ b/client/ayon_core/tools/utils/tasks_widget.py
@@ -16,6 +16,7 @@ ITEM_ID_ROLE = QtCore.Qt.UserRole + 1
 PARENT_ID_ROLE = QtCore.Qt.UserRole + 2
 ITEM_NAME_ROLE = QtCore.Qt.UserRole + 3
 TASK_TYPE_ROLE = QtCore.Qt.UserRole + 4
+TASK_SORT_ROLE = QtCore.Qt.UserRole + 5
 
 
 class TasksQtModel(QtGui.QStandardItemModel):
@@ -285,6 +286,7 @@ class TasksQtModel(QtGui.QStandardItemModel):
             item.setData(task_item.id, ITEM_ID_ROLE)
             item.setData(task_item.task_type, TASK_TYPE_ROLE)
             item.setData(task_item.parent_id, PARENT_ID_ROLE)
+            item.setData(task_item.task_type_order, TASK_SORT_ROLE)
             item.setData(icon, QtCore.Qt.DecorationRole)
 
         root_item = self.invisibleRootItem()
@@ -358,6 +360,13 @@ class TasksProxyModel(QtCore.QSortFilterProxyModel):
             return
         self._task_ids_filter = task_ids
         self.invalidateFilter()
+
+    def lessThan(self, source_left, source_right):
+        left_sort = source_left.data(TASK_SORT_ROLE)
+        right_sort = source_right.data(TASK_SORT_ROLE)
+        if left_sort is not None and right_sort is not None:
+            return left_sort < right_sort
+        return super().lessThan(source_left, source_right)
 
     def filterAcceptsRow(self, row, parent_index):
         if self._task_ids_filter is not None:


### PR DESCRIPTION
## Changelog Description
Use order of task types from project to sort task items in UIs.

## Additional information
With this changes we're matching the order to web fronetned.

## Testing notes:
1. Tasks are order by task type order defined in project anatomy.

Replacement of https://github.com/ynput/ayon-core/pull/1512