### PR TITLE
UIs: Tasks sorting can ignore task type sorting

### DIFF
--- a/client/ayon_core/tools/common_models/__init__.py
+++ b/client/ayon_core/tools/common_models/__init__.py
@@ -28,6 +28,8 @@ __all__ = (
     "CacheItem",
     "NestedCacheItem",
 
+    "SettingsModel",
+
     "TagItem",
     "StatusItem",
     "StatusStates",

--- a/client/ayon_core/tools/common_models/__init__.py
+++ b/client/ayon_core/tools/common_models/__init__.py
@@ -1,6 +1,7 @@
 """Backend models that can be used in controllers."""
 
 from .cache import CacheItem, NestedCacheItem
+from .settings import SettingsModel
 from .projects import (
     TagItem,
     StatusItem,

--- a/client/ayon_core/tools/common_models/settings.py
+++ b/client/ayon_core/tools/common_models/settings.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import copy
+
+from ayon_core.settings import get_studio_settings, get_project_settings
+
+
+class SettingsModel:
+    def __init__(self):
+        self._settings = {}
+
+    def reset(self) -> None:
+        self._settings = {}
+
+    def get_settings(self, project_name: str | None = None) -> dict:
+        settings = self._settings.get(project_name)
+        if settings is None:
+            if project_name is None:
+                settings = get_studio_settings()
+            else:
+                settings = get_project_settings(project_name)
+            self._settings[project_name] = settings
+        return copy.deepcopy(settings)

--- a/client/ayon_core/tools/context_dialog/window.py
+++ b/client/ayon_core/tools/context_dialog/window.py
@@ -8,7 +8,6 @@ from qtpy import QtWidgets, QtCore, QtGui
 
 from ayon_core import style
 from ayon_core.lib.events import QueuedEventSystem
-from ayon_core.settings import get_project_settings, get_studio_settings
 from ayon_core.tools.common_models import (
     SettingsModel,
     ProjectsModel,

--- a/client/ayon_core/tools/context_dialog/window.py
+++ b/client/ayon_core/tools/context_dialog/window.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import json
 
@@ -6,7 +8,9 @@ from qtpy import QtWidgets, QtCore, QtGui
 
 from ayon_core import style
 from ayon_core.lib.events import QueuedEventSystem
+from ayon_core.settings import get_project_settings, get_studio_settings
 from ayon_core.tools.common_models import (
+    SettingsModel,
     ProjectsModel,
     HierarchyModel,
 )
@@ -158,6 +162,7 @@ class ContextDialogController:
     def __init__(self):
         self._event_system = None
 
+        self._settings_model = SettingsModel()
         self._projects_model = ProjectsModel(self)
         self._hierarchy_model = HierarchyModel(self)
         self._selection_model = SelectionModel(self)
@@ -187,6 +192,7 @@ class ContextDialogController:
         self._initial_folder_found = True
         self._initial_tasks_found = True
 
+        self._settings_model.reset()
         self._projects_model.reset()
         self._hierarchy_model.reset()
 
@@ -195,6 +201,7 @@ class ContextDialogController:
     def refresh(self):
         self._emit_event("controller.refresh.started")
 
+        self._settings_model.reset()
         self._projects_model.reset()
         self._hierarchy_model.reset()
 
@@ -224,6 +231,9 @@ class ContextDialogController:
         self._emit_event("strict.changed", {"strict": enabled})
 
     # Data model functions
+    def get_project_settings(self, project_name: str | None) -> dict:
+        return self._settings_model.get_settings(project_name)
+
     def get_project_items(self, sender=None):
         return self._projects_model.get_project_items(sender)
 

--- a/client/ayon_core/tools/launcher/control.py
+++ b/client/ayon_core/tools/launcher/control.py
@@ -6,8 +6,8 @@ from typing import Optional
 from ayon_core.lib import Logger, JSONSettingRegistry, get_launcher_local_dir
 from ayon_core.lib.events import QueuedEventSystem
 from ayon_core.addon import AddonsManager
-from ayon_core.settings import get_project_settings, get_studio_settings
 from ayon_core.tools.common_models import (
+    SettingsModel,
     ProjectsModel,
     HierarchyModel,
     UsersModel,
@@ -31,7 +31,6 @@ class BaseLauncherController(
     AbstractLauncherFrontEnd, AbstractLauncherBackend
 ):
     def __init__(self):
-        self._project_settings = {}
         self._event_system = None
         self._log = None
 
@@ -42,6 +41,7 @@ class BaseLauncherController(
 
         self._addons_manager = None
 
+        self._settings_model = SettingsModel()
         self._selection_model = LauncherSelectionModel(self)
         self._projects_model = ProjectsModel(self)
         self._hierarchy_model = HierarchyModel(self)
@@ -128,14 +128,7 @@ class BaseLauncherController(
 
     # Project settings for applications actions
     def get_project_settings(self, project_name):
-        if project_name in self._project_settings:
-            return self._project_settings[project_name]
-        if project_name:
-            settings = get_project_settings(project_name)
-        else:
-            settings = get_studio_settings()
-        self._project_settings[project_name] = settings
-        return settings
+        return self._settings_model.get_settings(project_name)
 
     # Entity for backend
     def get_project_entity(self, project_name):
@@ -231,8 +224,7 @@ class BaseLauncherController(
     def refresh(self):
         self._emit_event("controller.refresh.started")
 
-        self._project_settings = {}
-
+        self._settings_model.reset()
         self._projects_model.reset()
         self._hierarchy_model.reset()
         self._users_model.reset()
@@ -246,7 +238,7 @@ class BaseLauncherController(
         self._emit_event("controller.refresh.actions.started")
 
         # Refresh project settings (used for actions discovery)
-        self._project_settings = {}
+        self._settings_model.reset()
         # Refresh projects - they define applications
         self._projects_model.reset()
         # Refresh actions

--- a/client/ayon_core/tools/loader/abstract.py
+++ b/client/ayon_core/tools/loader/abstract.py
@@ -498,6 +498,10 @@ class BackendLoaderController(_BaseLoaderController):
         pass
 
     @abstractmethod
+    def get_project_settings(self, project_name: str | None) -> dict:
+        pass
+
+    @abstractmethod
     def get_product_type_icons_mapping(
         self, project_name: Optional[str]
     ) -> ProductTypeIconMapping:

--- a/client/ayon_core/tools/loader/control.py
+++ b/client/ayon_core/tools/loader/control.py
@@ -6,7 +6,6 @@ from typing import Optional, Any
 
 import ayon_api
 
-from ayon_core.settings import get_project_settings
 from ayon_core.pipeline import get_current_host_name
 from ayon_core.lib import (
     NestedCacheItem,
@@ -17,6 +16,7 @@ from ayon_core.lib.events import QueuedEventSystem
 from ayon_core.pipeline import Anatomy, get_current_context
 from ayon_core.host import ILoadHost, AbstractHost
 from ayon_core.tools.common_models import (
+    SettingsModel,
     ProjectsModel,
     HierarchyModel,
     ThumbnailsModel,
@@ -119,6 +119,8 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
 
         self._event_system = self._create_event_system()
 
+        self._project_settings = {}
+
         self._project_anatomy_cache = NestedCacheItem(
             levels=1, lifetime=60)
         self._loaded_products_cache = CacheItem(
@@ -133,6 +135,7 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
         self._thumbnails_model = ThumbnailsModel()
         self._sitesync_model = SiteSyncModel(self)
         self._users_model = UsersModel(self)
+        self._settings_model = SettingsModel()
 
     @property
     def log(self):
@@ -165,6 +168,8 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
         project_name = self.get_selected_project_name()
         folder_ids = self.get_selected_folder_ids()
 
+        self._project_settings = {}
+
         self._project_anatomy_cache.reset()
         self._loaded_products_cache.reset()
 
@@ -175,6 +180,7 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
         self._thumbnails_model.reset()
         self._sitesync_model.reset()
         self._users_model.reset()
+        self._settings_model.reset()
 
         self._projects_model.refresh()
 
@@ -267,6 +273,9 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
         return self._hierarchy_model.get_available_tags_by_entity_type(
             project_name
         )
+
+    def get_project_settings(self, project_name: str | None) -> dict:
+        return self._settings_model.get_settings(project_name)
 
     def get_project_anatomy_tags(self, project_name: str) -> list[TagItem]:
         return self._projects_model.get_project_anatomy_tags(project_name)
@@ -523,7 +532,7 @@ class LoaderController(BackendLoaderController, FrontendLoaderController):
         project_name = context.get("project_name")
         if not project_name:
             return output
-        settings = get_project_settings(project_name)
+        settings = self.get_project_settings(project_name)
         profiles = (
             settings
             ["core"]

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -194,6 +194,10 @@ class AbstractPublisherBackend(AbstractPublisherCommon):
         pass
 
     @abstractmethod
+    def get_project_settings(self, project_name: str | None) -> dict:
+        pass
+
+    @abstractmethod
     def get_project_entity(
         self, project_name: str
     ) -> Union[Dict[str, Any], None]:

--- a/client/ayon_core/tools/publisher/control.py
+++ b/client/ayon_core/tools/publisher/control.py
@@ -19,6 +19,7 @@ from ayon_core.tools.common_models import (
 )
 
 from .models import (
+    SettingsModel,
     PublishModel,
     CreateModel,
 )
@@ -100,6 +101,7 @@ class PublisherController(
         self._host = registered_host()
         self._headless = headless
 
+        self._settings_model = SettingsModel(self)
         self._create_model = CreateModel(self)
         self._publish_model = PublishModel(self)
 
@@ -239,6 +241,9 @@ class PublisherController(
 
     def get_convertor_items(self):
         return self._create_model.get_convertor_items()
+
+    def get_project_settings(self, project_name: str | None) -> dict:
+        return self._settings_model.get_settings(project_name)
 
     def get_project_entity(self, project_name):
         return self._projects_model.get_project_entity(project_name)
@@ -384,6 +389,7 @@ class PublisherController(
         self._users_model.reset()
 
         # Publish part must be reset after plugins
+        self._settings_model.reset()
         self._create_model.reset()
         self._publish_model.reset()
 

--- a/client/ayon_core/tools/push_to_project/control.py
+++ b/client/ayon_core/tools/push_to_project/control.py
@@ -5,7 +5,6 @@ from typing import Dict
 
 import ayon_api
 
-from ayon_core.settings import get_project_settings
 from ayon_core.lib import prepare_template_data
 from ayon_core.lib.events import QueuedEventSystem
 from ayon_core.pipeline.create import get_product_name_template
@@ -16,6 +15,7 @@ from ayon_core.tools.common_models import (
 )
 
 from .models import (
+    SettingsModel,
     PushToProjectSelectionModel,
     UserPublishValuesModel,
     IntegrateModel,
@@ -27,6 +27,7 @@ class PushToContextController:
     def __init__(self, project_name=None, version_ids=None):
         self._event_system = self._create_event_system()
 
+        self._settings_model = SettingsModel()
         self._projects_model = ProjectsModel(self)
         self._hierarchy_model = HierarchyModel(self)
         self._integrate_model = IntegrateModel(self)
@@ -150,6 +151,9 @@ class PushToContextController:
         if self._src_label is None:
             self._src_label = self._prepare_source_label()
         return self._src_label
+
+    def get_project_settings(self, project_name):
+        return self._settings_model.get_settings(project_name)
 
     def get_project_items(self, sender=None):
         return self._projects_model.get_project_items(sender)
@@ -322,7 +326,7 @@ class PushToContextController:
             version_entity["productId"]
         )
 
-        project_settings = get_project_settings(project_name)
+        project_settings = self.get_project_settings(project_name)
         product_base_type = product_entity.get("productBaseType")
         product_type = product_entity["productType"]
         if not product_base_type:

--- a/client/ayon_core/tools/utils/tasks_widget.py
+++ b/client/ayon_core/tools/utils/tasks_widget.py
@@ -312,7 +312,6 @@ class TasksQtModel(QtGui.QStandardItemModel):
         Args:
             thread_id (str): Thread id.
         """
-
         # Make sure to remove thread from '_refresh_threads' dict
         thread = self._refresh_threads.pop(thread_id)
         if (
@@ -460,6 +459,7 @@ class TasksWidget(QtWidgets.QWidget):
         """
         self._use_task_type_sorting = None
         self._update_task_type_sorting()
+        self._tasks_proxy_model.sort(0)
         self._tasks_model.refresh()
 
     def get_selected_task_info(self):

--- a/client/ayon_core/tools/utils/tasks_widget.py
+++ b/client/ayon_core/tools/utils/tasks_widget.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from qtpy import QtWidgets, QtGui, QtCore
 
+from ayon_core.lib import Logger
 from ayon_core.style import (
     get_disabled_entity_icon_color,
     get_default_entity_icon_color,
@@ -354,6 +355,7 @@ class TasksProxyModel(QtCore.QSortFilterProxyModel):
         super().__init__()
 
         self._task_ids_filter: Optional[set[str]] = None
+        self._task_type_sorting_enabled = False
 
     def set_task_ids_filter(self, task_ids: Optional[set[str]]):
         if self._task_ids_filter == task_ids:
@@ -361,11 +363,20 @@ class TasksProxyModel(QtCore.QSortFilterProxyModel):
         self._task_ids_filter = task_ids
         self.invalidateFilter()
 
+    def set_task_type_sorting_enabled(self, enabled: bool):
+        if self._task_type_sorting_enabled is not enabled:
+            self._task_type_sorting_enabled = enabled
+
     def lessThan(self, source_left, source_right):
-        left_sort = source_left.data(TASK_TYPE_ORDER_ROLE)
-        right_sort = source_right.data(TASK_TYPE_ORDER_ROLE)
-        if left_sort is not None and right_sort is not None:
-            return left_sort < right_sort
+        if self._task_type_sorting_enabled:
+            left_sort = source_left.data(TASK_TYPE_ORDER_ROLE)
+            right_sort = source_right.data(TASK_TYPE_ORDER_ROLE)
+            if (
+                left_sort is not None
+                and right_sort is not None
+                and left_sort != right_sort
+            ):
+                return left_sort < right_sort
         return super().lessThan(source_left, source_right)
 
     def filterAcceptsRow(self, row, parent_index):
@@ -438,13 +449,15 @@ class TasksWidget(QtWidgets.QWidget):
         self._handle_expected_selection = handle_expected_selection
         self._expected_selection_data = None
 
+        self._use_task_type_sorting = None
+
     def refresh(self):
         """Refresh folders for last selected project.
 
         Force to update folders model from controller. This may or may not
         trigger query from server, that's based on controller's cache.
         """
-
+        self._use_task_type_sorting = None
         self._tasks_model.refresh()
 
     def get_selected_task_info(self):
@@ -551,6 +564,7 @@ class TasksWidget(QtWidgets.QWidget):
             or event["folder_id"] != self._selected_folder_id
         ):
             return
+
         self._tasks_model.set_context(
             event["project_name"], self._selected_folder_id
         )
@@ -564,6 +578,9 @@ class TasksWidget(QtWidgets.QWidget):
     def _on_tasks_model_refresh(self):
         if not self._set_expected_selection():
             self._on_selection_change()
+
+        self._update_task_type_sorting()
+
         self._tasks_proxy_model.sort(0)
         self.refreshed.emit()
 
@@ -612,6 +629,32 @@ class TasksWidget(QtWidgets.QWidget):
                 self._tasks_view.setCurrentIndex(proxy_index)
         self._controller.expected_task_selected(folder_id, task_name)
         return True
+
+    def _update_task_type_sorting(self):
+        if self._use_task_type_sorting is not None:
+            return
+
+        project_name = self._tasks_model.get_last_project_name()
+        if project_name is None:
+            return
+
+        use_task_type_sorting = False
+        if hasattr(self._controller, "get_project_settings"):
+            settings = self._controller.get_project_settings(project_name)
+            use_task_type_sorting = (
+                settings["tools"]["general"]["use_task_type_sorting"]
+            )
+        else:
+            log.warning(
+                "Controller '{self._controller}' doesn't have"
+                " 'get_project_settings' method, task type"
+                " sorting will be disabled."
+            )
+
+        self._use_task_type_sorting = use_task_type_sorting
+        self._tasks_proxy_model.set_task_type_sorting_enabled(
+            self._use_task_type_sorting
+        )
 
     def _update_expected_selection(self, expected_data=None):
         if not self._handle_expected_selection:

--- a/client/ayon_core/tools/utils/tasks_widget.py
+++ b/client/ayon_core/tools/utils/tasks_widget.py
@@ -459,6 +459,7 @@ class TasksWidget(QtWidgets.QWidget):
         trigger query from server, that's based on controller's cache.
         """
         self._use_task_type_sorting = None
+        self._update_task_type_sorting()
         self._tasks_model.refresh()
 
     def get_selected_task_info(self):

--- a/client/ayon_core/tools/utils/tasks_widget.py
+++ b/client/ayon_core/tools/utils/tasks_widget.py
@@ -400,6 +400,7 @@ class TasksWidget(QtWidgets.QWidget):
         parent (QtWidgets.QWidget): Parent widget.
         handle_expected_selection (Optional[bool]): Handle expected selection.
     """
+    log = Logger.get_logger("TasksWidget")
 
     refreshed = QtCore.Signal()
     selection_changed = QtCore.Signal()
@@ -645,8 +646,8 @@ class TasksWidget(QtWidgets.QWidget):
                 settings["tools"]["general"]["use_task_type_sorting"]
             )
         else:
-            log.warning(
-                "Controller '{self._controller}' doesn't have"
+            self.log.warning(
+                f"Controller '{self._controller}' doesn't have"
                 " 'get_project_settings' method, task type"
                 " sorting will be disabled."
             )

--- a/client/ayon_core/tools/utils/tasks_widget.py
+++ b/client/ayon_core/tools/utils/tasks_widget.py
@@ -643,7 +643,7 @@ class TasksWidget(QtWidgets.QWidget):
         if hasattr(self._controller, "get_project_settings"):
             settings = self._controller.get_project_settings(project_name)
             use_task_type_sorting = (
-                settings["tools"]["general"]["use_task_type_sorting"]
+                settings["core"]["tools"]["general"]["use_task_type_sorting"]
             )
         else:
             self.log.warning(

--- a/client/ayon_core/tools/workfiles/abstract.py
+++ b/client/ayon_core/tools/workfiles/abstract.py
@@ -276,6 +276,10 @@ class AbstractWorkfilesBackend(AbstractWorkfilesCommon):
         """
         pass
 
+    @abstractmethod
+    def get_project_settings(self, project_name: str | None) -> dict:
+        pass
+
     @property
     @abstractmethod
     def project_anatomy(self):

--- a/client/ayon_core/tools/workfiles/control.py
+++ b/client/ayon_core/tools/workfiles/control.py
@@ -10,8 +10,8 @@ from ayon_core.lib import Logger, get_ayon_username
 from ayon_core.lib.events import QueuedEventSystem
 from ayon_core.pipeline import Anatomy, registered_host
 from ayon_core.pipeline.context_tools import get_global_context
-from ayon_core.settings import get_project_settings
 from ayon_core.tools.common_models import (
+    SettingsModel,
     HierarchyExpectedSelection,
     HierarchyModel,
     ProjectsModel,
@@ -143,7 +143,6 @@ class BaseWorkfileController(
         self._host_is_valid = host_is_valid
 
         self._project_anatomy = None
-        self._project_settings = None
         self._event_system = None
         self._log = None
         self._username = NOT_SET
@@ -155,6 +154,7 @@ class BaseWorkfileController(
         self._save_is_enabled = True
 
         # Expected selected folder and task
+        self._settings_model = SettingsModel()
         self._users_model = self._create_users_model()
         self._expected_selection = self._create_expected_selection_obj()
         self._selection_model = self._create_selection_model()
@@ -212,12 +212,12 @@ class BaseWorkfileController(
     # ----------------------------------------------------
     # Implementation of methods required for backend logic
     # ----------------------------------------------------
+    def get_project_settings(self, project_name):
+        return self._settings_model.get_settings(project_name)
+
     @property
     def project_settings(self):
-        if self._project_settings is None:
-            self._project_settings = get_project_settings(
-                self.get_current_project_name())
-        return self._project_settings
+        return self.get_project_settings(self.get_current_project_name())
 
     @property
     def project_anatomy(self):
@@ -499,7 +499,6 @@ class BaseWorkfileController(
             if folder:
                 folder_id = folder["id"]
 
-        self._project_settings = None
         self._project_anatomy = None
 
         self._current_project_name = project_name
@@ -507,6 +506,8 @@ class BaseWorkfileController(
         self._current_folder_id = folder_id
         self._current_task_name = task_name
 
+        self._settings_model.reset()
+        self._users_model.reset()
         self._projects_model.reset()
         self._hierarchy_model.reset()
         self._workfiles_model.reset()

--- a/client/ayon_core/tools/workfiles/widgets/window.py
+++ b/client/ayon_core/tools/workfiles/widgets/window.py
@@ -345,6 +345,8 @@ class WorkfilesToolWindow(QtWidgets.QWidget):
 
         self._project_name = self._controller.get_current_project_name()
         self._folders_widget.set_project_name(self._project_name)
+        self._tasks_widget.refresh()
+
         # Update my tasks
         self._on_my_tasks_checkbox_state_changed(
             self._filters_widget.is_my_tasks_checked()

--- a/server/settings/tools.py
+++ b/server/settings/tools.py
@@ -203,6 +203,16 @@ class AYONMenuModel(BaseSettingsModel):
     )
 
 
+class GeneralToolsModel(BaseSettingsModel):
+    use_task_type_sorting: bool = SettingsField(
+        True,
+        title="Use task type sorting",
+        description=(
+            "Sort tasks in UIs based on task types order in Anatomy."
+        )
+    )
+
+
 class WorkfilesToolModel(BaseSettingsModel):
     workfile_template_profiles: list[WorkfileTemplateProfile] = SettingsField(
         default_factory=list,
@@ -445,6 +455,10 @@ class GlobalToolsModel(BaseSettingsModel):
     ayon_menu: AYONMenuModel = SettingsField(
         default_factory=AYONMenuModel,
         title="AYON Menu"
+    )
+    general: GeneralToolsModel = SettingsField(
+        default_factory=GeneralToolsModel,
+        title="General"
     )
     creator: CreatorToolModel = SettingsField(
         default_factory=CreatorToolModel,


### PR DESCRIPTION
## Changelog Description
Added settings to be able to disable task type sorting.

## Additional info
Task type sorting might be confusing for artists, Qt implementation does not allow that option by default and would require more work to be able to define multiple sorting options in UI. So the easiest solution is to add settings for it.

## Testing notes:
Settings `ayon+settings://core/tools/general/use_task_type_sorting`.
1. Tasks in UIs are sorted with task types in mind if the checkbox is enabled.
2. Tasks in UIs are NOT sorted with task types in mind if the checkbox is enabled.

Resolves https://github.com/ynput/ayon-core/issues/1829