### PR TITLE
Publisher: Fix type hints annotations

### DIFF
--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, asdict
 from typing import (

--- a/client/ayon_core/tools/publisher/control.py
+++ b/client/ayon_core/tools/publisher/control.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import logging
 import tempfile


### PR DESCRIPTION
## Changelog Description
Fix typehits annotations.

## Additional info
There was added typehint that is not compatible with older pythons, added futures import of annotations to avoid issues.

## Testing notes:
1. Traypublisher works with AYON launcher 1.5.4.
