### PR TITLE
macOs: Use `open` only for app bundles

### DIFF
--- a/client/ayon_core/lib/execute.py
+++ b/client/ayon_core/lib/execute.py
@@ -249,9 +249,14 @@ def run_detached_process(args, **kwargs):
 
     low_platform = platform.system().lower()
     if low_platform == "darwin":
-        new_args = ["open", "-na", args.pop(0), "--args"]
-        new_args.extend(args)
-        args = new_args
+        executable = args[0]
+        # If it's a macOS app bundle, use open -na
+        if executable.endswith(".app") or "/Contents/MacOS/" in executable:
+            new_args = ["open", "-na", args.pop(0), "--args"]
+            new_args.extend(args)
+            args = new_args
+        else:
+            kwargs["start_new_session "] = True
 
     elif low_platform == "windows":
         flags = (

--- a/client/ayon_core/lib/execute.py
+++ b/client/ayon_core/lib/execute.py
@@ -256,7 +256,7 @@ def run_detached_process(args, **kwargs):
             new_args.extend(args)
             args = new_args
         else:
-            kwargs["start_new_session "] = True
+            kwargs["start_new_session"] = True
 
     elif low_platform == "windows":
         flags = (


### PR DESCRIPTION
## Changelog Description
Run detached process on macos does not use `open` command for non-bundle applications (like python) and instead uses `start_new_session`.

## Additional info
This should fix few issues on macOs, for example running webactions from launcher tool.

## Testing notes:
1. Launch of applications should work as expected.
2. Webactions started from launcher tool should work on macOs (while running AYON launcher from code).