### PR TITLE
Launcher tool: Sort webactions by order from server

### DIFF
--- a/client/ayon_core/tools/launcher/abstract.py
+++ b/client/ayon_core/tools/launcher/abstract.py
@@ -34,6 +34,7 @@ class ActionItem:
         action_type (Literal["webaction", "local"]): Type of action.
         identifier (str): Unique identifier of action item.
         order (int): Action ordering.
+        suborder (int): Internal ordering used for webactions order.
         label (str): Action label.
         variant_label (Optional[str]): Variant label, full label is
             concatenated with space. Actions are grouped under single
@@ -49,6 +50,7 @@ class ActionItem:
     action_type: str
     identifier: str
     order: int
+    suborder: int
     label: str
     variant_label: Optional[str]
     full_label: str

--- a/client/ayon_core/tools/launcher/models/actions.py
+++ b/client/ayon_core/tools/launcher/models/actions.py
@@ -631,6 +631,7 @@ class ActionsModel:
                 self.log.warning(
                     f"Got action without order. Identifier: {identifier}"
                 )
+
             item = ActionItem(
                 action_type="local",
                 identifier=identifier,

--- a/client/ayon_core/tools/launcher/models/actions.py
+++ b/client/ayon_core/tools/launcher/models/actions.py
@@ -436,7 +436,7 @@ class ActionsModel:
             return []
 
         action_items = []
-        for action in response.data["actions"]:
+        for idx, action in enumerate(response.data["actions"]):
             # NOTE Settings variant may be important for triggering?
             # - action["variant"]
             icon = action.get("icon")
@@ -454,10 +454,19 @@ class ActionsModel:
             full_label = self.calculate_full_label(
                 group_label, variant_label
             )
+            identifier = action["identifier"]
+            order = action["order"]
+            if order is None:
+                order = 0
+                self.log.warning(
+                    f"Got webaction without order. Identifier: {identifier}"
+                )
+
             action_items.append(ActionItem(
                 action_type="webaction",
                 identifier=action["identifier"],
-                order=action["order"],
+                order=order,
+                suborder=idx,
                 label=group_label,
                 variant_label=variant_label,
                 full_label=full_label,
@@ -615,11 +624,18 @@ class ActionsModel:
                 label, variant_label
             )
             icon = get_action_icon(action)
-
+            order = action.order
+            # Make sure it is not 'None'
+            if order is None:
+                order = 0
+                self.log.warning(
+                    f"Got action without order. Identifier: {identifier}"
+                )
             item = ActionItem(
                 action_type="local",
                 identifier=identifier,
-                order=action.order,
+                order=order,
+                suborder=0,
                 label=label,
                 variant_label=variant_label,
                 full_label=full_label,

--- a/client/ayon_core/tools/launcher/ui/actions_widget.py
+++ b/client/ayon_core/tools/launcher/ui/actions_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 import collections
 import platform
@@ -19,12 +21,13 @@ ACTION_ID_ROLE = QtCore.Qt.UserRole + 1
 ACTION_TYPE_ROLE = QtCore.Qt.UserRole + 2
 ACTION_IS_GROUP_ROLE = QtCore.Qt.UserRole + 3
 ACTION_HAS_CONFIGS_ROLE = QtCore.Qt.UserRole + 4
-ACTION_SORT_ROLE = QtCore.Qt.UserRole + 5
-ACTION_ADDON_NAME_ROLE = QtCore.Qt.UserRole + 6
-ACTION_ADDON_VERSION_ROLE = QtCore.Qt.UserRole + 7
-PLACEHOLDER_ITEM_ROLE = QtCore.Qt.UserRole + 8
-ANIMATION_START_ROLE = QtCore.Qt.UserRole + 9
-ANIMATION_STATE_ROLE = QtCore.Qt.UserRole + 10
+ACTION_ORDER_ROLE = QtCore.Qt.UserRole + 5
+ACTION_SUBORDER_ROLE = QtCore.Qt.UserRole + 6
+ACTION_ADDON_NAME_ROLE = QtCore.Qt.UserRole + 7
+ACTION_ADDON_VERSION_ROLE = QtCore.Qt.UserRole + 8
+PLACEHOLDER_ITEM_ROLE = QtCore.Qt.UserRole + 9
+ANIMATION_START_ROLE = QtCore.Qt.UserRole + 10
+ANIMATION_STATE_ROLE = QtCore.Qt.UserRole + 11
 
 
 def _variant_label_sort_getter(action_item):
@@ -260,7 +263,8 @@ class ActionsQtModel(QtGui.QStandardItemModel):
             item.setData(action_item.action_type, ACTION_TYPE_ROLE)
             item.setData(action_item.addon_name, ACTION_ADDON_NAME_ROLE)
             item.setData(action_item.addon_version, ACTION_ADDON_VERSION_ROLE)
-            item.setData(action_item.order, ACTION_SORT_ROLE)
+            item.setData(action_item.order, ACTION_ORDER_ROLE)
+            item.setData(action_item.suborder, ACTION_SUBORDER_ROLE)
             items_by_id[action_item.identifier] = item
 
         if new_items:
@@ -344,7 +348,8 @@ class ActionMenuPopupModel(QtGui.QStandardItemModel):
                 bool(action_item.config_fields),
                 ACTION_HAS_CONFIGS_ROLE
             )
-            item.setData(action_item.order, ACTION_SORT_ROLE)
+            item.setData(action_item.order, ACTION_ORDER_ROLE)
+            item.setData(action_item.suborder, ACTION_SUBORDER_ROLE)
 
             new_items.append(item)
 
@@ -820,24 +825,16 @@ class ActionsProxyModel(QtCore.QSortFilterProxyModel):
         if right.data(PLACEHOLDER_ITEM_ROLE):
             return False
 
-        left_value = left.data(ACTION_SORT_ROLE)
-        right_value = right.data(ACTION_SORT_ROLE)
+        left_order_value: int = left.data(ACTION_ORDER_ROLE) or 0
+        right_order_value: int = right.data(ACTION_ORDER_ROLE) or 0
+        if left_order_value != right_order_value:
+            return left_order_value < right_order_value
 
-        # Values are same -> use super sorting
-        if left_value == right_value:
-            # Default behavior is using DisplayRole
-            return super().lessThan(left, right)
-
-        # Validate 'None' values
-        if right_value is None:
-            return True
-        if left_value is None:
-            return False
-        # Sort values and handle incompatible types
-        try:
-            return left_value < right_value
-        except TypeError:
-            return True
+        left_suborder_value: int = left.data(ACTION_SUBORDER_ROLE) or 0
+        right_suborder_value: int = right.data(ACTION_SUBORDER_ROLE) or 0
+        if left_suborder_value != right_suborder_value:
+            return left_suborder_value < right_suborder_value
+        return super().lessThan(left, right)
 
 
 class ActionsView(QtWidgets.QListView):


### PR DESCRIPTION
## Changelog Description
Sort webactions by order from server.

## Additional info
Launcher did sort actions by group label and variable label, but web UI shows actions in order it is returned from server (in case they have same value of `order`). That was recently used to define order of applications in applications addon, to allow that sorting in launcher UI it was necessary to handle the actions the same way.

In order to achieve that a `suborder` was added to `ActionItem` which is used only for the tool UI purposes. Value of `suborder` is filled with an idex of the action returned from server and is also used in proxy as additional sorting option.

## Testing notes:
1. Can be tested with `https://github.com/ynput/ayon-applications/pull/145` where applications actions can be sorted in different order.
2. If you change the order of applications in settings it should be propagated in launcher tool.
