### PR TITLE
OCIO: Add app name to OCIO profile fitlering

### DIFF
--- a/client/ayon_core/hooks/pre_ocio_hook.py
+++ b/client/ayon_core/hooks/pre_ocio_hook.py
@@ -56,6 +56,7 @@ class OCIOEnvHook(PreLaunchHook):
             self.data["folder_path"],
             self.data["task_name"],
             self.host_name,
+            self.app_name,
             anatomy=self.data["anatomy"],
             project_settings=self.data["project_settings"],
             template_data=template_data,

--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -984,7 +984,7 @@ def get_imageio_config_preset(
         if not project_entity:
             project_entity = ayon_api.get_project(project_name)
 
-        folder_entity = task_entity = folder_id = None
+        folder_entity = task_entity = None
         if folder_path:
             folder_entity = ayon_api.get_folder_by_path(
                 project_name, folder_path

--- a/client/ayon_core/pipeline/colorspace.py
+++ b/client/ayon_core/pipeline/colorspace.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import re
 import os
 import json
@@ -744,13 +745,14 @@ def _get_config_path_from_profile_data(
 
 
 def _get_global_config_data(
-    project_name,
-    host_name,
-    anatomy,
-    template_data,
-    imageio_global,
-    folder_id,
-    log,
+    project_name: str,
+    host_name: str,
+    app_name: str | None,
+    anatomy: Anatomy,
+    template_data: dict[str, Any],
+    imageio_global: dict[str, Any],
+    folder_id: str,
+    log: logging.Logger,
 ) -> ConfigData:
     """Get global config data.
 
@@ -768,6 +770,7 @@ def _get_global_config_data(
     Args:
         project_name (str): Project name.
         host_name (str): Host name.
+        app_name (str | None): Applications name.
         anatomy (Anatomy): Project anatomy object.
         template_data (dict[str, Any]): Template data.
         imageio_global (dict[str, Any]): Core imagio settings.
@@ -788,6 +791,7 @@ def _get_global_config_data(
         "task_names": task_name,
         "task_types": task_type,
         "host_names": host_name,
+        "app_names": app_name,
     }
     profile = filter_profiles(
         imageio_global["ocio_config_profiles"], filter_values
@@ -897,15 +901,17 @@ def _get_global_config_data(
 
 
 def get_imageio_config_preset(
-    project_name,
-    folder_path,
-    task_name,
-    host_name,
-    anatomy=None,
-    project_settings=None,
-    template_data=None,
-    env=None,
-    folder_id=None,
+    project_name: str,
+    folder_path: str,
+    task_name: str,
+    host_name: str,
+    app_name: str | None = None,
+    *,
+    anatomy: Anatomy | None = None,
+    project_settings: dict | None = None,
+    template_data: dict | None = None,
+    env: dict | None = None,
+    folder_id: str | None = None,
 ):
     """Returns config data from settings
 
@@ -918,6 +924,7 @@ def get_imageio_config_preset(
         folder_path (str): Folder path.
         task_name (str): Task name.
         host_name (str): Host name.
+        app_name (str): Application name.
         anatomy (Optional[Anatomy]): Project anatomy object.
         project_settings (Optional[dict]): Project settings.
         template_data (Optional[dict]): Template data used for
@@ -1021,11 +1028,12 @@ def get_imageio_config_preset(
         config_data = _get_global_config_data(
             project_name,
             host_name,
-            anatomy,
-            template_data,
-            imageio_global,
-            folder_id,
-            log,
+            app_name,
+            anatomy=anatomy,
+            template_data=template_data,
+            imageio_global=imageio_global,
+            folder_id=folder_id,
+            log=log,
         )
     else:
         config_data = _get_host_config_data(
@@ -1208,6 +1216,7 @@ def get_colorspace_settings_from_publish_context(context_data):
     folder_path = context_data["folderPath"]
     task_name = context_data["task"]
     host_name = context_data["hostName"]
+    app_name = context_data.get("appName")
     anatomy = context_data["anatomy"]
     template_data = context_data["anatomyData"]
     project_settings = context_data["project_settings"]
@@ -1221,6 +1230,7 @@ def get_colorspace_settings_from_publish_context(context_data):
         folder_path,
         task_name,
         host_name,
+        app_name,
         anatomy=anatomy,
         project_settings=project_settings,
         template_data=template_data,
@@ -1525,19 +1535,21 @@ def _get_ocio_config_views(config_path):
 
 # --- Current context functions ---
 def get_current_context_imageio_config_preset(
-    anatomy=None,
-    project_settings=None,
-    template_data=None,
-    env=None,
+    anatomy: Anatomy | None = None,
+    project_settings: dict | None = None,
+    template_data: dict | None = None,
+    env: dict[str, str] | None = None,
+    app_name: str | None = None,
 ):
     """Get ImageIO config preset for current context.
 
     Args:
-        anatomy (Optional[Anatomy]): Current project anatomy.
-        project_settings (Optional[dict[str, Any]]): Current project settings.
-        template_data (Optional[dict[str, Any]]): Prepared template data
+        anatomy (Anatomy | None): Current project anatomy.
+        project_settings (dict[str, Any] | NOne): Current project settings.
+        template_data (dict[str, Any] | None): Prepared template data
             for current context.
-        env (Optional[dict[str, str]]): Custom environment variable values.
+        env (dict[str, str] | None): Custom environment variable values.
+        app_name (str | None): Application name.
 
     Returns:
         dict: ImageIO config preset.
@@ -1547,11 +1559,14 @@ def get_current_context_imageio_config_preset(
 
     context = get_current_context()
     host_name = get_current_host_name()
+    if not app_name:
+        app_name = os.getenv("AYON_APP_NAME")
     return get_imageio_config_preset(
         context["project_name"],
         context["folder_path"],
         context["task_name"],
         host_name,
+        app_name,
         anatomy=anatomy,
         project_settings=project_settings,
         template_data=template_data,
@@ -1622,12 +1637,12 @@ def get_views_data_subprocess(config_path):
 
 @deprecated("get_imageio_config_preset")
 def get_imageio_config(
-    project_name,
-    host_name,
-    project_settings=None,
-    anatomy_data=None,
-    anatomy=None,
-    env=None
+    project_name: str,
+    host_name: str,
+    project_settings: dict | None = None,
+    anatomy_data: dict | None = None,
+    anatomy: Anatomy | None = None,
+    env: dict[str, str] | None = None,
 ):
     """Returns config data from settings
 
@@ -1653,6 +1668,13 @@ def get_imageio_config(
         from .context_tools import get_current_context_template_data
         anatomy_data = get_current_context_template_data()
 
+    app_name = None
+    if env is not None:
+        app_name = env.get("AYON_APP_NAME")
+
+    if not app_name:
+        app_name = os.getenv("AYON_APP_NAME")
+
     task_name = anatomy_data.get("task", {}).get("name")
     folder_path = anatomy_data.get("folder", {}).get("path")
     return get_imageio_config_preset(
@@ -1660,6 +1682,7 @@ def get_imageio_config(
         folder_path,
         task_name,
         host_name,
+        app_name,
         anatomy=anatomy,
         project_settings=project_settings,
         template_data=anatomy_data,

--- a/client/ayon_core/pipeline/template_data.py
+++ b/client/ayon_core/pipeline/template_data.py
@@ -219,6 +219,9 @@ def get_template_data(
 
     if host_name:
         template_data["app"] = host_name
+        template_data["host"] = {
+            "name": host_name,
+        }
 
     return template_data
 

--- a/client/ayon_core/pipeline/workfile/path_resolving.py
+++ b/client/ayon_core/pipeline/workfile/path_resolving.py
@@ -144,11 +144,14 @@ def get_workdir_with_workdir_data(
         anatomy = Anatomy(project_name)
 
     if not template_key:
+        host_name = workdir_data.get("host", {}).get("name")
+        if host_name is None:
+            host_name = workdir_data["app"]
         template_key = get_workfile_template_key(
             workdir_data["project"]["name"],
             workdir_data["task"]["type"],
-            workdir_data["app"],
-            project_settings
+            host_name,
+            project_settings,
         )
 
     template_obj = anatomy.get_template_item(
@@ -590,9 +593,12 @@ def get_last_workfile(
     )
     if filepath is None:
         data = copy.deepcopy(template_data)
+        host_name = data.get("host", {}).get("name")
+        if host_name is None:
+            host_name = data["app"]
         data["version"] = version_start.get_versioning_start(
             data["project"]["name"],
-            data["app"],
+            host_name,
             task_name=data["task"]["name"],
             task_type=data["task"]["type"],
             product_base_type="workfile",

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -170,6 +170,7 @@ class CoreImageIOConfigProfilesModel(BaseSettingsModel):
     app_names: list[str] = SettingsField(
         default_factory=list,
         title="Application names",
+        placeholder="{group}/{variant} (maya/2026, nuke/13.2, ...)",
         description=(
             "Application full name (group/variant) from applications addon."
         ),

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -170,7 +170,7 @@ class CoreImageIOConfigProfilesModel(BaseSettingsModel):
     app_names: list[str] = SettingsField(
         default_factory=list,
         title="Application names",
-        placeholder="{group}/{variant} (maya/2026, nuke/13.2, ...)",
+        placeholder="{group}/{variant} (maya/2026,  ...)",
         description=(
             "Application full name (group/variant) from applications addon."
         ),

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -167,6 +167,13 @@ class CoreImageIOConfigProfilesModel(BaseSettingsModel):
         default_factory=list,
         title="Task names"
     )
+    app_names: list[str] = SettingsField(
+        default_factory=list,
+        title="Application names",
+        description=(
+            "Application full name (group/variant) from applications addon."
+        ),
+    )
     type: str = SettingsField(
         title="Profile type",
         enum_resolver=_ocio_config_profile_types,
@@ -382,6 +389,7 @@ DEFAULT_VALUES = {
         "ocio_config_profiles": [
             {
                 "host_names": [],
+                "app_names": [],
                 "task_types": [],
                 "task_names": [],
                 "type": "builtin_path",


### PR DESCRIPTION
## Changelog Description
Add app variant filtering to OCIO filtering.

## Additional info
This change may affect code that is not living within ayon-core but is trying to get OCIO config. As far as I was able to find it affects only one other addon (making PR). Other addons are using `get_current_context_imageio_config_preset`, `get_colorspace_settings_from_publish_context` or deprecated `get_imageio_config` (made PR).

## Testing notes:
1. OCIO profiles now allow to specify app name from applications addon.
2. Go to settings and specify app names in `ayon+settings://core/imageio/ocio_config_profiles/0/app_names` .
3. The OCIO should be picked up, it should be used during publishing even on farm.

Resolves https://github.com/ynput/ayon-core/issues/1726