### PR TITLE
Update speedcopy dependency version to 2.2

### DIFF
--- a/client/ayon_core/lib/file_transaction.py
+++ b/client/ayon_core/lib/file_transaction.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 from ayon_core.lib import create_hard_link
 
 import speedcopy
+import speedcopy.version
 
 _IS_MACOS = platform.system().lower() == "darwin"
 
@@ -25,9 +26,9 @@ def copyfile(src, dst):
         src (str): Source path.
         dst (str): Destination path.
     """
-    # NOTE speedcopy has a bug that causes failure on macOs.
+    # NOTE speedcopy has a bug that causes failure on macOS, fixed in 2.2.0
     # TODO find out if speedcopy is still needed and remove if not.
-    if _IS_MACOS:
+    if _IS_MACOS and speedcopy.version.version_info <= (2, 2, 0):
         shutil.copyfile(src, dst)
     elif os.getenv("AYON_COPY_FILE_DISABLE_SPEEDCOPY") != "1":
         speedcopy.copyfile(src, dst)

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -8,7 +8,7 @@ clique = "1.6.*"
 jsonschema = "^2.6.0"
 pyblish-base = "^1.8.11"
 pygments = "^2.15.0"
-speedcopy = "^2.1"
+speedcopy = "^2.2"
 six = "^1.15"
 qtawesome = "0.7.3"
 


### PR DESCRIPTION
## Changelog Description
Bump version of [speedcopy](https://github.com/antirotor/speedcopy)

## Additional info
New version of speedcopy fixes some macos related issues (crashes in integrator).

## Testing notes:
Test asset integration on all platforms (publish)

> [!WARNING]
> You need to build new dependency package

