### PR TITLE
Publisher: Fix `SettingsModel`

### DIFF
--- a/client/ayon_core/tools/publisher/control.py
+++ b/client/ayon_core/tools/publisher/control.py
@@ -13,13 +13,13 @@ from ayon_core.pipeline import (
     get_process_id,
 )
 from ayon_core.tools.common_models import (
+    SettingsModel,
     ProjectsModel,
     HierarchyModel,
     UsersModel,
 )
 
 from .models import (
-    SettingsModel,
     PublishModel,
     CreateModel,
 )
@@ -101,7 +101,7 @@ class PublisherController(
         self._host = registered_host()
         self._headless = headless
 
-        self._settings_model = SettingsModel(self)
+        self._settings_model = SettingsModel()
         self._create_model = CreateModel(self)
         self._publish_model = PublishModel(self)
 


### PR DESCRIPTION
## Changelog Description

Fix publisher after merge of https://github.com/ynput/ayon-core/pull/1833

## Additional info

Fixes non-existing import.

```py
# Error: cannot import name 'SettingsModel' from 'ayon_core.tools.publisher.models' (C:\Users\User\AppData\Local\Ynput\AYON\addons\core_1.9.2+dev\ayon_core\tools\publisher\models\__init__.py)
# # Traceback (most recent call last):
# #   File "C:\Users\User\AppData\Local\Ynput\AYON\addons\maya_0.6.3+dev\ayon_maya\api\menu.py", line 117, in <lambda>
# #     command=lambda *args: host_tools.show_publisher(
# #   File "C:\Users\User\AppData\Local\Ynput\AYON\addons\core_1.9.2+dev\ayon_core\tools\utils\host_tools.py", line 334, in show_publisher
# #     _SingletonPoint.show_tool_by_name("publisher", parent, **kwargs)
# #   File "C:\Users\User\AppData\Local\Ynput\AYON\addons\core_1.9.2+dev\ayon_core\tools\utils\host_tools.py", line 292, in show_tool_by_name
# #     cls.helper.show_tool_by_name(tool_name, parent, *args, **kwargs)
# #   File "C:\Users\User\AppData\Local\Ynput\AYON\addons\core_1.9.2+dev\ayon_core\tools\utils\host_tools.py", line 264, in show_tool_by_name
# #     self.show_publisher_tool(parent, *args, **kwargs)
# #   File "C:\Users\User\AppData\Local\Ynput\AYON\addons\core_1.9.2+dev\ayon_core\tools\utils\host_tools.py", line 206, in show_publisher_tool
# #     window = self.get_publisher_tool(parent, controller)
# #   File "C:\Users\User\AppData\Local\Ynput\AYON\addons\core_1.9.2+dev\ayon_core\tools\utils\host_tools.py", line 191, in get_publisher_tool
# #     from ayon_core.tools.publisher.window import PublisherWindow
# #   File "C:\Users\User\AppData\Local\Ynput\AYON\addons\core_1.9.2+dev\ayon_core\tools\publisher\window.py", line 27, in <module>
# #     from .control_qt import QtPublisherController
# #   File "C:\Users\User\AppData\Local\Ynput\AYON\addons\core_1.9.2+dev\ayon_core\tools\publisher\control_qt.py", line 5, in <module>
# #     from .control import PublisherController
# #   File "C:\Users\User\AppData\Local\Ynput\AYON\addons\core_1.9.2+dev\ayon_core\tools\publisher\control.py", line 21, in <module>
# #     from .models import (
# # ImportError: cannot import name 'SettingsModel' from 'ayon_core.tools.publisher.models' (C:\Users\User\AppData\Local\Ynput\AYON\addons\core_1.9.2+dev\ayon_core\tools\publisher\models\__init__.py)
```

## Testing notes:

1. Publisher should work
