### PR TITLE
Add udim check for template data in Integrate Hero Version

### DIFF
--- a/client/ayon_core/plugins/publish/integrate_hero_version.py
+++ b/client/ayon_core/plugins/publish/integrate_hero_version.py
@@ -380,6 +380,7 @@ class IntegrateHeroVersion(
                 }
 
                 dst_paths = []
+                is_udim = bool(repre_context.get("udim"))
                 # Prepare paths of source and destination files
                 if len(published_files) == 1:
                     dst_paths.append(str(template_filled))
@@ -400,7 +401,10 @@ class IntegrateHeroVersion(
 
                     # Get head and tail for collection
                     frame_splitter = "_-_FRAME_SPLIT_-_"
-                    anatomy_data["frame"] = frame_splitter
+                    if is_udim:
+                        anatomy_data["udim"] = frame_splitter
+                    else:
+                        anatomy_data["frame"] = frame_splitter
                     _template_filled = path_template_obj.format_strict(
                         anatomy_data
                     )


### PR DESCRIPTION
## Changelog Description
This PR is to add missing udim data for template data to query the correct destination collection only when there is udim found.
Resolve https://github.com/ynput/ayon-core/issues/1821

## Additional info
Besides checking with image families, please make sure checking review families for integrate hero version too

## Testing notes:
1. Add image as part of the families `ayon+settings://core/publish/IntegrateHeroVersion`
2. Launch SP
3. Publish
4. The image with hero version should be published and named e.g.  `il_lib_TextureTableMain.Table.BaseColor_v005_1011.png`
