### PR TITLE
Launcher tool: Remove backwards compatibility

### DIFF
--- a/client/ayon_core/tools/launcher/models/actions.py
+++ b/client/ayon_core/tools/launcher/models/actions.py
@@ -256,17 +256,7 @@ class ActionsModel:
                 }
             )
 
-            conn = ayon_api.get_server_api_connection()
-            # Add 'referer' header to the request
-            # - ayon-api 1.1.1 adds the value to the header automatically
-            headers = conn.get_headers()
-            if "referer" in headers:
-                headers = None
-            else:
-                headers["referer"] = conn.get_base_url()
-            response = ayon_api.raw_post(
-                url, headers=headers, json=request_data
-            )
+            response = ayon_api.raw_post(url, json=request_data)
             response.raise_for_status()
             handle_response = self._handle_webaction_response(response.data)
 


### PR DESCRIPTION
## Changelog Description
Remove actions execute backwards compatibility.

## Additional info
The core addon already requires launcher 1.5.4 which does include newer ayon api so the BW is not needed anymore.

## Testing notes:
1. Validate code changes.
