### PR TITLE
Finish inspector representations.

### DIFF
--- a/client/ayon_core/tests/tools/loader/ui/test_review_controller.py
+++ b/client/ayon_core/tests/tools/loader/ui/test_review_controller.py
@@ -1,6 +1,7 @@
 from ayon_ui_qt.components.table_model import BatchFetchRequest
 
 from ayon_core.tools.loader.ui.review_controller import ReviewController
+from ayon_core.tools.loader.control import LoaderController
 
 
 def _make_request(
@@ -22,7 +23,7 @@ def _make_request(
 def test_fetch_product_group_headers_fetches_all_pages_and_deduplicates(
     monkeypatch,
 ):
-    controller = ReviewController(None)
+    controller = ReviewController(LoaderController())
     controller._current_project = "test_project"
     controller._selected_folder_ids = ["folder_A"]
 
@@ -101,7 +102,7 @@ def test_fetch_product_group_headers_fetches_all_pages_and_deduplicates(
 def test_fetch_versions_page_batch_page_zero_prepends_folders_and_tracks_cursors(
     monkeypatch,
 ):
-    controller = ReviewController(None)
+    controller = ReviewController(LoaderController())
     controller._current_project = "test_project"
     controller._folder_cursors = {"A": "stale", "B": "stale"}
     controller._folder_has_more = {"A": True, "B": True}
@@ -168,7 +169,7 @@ def test_fetch_versions_page_batch_page_zero_prepends_folders_and_tracks_cursors
 def test_fetch_versions_page_batch_continuation_uses_each_parent_cursor(
     monkeypatch,
 ):
-    controller = ReviewController(None)
+    controller = ReviewController(LoaderController())
     controller._current_project = "test_project"
     controller._folder_cursors = {"A": "cursor:A", "B": "cursor:B"}
     controller._folder_has_more = {"A": True, "B": False}

--- a/client/ayon_core/tests/tools/loader/ui/test_review_controller.py
+++ b/client/ayon_core/tests/tools/loader/ui/test_review_controller.py
@@ -22,7 +22,7 @@ def _make_request(
 def test_fetch_product_group_headers_fetches_all_pages_and_deduplicates(
     monkeypatch,
 ):
-    controller = ReviewController()
+    controller = ReviewController(None)
     controller._current_project = "test_project"
     controller._selected_folder_id = "folder_A"
 
@@ -101,7 +101,7 @@ def test_fetch_product_group_headers_fetches_all_pages_and_deduplicates(
 def test_fetch_versions_page_batch_page_zero_prepends_folders_and_tracks_cursors(
     monkeypatch,
 ):
-    controller = ReviewController()
+    controller = ReviewController(None)
     controller._current_project = "test_project"
     controller._folder_cursors = {"A": "stale", "B": "stale"}
     controller._folder_has_more = {"A": True, "B": True}
@@ -168,7 +168,7 @@ def test_fetch_versions_page_batch_page_zero_prepends_folders_and_tracks_cursors
 def test_fetch_versions_page_batch_continuation_uses_each_parent_cursor(
     monkeypatch,
 ):
-    controller = ReviewController()
+    controller = ReviewController(None)
     controller._current_project = "test_project"
     controller._folder_cursors = {"A": "cursor:A", "B": "cursor:B"}
     controller._folder_has_more = {"A": True, "B": False}

--- a/client/ayon_core/tests/tools/loader/ui/test_review_controller.py
+++ b/client/ayon_core/tests/tools/loader/ui/test_review_controller.py
@@ -24,7 +24,7 @@ def test_fetch_product_group_headers_fetches_all_pages_and_deduplicates(
 ):
     controller = ReviewController(None)
     controller._current_project = "test_project"
-    controller._selected_folder_id = "folder_A"
+    controller._selected_folder_ids = ["folder_A"]
 
     calls: list[str | None] = []
 

--- a/client/ayon_core/tools/loader/ui/review_controller.py
+++ b/client/ayon_core/tools/loader/ui/review_controller.py
@@ -660,12 +660,6 @@ class ReviewController(QtCore.QObject):
         Returns:
             List of :class:`ActionItem` objects.
         """
-        if not isinstance(self._loader_controller, LoaderController):
-            self.log.warning(
-                "get_action_items called but no loader controller is "
-                "available, returning empty list."
-            )
-            return []
         return self._loader_controller.get_action_items(
             project_name, entity_ids, entity_type
         )
@@ -689,12 +683,6 @@ class ReviewController(QtCore.QObject):
             List of :class:`~ayon_core.tools.loader.abstract.RepreItem`
             objects.
         """
-        if not isinstance(self._loader_controller, LoaderController):
-            self.log.warning(
-                "get_representation_items called but no loader controller is "
-                "available, returning empty list."
-            )
-            return []
         return self._loader_controller.get_representation_items(
             project_name, version_ids
         )
@@ -724,12 +712,6 @@ class ReviewController(QtCore.QObject):
             options: Loader option values.
             form_values: Form values returned by the action dialog.
         """
-        if not isinstance(self._loader_controller, LoaderController):
-            self.log.warning(
-                "trigger_action_item called but no loader controller is "
-                "available, action will not be triggered."
-            )
-            return
         self._loader_controller.trigger_action_item(
             identifier=identifier,
             project_name=project_name,

--- a/client/ayon_core/tools/loader/ui/review_controller.py
+++ b/client/ayon_core/tools/loader/ui/review_controller.py
@@ -879,6 +879,7 @@ class ReviewController(QtCore.QObject):
                 "product/version__icon": icon or "label",
                 "entityType": group_option.label,
                 "entityType__icon": group_option.icon,
+                "project_name": self._current_project,
             }
         )
         if color:

--- a/client/ayon_core/tools/loader/ui/review_controller.py
+++ b/client/ayon_core/tools/loader/ui/review_controller.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import datetime
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import ayon_api
 from ayon_api.graphql_queries import projects_graphql_query
@@ -17,6 +17,7 @@ from qtpy import QtCore
 
 from ayon_core.lib import Logger
 from ayon_core.tools.loader.abstract import ActionItem
+from ayon_core.tools.loader.control import LoaderController
 from ayon_core.tools.loader.ui.review_group_by import (
     BUILTIN_GROUPS,
     GROUP_BY_NONE_KEY,
@@ -37,11 +38,6 @@ from ayon_core.tools.loader.ui.review_queries import (
 )
 from ayon_core.tools.loader.ui.review_types import ReviewCategory
 from ayon_core.tools.utils.user_prefs import UserPreferences
-
-if TYPE_CHECKING:
-    from ayon_core.tools.loader.abstract import (
-        FrontendLoaderController,
-    )
 
 # Maximum number of pages to fetch when building product group headers.
 # Each page contains up to 1 000 products, so this caps the total at
@@ -79,8 +75,8 @@ class ReviewController(QtCore.QObject):
 
     def __init__(
         self,
+        loader_controller: LoaderController,
         parent: QtCore.QObject | None = None,
-        loader_controller: FrontendLoaderController | None = None,
     ) -> None:
         super().__init__(parent)
         self._loader_controller = loader_controller
@@ -439,7 +435,8 @@ class ReviewController(QtCore.QObject):
             # the tree can be navigated depth-first all the way down to
             # version leaves.
             folder_rows = (
-                self._get_child_folder_rows(parent_id) if page_number == 0
+                self._get_child_folder_rows(parent_id)
+                if page_number == 0
                 else []
             )
 
@@ -663,7 +660,11 @@ class ReviewController(QtCore.QObject):
         Returns:
             List of :class:`ActionItem` objects.
         """
-        if self._loader_controller is None:
+        if not isinstance(self._loader_controller, LoaderController):
+            self.log.warning(
+                "get_action_items called but no loader controller is "
+                "available, returning empty list."
+            )
             return []
         return self._loader_controller.get_action_items(
             project_name, entity_ids, entity_type
@@ -688,7 +689,11 @@ class ReviewController(QtCore.QObject):
             List of :class:`~ayon_core.tools.loader.abstract.RepreItem`
             objects.
         """
-        if self._loader_controller is None:
+        if not isinstance(self._loader_controller, LoaderController):
+            self.log.warning(
+                "get_representation_items called but no loader controller is "
+                "available, returning empty list."
+            )
             return []
         return self._loader_controller.get_representation_items(
             project_name, version_ids
@@ -719,7 +724,11 @@ class ReviewController(QtCore.QObject):
             options: Loader option values.
             form_values: Form values returned by the action dialog.
         """
-        if self._loader_controller is None:
+        if not isinstance(self._loader_controller, LoaderController):
+            self.log.warning(
+                "trigger_action_item called but no loader controller is "
+                "available, action will not be triggered."
+            )
             return
         self._loader_controller.trigger_action_item(
             identifier=identifier,
@@ -893,9 +902,7 @@ class ReviewController(QtCore.QObject):
             )
             row["folderName"] = featured_version.get("parents", ["", ""])[-2]
             row["author"] = featured_version.get("author", "")
-            v_str = (
-                f"({num_versions} versions)" if num_versions else ""
-            )
+            v_str = f"({num_versions} versions)" if num_versions else ""
             row["version"] = (
                 f"{featured_version.get('name', '')} {v_str}".strip()
             )
@@ -1165,9 +1172,7 @@ class ReviewController(QtCore.QObject):
                 self._group_by_options[GROUP_BY_PRODUCT_KEY],
                 value=p_id,
                 label=p_name,
-                icon=self._pinfo(
-                    "productTypes", p_type, "icon", "view_in_ar"
-                ),
+                icon=self._pinfo("productTypes", p_type, "icon", "view_in_ar"),
                 color=self._pinfo("productTypes", p_type, "color"),
                 product_type=p_type,
                 featured_version=featured_v,
@@ -1543,23 +1548,18 @@ class ReviewController(QtCore.QObject):
         product_base_types = config.get("productBaseTypes", {})
         self._project_info["by_name"] = {
             "folderTypes": {
-                ft["name"]: ft
-                for ft in project_entity.get("folderTypes", [])
+                ft["name"]: ft for ft in project_entity.get("folderTypes", [])
             },
             "taskTypes": {
-                tt["name"]: tt
-                for tt in project_entity.get("taskTypes", [])
+                tt["name"]: tt for tt in project_entity.get("taskTypes", [])
             },
             "linkTypes": {
-                lt["name"]: lt
-                for lt in project_entity.get("linkTypes", [])
+                lt["name"]: lt for lt in project_entity.get("linkTypes", [])
             },
             "statuses": {
                 s["name"]: s for s in project_entity.get("statuses", [])
             },
-            "tags": {
-                t["name"]: t for t in project_entity.get("tags", [])
-            },
+            "tags": {t["name"]: t for t in project_entity.get("tags", [])},
             "productTypes": (
                 {
                     t["name"]: t

--- a/client/ayon_core/tools/loader/ui/review_inspector.py
+++ b/client/ayon_core/tools/loader/ui/review_inspector.py
@@ -13,6 +13,8 @@ from ayon_ui_qt.image_cache import ImageCache
 from qtpy import QtCore, QtGui, QtWidgets, shiboken
 
 from ayon_core.tools.loader.abstract import RepreItem
+from ayon_core.tools.loader.ui.actions_utils import show_actions_menu
+from ayon_core.tools.loader.ui.review_controller import ReviewController
 from ayon_core.tools.utils import get_qt_icon
 
 from ._review_thumbnails import _thumbnail_loader
@@ -29,7 +31,12 @@ def _str_wrap(text: str) -> str:
 class ReviewInspector(AYContainer):
     """A placeholder widget for the review inspector panel."""
 
-    def __init__(self, *args, controller=None, **kwargs):
+    def __init__(
+        self,
+        controller: ReviewController,
+        *args,
+        **kwargs,
+    ):
         super().__init__(
             *args,
             layout=AYContainer.Layout.VBox,
@@ -144,7 +151,7 @@ class ReviewInspector(AYContainer):
                 rel_text_size=1,
             )
         )
-        self._representations = Representations()
+        self._representations = Representations(self._controller)
         self.add_widget(self._representations)
 
     def set_view(self, view: QtWidgets.QAbstractItemView) -> None:
@@ -330,7 +337,7 @@ class Representations(AYContainer):
     rows regardless of the mode.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, controller: ReviewController, *args, **kwargs):
         super().__init__(
             *args,
             layout=AYContainer.Layout.VBox,
@@ -338,6 +345,10 @@ class Representations(AYContainer):
             layout_margin=2,
             **kwargs,
         )
+        self._controller = controller
+        self._current_project_name: str = ""
+        self._controller.project_changed.connect(self._on_project_change)
+
         self._layout.setAlignment(QtCore.Qt.AlignTop)
         self._table: AYTableView = AYTableView(
             variant=AYTableView.Variants.Low,
@@ -345,12 +356,66 @@ class Representations(AYContainer):
         self._model = QtGui.QStandardItemModel()
         self._model.setHorizontalHeaderLabels(["Name", "Folder", "Product"])
         self._table.setModel(self._model)
+        self._table.setSortingEnabled(True)
+        self._table.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+        self._table.setContextMenuPolicy(
+            QtCore.Qt.ContextMenuPolicy.CustomContextMenu
+        )
+        self._table.customContextMenuRequested.connect(self._on_context_menu)
 
         self.add_widget(self._table)
 
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    def _on_project_change(self, project_name: str) -> None:
+        self._current_project_name = project_name
+
+    def _get_selected_ids(self) -> set[str]:
+        selected_ids = set()
+        for midx in self._table.selectedIndexes():
+            if midx.column() > 0:
+                continue
+            user_data = midx.data(QtCore.Qt.ItemDataRole.UserRole) or {}
+            if user_data.get("is_group", False):
+                # If this is a group row, include all its children.
+                model = midx.model()
+                for i in range(model.rowCount(midx)):
+                    child_idx = model.index(i, 0, midx)
+                    child_user_data = (
+                        child_idx.data(QtCore.Qt.ItemDataRole.UserRole) or {}
+                    )
+                    selected_ids.add(child_user_data.get("id", ""))
+            else:
+                selected_ids.add(user_data.get("id", ""))
+        selected_ids.discard("")
+        return selected_ids
+
+    def _on_context_menu(self, pos: QtCore.QPoint) -> None:
+        selected_ids = self._get_selected_ids()
+        action_items = self._controller.get_action_items(
+            self._current_project_name, selected_ids, "representation"
+        )
+        global_point = self._table.mapToGlobal(pos)
+        result = show_actions_menu(
+            action_items, global_point, len(selected_ids) == 1, self
+        )
+        action_item, options = result
+        if action_item is None or options is None:
+            return
+
+        self._controller.trigger_action_item(
+            identifier=action_item.identifier,
+            project_name=self._current_project_name,
+            selected_ids=selected_ids,
+            selected_entity_type="representation",
+            data=action_item.data,
+            options=options,
+            form_values={},
+        )
 
     def _set_tree_mode(self, enabled: bool) -> None:
         """Enable or disable tree decoration on the view.
@@ -378,6 +443,10 @@ class Representations(AYContainer):
         icon = get_qt_icon(repre.representation_icon)
         if icon is not None:
             name_item.setIcon(icon)
+        name_item.setData(
+            {"id": repre.representation_id, "is_group": False},
+            QtCore.Qt.ItemDataRole.UserRole,
+        )
 
         folder_item = QtGui.QStandardItem(repre.folder_label)
         folder_item.setEditable(False)
@@ -409,6 +478,7 @@ class Representations(AYContainer):
         icon = get_qt_icon(sample_repre.representation_icon)
         if icon is not None:
             group_item.setIcon(icon)
+        group_item.setData({"is_group": True}, QtCore.Qt.ItemDataRole.UserRole)
         return group_item
 
     # ------------------------------------------------------------------

--- a/client/ayon_core/tools/loader/ui/review_inspector.py
+++ b/client/ayon_core/tools/loader/ui/review_inspector.py
@@ -194,8 +194,7 @@ class ReviewInspector(AYContainer):
         self._update()
 
     def _update(self) -> None:
-        """Update the inspector with the current selection,
-        if it is visible."""
+        """Update the inspector with the current selection, if visible."""
         if not self.isVisible():
             return
 

--- a/client/ayon_core/tools/loader/ui/review_inspector.py
+++ b/client/ayon_core/tools/loader/ui/review_inspector.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
-from ayon_ui_qt.components.container import AYContainer
-from ayon_ui_qt.components.layouts import AYHBoxLayout
-from ayon_ui_qt.components.label import AYLabel
-from ayon_ui_qt.components.buttons import AYButton
-from ayon_ui_qt.components.entity_thumbnail import AYEntityThumbnail
-from ayon_ui_qt.components.task_queue import AsyncTask, get_task_queue
-from ayon_ui_qt.components.table_view import AYTableView
-from ayon_ui_qt.image_cache import ImageCache
-from qtpy import QtCore, QtWidgets, QtGui, shiboken
+from collections import defaultdict
 
+from ayon_ui_qt.components.buttons import AYButton
+from ayon_ui_qt.components.container import AYContainer
+from ayon_ui_qt.components.entity_thumbnail import AYEntityThumbnail
+from ayon_ui_qt.components.label import AYLabel
+from ayon_ui_qt.components.layouts import AYHBoxLayout
+from ayon_ui_qt.components.table_view import AYTableView
+from ayon_ui_qt.components.task_queue import AsyncTask, get_task_queue
+from ayon_ui_qt.image_cache import ImageCache
+from qtpy import QtCore, QtGui, QtWidgets, shiboken
+
+from ayon_core.tools.loader.abstract import RepreItem
 from ayon_core.tools.utils import get_qt_icon
 
 from ._review_thumbnails import _thumbnail_loader
@@ -184,7 +187,8 @@ class ReviewInspector(AYContainer):
         self._update()
 
     def _update(self) -> None:
-        """Update the inspector with the current selection, if it is visible."""
+        """Update the inspector with the current selection,
+        if it is visible."""
         if not self.isVisible():
             return
 
@@ -221,8 +225,8 @@ class ReviewInspector(AYContainer):
         )
 
         thumb_keys: list[str] = []
-        version_id = data.get("_version_id") or data.get("id", "")
-        project_name = data.get("project_name", "")
+        version_ids: list[str] = []
+        project_name: str = data.get("project_name", "")
         for idx in self._current_selection:
             d = idx.data(QtCore.Qt.ItemDataRole.UserRole) or {}
             tid = d.get("thumbnailId", "")
@@ -230,6 +234,8 @@ class ReviewInspector(AYContainer):
             pname = d.get("project_name", "")
             if tid and vid and pname:
                 thumb_keys.append(f"{pname}/{vid}/{tid}")
+            if vid:
+                version_ids.append(vid)
 
         if thumb_keys:
             self._load_thumbnail(thumb_keys)
@@ -237,12 +243,15 @@ class ReviewInspector(AYContainer):
             self._current_thumb_key = ""
             self._thumbnail.set_thumbnail("")
 
-        # Fetch and display representations for this version.
-        if self._controller and project_name and version_id:
+        # Fetch and display representations for all selected versions.
+        if self._controller and project_name and version_ids:
             repre_items = self._controller.get_representation_items(
-                project_name, [version_id]
+                project_name, version_ids
             )
-            self._representations.set_items(repre_items)
+            self._representations.set_items(
+                repre_items,
+                multi_version=len(version_ids) > 1,
+            )
         else:
             self._representations.set_items([])
 
@@ -312,7 +321,14 @@ class ReviewInspector(AYContainer):
 
 
 class Representations(AYContainer):
-    """Widget displaying the representations for an inspected version."""
+    """Widget displaying the representations for an inspected version.
+
+    When multiple versions share common representation names the widget
+    switches to tree mode: each shared name becomes a collapsible parent
+    row and the individual representations appear as its children.  Names
+    that are unique across the current selection are shown as flat root
+    rows regardless of the mode.
+    """
 
     def __init__(self, *args, **kwargs):
         super().__init__(
@@ -332,28 +348,119 @@ class Representations(AYContainer):
 
         self.add_widget(self._table)
 
-    def set_items(self, repre_items: list) -> None:
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _set_tree_mode(self, enabled: bool) -> None:
+        """Enable or disable tree decoration on the view.
+
+        Args:
+            enabled: ``True`` to show collapse/expand indicators.
+        """
+        self._table._apply_tree_mode(enabled)
+
+    def _make_row(self, repre: RepreItem) -> list[QtGui.QStandardItem]:
+        """Build the three-column item list for a single representation.
+
+        Args:
+            repre: A
+                :class:`~ayon_core.tools.loader.abstract.RepreItem`
+                instance.
+
+        Returns:
+            A three-element list ``[name_item, folder_item,
+            product_item]`` ready to pass to
+            :meth:`QtGui.QStandardItemModel.appendRow`.
+        """
+        name_item = QtGui.QStandardItem(repre.representation_name)
+        name_item.setEditable(False)
+        icon = get_qt_icon(repre.representation_icon)
+        if icon is not None:
+            name_item.setIcon(icon)
+
+        folder_item = QtGui.QStandardItem(repre.folder_label)
+        folder_item.setEditable(False)
+
+        product_item = QtGui.QStandardItem(repre.product_name)
+        product_item.setEditable(False)
+
+        return [name_item, folder_item, product_item]
+
+    def _make_group_row(
+        self, name: str, sample_repre: RepreItem
+    ) -> QtGui.QStandardItem:
+        """Build the parent (group) item for a shared representation name.
+
+        The group item spans the Name column only; Folder and Product
+        cells are intentionally left empty.
+
+        Args:
+            name: The shared representation name used as the label.
+            sample_repre: Any child
+                :class:`~ayon_core.tools.loader.abstract.RepreItem`
+                from this group — used to copy the icon.
+
+        Returns:
+            A :class:`QtGui.QStandardItem` to use as the parent row.
+        """
+        group_item = QtGui.QStandardItem(name)
+        group_item.setEditable(False)
+        icon = get_qt_icon(sample_repre.representation_icon)
+        if icon is not None:
+            group_item.setIcon(icon)
+        return group_item
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def set_items(
+        self,
+        repre_items: list[RepreItem],
+        multi_version: bool = False,
+    ) -> None:
         """Populate the table from a list of RepreItem.
+
+        When *multi_version* is ``True`` and at least one representation
+        name is shared across the provided items, the view switches to
+        tree mode.  Each shared name gets a collapsible parent row; its
+        individual representations appear as children below it.  Names
+        that appear only once remain as flat root rows.
+
+        When *multi_version* is ``False`` (or no duplicate names exist)
+        the view renders as a plain flat table.
 
         Args:
             repre_items: List of
                 :class:`~ayon_core.tools.loader.abstract.RepreItem`
                 objects to display.
+            multi_version: ``True`` when the items come from more than
+                one selected version.
         """
         self._model.removeRows(0, self._model.rowCount())
+
+        if not multi_version:
+            self._set_tree_mode(False)
+            for repre in repre_items:
+                self._model.appendRow(self._make_row(repre))
+            return
+
+        # Group representations by name to detect shared names.
+        groups: dict[str, list[RepreItem]] = defaultdict(list)
         for repre in repre_items:
-            # print(repre.to_data())
+            groups[repre.representation_name].append(repre)
 
-            name_item = QtGui.QStandardItem(repre.representation_name)
-            name_item.setEditable(False)
-            icon = get_qt_icon(repre.representation_icon)
-            if icon is not None:
-                name_item.setIcon(icon)
+        has_groups = any(len(items) > 1 for items in groups.values())
+        self._set_tree_mode(has_groups)
 
-            folder_item = QtGui.QStandardItem(repre.folder_label)
-            folder_item.setEditable(False)
-
-            product_item = QtGui.QStandardItem(repre.product_name)
-            product_item.setEditable(False)
-
-            self._model.appendRow([name_item, folder_item, product_item])
+        for name, items in groups.items():
+            if len(items) == 1:
+                # Unique name — keep as a flat root row.
+                self._model.appendRow(self._make_row(items[0]))
+            else:
+                # Shared name — create a collapsible parent.
+                group_item = self._make_group_row(name, items[0])
+                for repre in items:
+                    group_item.appendRow(self._make_row(repre))
+                self._model.appendRow(group_item)

--- a/client/ayon_core/tools/loader/ui/review_inspector.py
+++ b/client/ayon_core/tools/loader/ui/review_inspector.py
@@ -220,10 +220,9 @@ class ReviewInspector(AYContainer):
         index = next(iter(self._current_selection), QtCore.QModelIndex())
         data = index.data(QtCore.Qt.ItemDataRole.UserRole) or {}
 
-        # Folder rows have no version data — clear and bail out.
+        # Folder rows have no version data — clear the inspector.
         if data.get("entityType", "") == "Folder":
-            self._representations.set_items([])
-            return
+            data = {}
 
         # print(f"Updating inspector with data: {data}")
         self._path_label.setText(

--- a/client/ayon_core/tools/loader/ui/review_inspector.py
+++ b/client/ayon_core/tools/loader/ui/review_inspector.py
@@ -522,11 +522,13 @@ class Representations(AYContainer):
                 one selected version.
         """
         self._model.removeRows(0, self._model.rowCount())
+        sort_column = self._table.header().sortIndicatorSection()
 
         if not multi_version:
             self._set_tree_mode(False)
             for repre in repre_items:
                 self._model.appendRow(self._make_row(repre))
+            self._model.sort(sort_column, QtCore.Qt.SortOrder.AscendingOrder)
             return
 
         # Group representations by name to detect shared names.
@@ -547,3 +549,5 @@ class Representations(AYContainer):
                 for repre in items:
                     group_item.appendRow(self._make_row(repre))
                 self._model.appendRow(group_item)
+
+        self._model.sort(sort_column, QtCore.Qt.SortOrder.AscendingOrder)

--- a/client/ayon_core/tools/loader/ui/review_inspector.py
+++ b/client/ayon_core/tools/loader/ui/review_inspector.py
@@ -156,6 +156,21 @@ class ReviewInspector(AYContainer):
 
     def set_view(self, view: QtWidgets.QAbstractItemView) -> None:
         """Set the view for the inspector."""
+        if self._view is view:
+            # already configured
+            return
+
+        if self._view is not None:
+            # disconnect from previous view signals, if any
+            try:
+                self._view.activated.disconnect(self._on_activated)
+                self._view.selection_changed.disconnect(
+                    self._on_selection_changed
+                )
+                self._view.model().modelReset.disconnect(self._on_model_reset)
+            except (RuntimeError, TypeError):
+                pass
+
         self._view = view
         self._view.activated.connect(self._on_activated)
         self._view.selection_changed.connect(self._on_selection_changed)

--- a/client/ayon_core/tools/loader/ui/reviews_widget.py
+++ b/client/ayon_core/tools/loader/ui/reviews_widget.py
@@ -12,6 +12,7 @@ from ayon_core.lib import Logger
 from ayon_core.tools.loader.ui.actions_utils import show_actions_menu
 from ayon_core.tools.loader.ui.review_controller import ReviewController
 from ayon_core.tools.loader.ui.review_types import ReviewCategory
+from ayon_core.tools.loader.control import LoaderController
 from ayon_core.tools.utils.user_prefs import UserPreferences
 
 from ._review_slicer import ReviewSlicer
@@ -27,7 +28,7 @@ class ReviewsWidget(AYContainer):
     def __init__(
         self,
         *args: Any,
-        loader_controller: Any = None,
+        loader_controller: LoaderController | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -43,8 +44,13 @@ class ReviewsWidget(AYContainer):
             ReviewCategory.HIERARCHY.value,
         )
 
+        if not isinstance(loader_controller, LoaderController):
+            raise TypeError(
+                f"Expected LoaderController, got {type(loader_controller)}"
+            )
         self._controller = ReviewController(
-            parent=self, loader_controller=loader_controller
+            loader_controller,
+            parent=self,
         )
         self._slicer = ReviewSlicer(
             self._controller,
@@ -69,7 +75,7 @@ class ReviewsWidget(AYContainer):
         self._table.card_view.customContextMenuRequested.connect(
             self._on_context_menu
         )
-        self._inspector = ReviewInspector(controller=self._controller)
+        self._inspector = ReviewInspector(self._controller)
         self._table.display_type_changed.connect(self._inspector.set_view)
         self._inspector.set_view(self._table.active_view)
         self._build()

--- a/client/ayon_core/tools/loader/ui/reviews_widget.py
+++ b/client/ayon_core/tools/loader/ui/reviews_widget.py
@@ -27,8 +27,8 @@ class ReviewsWidget(AYContainer):
 
     def __init__(
         self,
+        loader_controller: LoaderController,
         *args: Any,
-        loader_controller: LoaderController | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -44,10 +44,6 @@ class ReviewsWidget(AYContainer):
             ReviewCategory.HIERARCHY.value,
         )
 
-        if not isinstance(loader_controller, LoaderController):
-            raise TypeError(
-                f"Expected LoaderController, got {type(loader_controller)}"
-            )
         self._controller = ReviewController(
             loader_controller,
             parent=self,

--- a/client/ayon_core/tools/loader/ui/window.py
+++ b/client/ayon_core/tools/loader/ui/window.py
@@ -255,9 +255,7 @@ class LoaderWindow(AYContainer):
         main_splitter.setStretchFactor(1, 6)
         main_splitter.setStretchFactor(2, 1)
 
-        self.review_wdgt = ReviewsWidget(
-            loader_controller=controller
-        )
+        self.review_wdgt = ReviewsWidget(controller)
 
         self._tab = QtWidgets.QTabWidget()
         self._tab.addTab(main_splitter, "Folders")


### PR DESCRIPTION
## Changelog Description
- display merged representations when the user selects more than one item.
- connect contextual menu to the representation table.
- refactor ReviewController to require a LoaderController to initialize.
- make sure the featured version is used when available.

## Additional info
This should make the representations as usable as they are in the loader.

## Testing notes:
1. Open the browser: `tools/make.sh run --use-dev browser`
2. select one or more versions and check the inspector.
3. try different groupings.
4. weep with happiness. or get a coffee. whatever floats your boat.

closes #1828 