### PR TITLE
Browser right click group error with group by status

### DIFF
--- a/client/ayon_core/tools/loader/ui/reviews_widget.py
+++ b/client/ayon_core/tools/loader/ui/reviews_widget.py
@@ -160,14 +160,14 @@ class ReviewsWidget(AYContainer):
             row_dict = proxy_idx.data(QtCore.Qt.ItemDataRole.UserRole) or {}
             if row_dict.get("entityType", "") == "Folder":
                 continue
-            version_id = row_dict.get("_version_id", row_dict.get("id", ""))
-            if version_id:
+            version_id = row_dict.get("_version_id") or row_dict.get("id", "")
+            if version_id and not version_id.startswith("grp:"):
                 version_ids.add(version_id)
 
         global_point = self._table.active_view.viewport().mapToGlobal(pos)
 
         if not version_ids or not project_name:
-            log.warning("No version ids or project name")
+            log.debug("No version ids or project name")
             return
 
         action_items = self._controller.get_action_items(


### PR DESCRIPTION
## Changelog Description
Prevent a contextual menu error on items without a valid version id. This includes groups like Status, that don't carry a featured version id. By product grouping works as usual.

## Additional info
None.

## Testing notes:
1. `tools/make.sh run --use-dev browser`
2. in table view, group by anything and right-click the group.
3. there shouldn't be any error and no contextual menu.

closes #1844 