### PR TITLE
Integrate: Representation rootless paths

### DIFF
--- a/client/ayon_core/pipeline/anatomy/__init__.py
+++ b/client/ayon_core/pipeline/anatomy/__init__.py
@@ -5,8 +5,9 @@ from .exceptions import (
     TemplateMissingKey,
     AnatomyTemplateUnsolved,
 )
-from .anatomy import Anatomy
+from .roots import AnatomyRoot, AnatomyRoots
 from .templates import AnatomyTemplateResult, AnatomyStringTemplate
+from .anatomy import Anatomy
 
 
 __all__ = (
@@ -16,8 +17,11 @@ __all__ = (
     "TemplateMissingKey",
     "AnatomyTemplateUnsolved",
 
-    "Anatomy",
+    "AnatomyRoot",
+    "AnatomyRoots",
 
     "AnatomyTemplateResult",
     "AnatomyStringTemplate",
+
+    "Anatomy",
 )

--- a/client/ayon_core/pipeline/anatomy/roots.py
+++ b/client/ayon_core/pipeline/anatomy/roots.py
@@ -8,7 +8,7 @@ from ayon_core.lib.path_templates import FormatObject
 from .exceptions import RootMissingEnv
 
 
-class RootItem(FormatObject):
+class AnatomyRoot(FormatObject):
     """Represents one item or roots.
 
     Holds raw data of root item specification. Raw data contain value
@@ -243,6 +243,11 @@ class RootItem(FormatObject):
         return (result, output)
 
 
+# TODO remove
+# Backwards compatibility added 2026/05/21
+RootItem = AnatomyRoot  # DEPRECATED
+
+
 class AnatomyRoots:
     """Object which should be used for formatting "root" key in templates.
 
@@ -296,7 +301,7 @@ class AnatomyRoots:
             src_platform (Optional[str]): Specify source platform. This is
                 recommended to not use and keep unset until you really want
                 to use specific platform.
-            roots (Optional[Union[dict, RootItem])): It is possible to remap
+            roots (Optional[Union[dict, AnatomyRoot])): It is possible to remap
                 path with different roots then instance where method was
                 called has.
 
@@ -318,7 +323,7 @@ class AnatomyRoots:
             if not dst_platform:
                 return path
 
-        if isinstance(roots, RootItem):
+        if isinstance(roots, AnatomyRoot):
             return roots.path_remapper(path, dst_platform, src_platform)
 
         for _root in roots.values():
@@ -353,7 +358,7 @@ class AnatomyRoots:
         if roots is None:
             raise ValueError("Roots are not set. Can't find path.")
 
-        if isinstance(roots, RootItem):
+        if isinstance(roots, AnatomyRoot):
             return roots.find_root_template_from_path(path)
 
         for root_name, _root in roots.items():
@@ -411,7 +416,7 @@ class AnatomyRoots:
             roots = self.roots
 
         output = []
-        if isinstance(roots, RootItem):
+        if isinstance(roots, AnatomyRoot):
             for value in roots.raw_data.values():
                 output.append(value)
             return output
@@ -426,7 +431,7 @@ class AnatomyRoots:
         if roots is None:
             roots = self.roots
 
-        if isinstance(roots, RootItem):
+        if isinstance(roots, AnatomyRoot):
             key_items = [self.env_prefix]
             for _key in keys:
                 key_items.append(_key.upper())
@@ -462,7 +467,7 @@ class AnatomyRoots:
                 )
             }
 
-        if isinstance(roots, RootItem):
+        if isinstance(roots, AnatomyRoot):
             key_items = [AnatomyRoots.env_prefix]
             for _key in keys:
                 key_items.append(_key.upper())
@@ -513,7 +518,7 @@ class AnatomyRoots:
         Default roots are loaded if project override's does not contain roots.
 
         Returns:
-            `RootItem` or `dict` with multiple `RootItem`s when multiroot
+            `AnatomyRoot` or `dict` with multiple `AnatomyRoot`s when multiroot
             setting is used.
         """
 
@@ -521,24 +526,23 @@ class AnatomyRoots:
 
     @staticmethod
     def _parse_dict(data, parent):
-        """Parse roots raw data into RootItem or dictionary with RootItems.
+        """Parse roots raw data into dictionary with AnatomyRoots.
 
-        Converting raw roots data to `RootItem` helps to handle platform keys.
-        This method is recursive to be able handle multiroot setup and
-        is static to be able to load default roots without creating new object.
+        Converting raw roots data to `AnatomyRoot` helps to handle platform
+            keys.
 
         Args:
             data (dict): Should contain raw roots data to be parsed.
             parent (AnatomyRoots): Parent object set as parent
-                for ``RootItem``.
+                for ``AnatomyRoot``.
 
         Returns:
-            dict[str, RootItem]: Root items by name.
+            dict[str, AnatomyRoot]: Root items by name.
 
         """
         output = {}
         for root_name, root_values in data.items():
-            output[root_name] = RootItem(
+            output[root_name] = AnatomyRoot(
                 parent, root_values, root_name
             )
         return output

--- a/client/ayon_core/pipeline/anatomy/roots.py
+++ b/client/ayon_core/pipeline/anatomy/roots.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import numbers
+import warnings
 
 from ayon_core.lib import Logger, StringTemplate
 from ayon_core.lib.path_templates import FormatObject
@@ -244,8 +245,18 @@ class AnatomyRoot(FormatObject):
 
 
 # TODO remove
-# Backwards compatibility added 2026/05/21
-RootItem = AnatomyRoot  # DEPRECATED
+class RootItem(AnatomyRoot):
+    """DEPRECATED: Use 'AnatomyRoot' instead.
+
+    Backwards compatibility added 2026/05/21.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn(
+            "RootItem is deprecated. Use AnatomyRoot instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
 
 class AnatomyRoots:

--- a/client/ayon_core/pipeline/anatomy/templates.py
+++ b/client/ayon_core/pipeline/anatomy/templates.py
@@ -441,7 +441,7 @@ class AnatomyTemplates:
         """Anatomy roots object.
 
         Returns:
-            RootItem: Anatomy roots data.
+            dict[str, AnatomyRoot]: Anatomy roots data.
 
         """
         return self._anatomy.roots

--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -212,6 +212,9 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             )
 
         template_name = self.get_template_name(instance)
+        self.log.debug(f"Anatomy template name: {template_name}")
+        anatomy = instance.context.data["anatomy"]
+        publish_template = anatomy.get_template_item("publish", template_name)
 
         op_session = OperationsSession()
         product_entity = self.prepare_product(
@@ -239,7 +242,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             # todo: reduce/simplify what is returned from this function
             prepared = self.prepare_representation(
                 repre,
-                template_name,
+                publish_template,
                 existing_repres_by_name,
                 version_entity,
                 instance_stagingdir,
@@ -549,7 +552,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
     def prepare_representation(
         self,
         repre,
-        template_name,
+        publish_template,
         existing_repres_by_name,
         version_entity,
         instance_stagingdir,
@@ -621,9 +624,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             if value is not None:
                 template_data[anatomy_key] = value
 
-        self.log.debug("Anatomy template name: {}".format(template_name))
         anatomy = instance.context.data["anatomy"]
-        publish_template = anatomy.get_template_item("publish", template_name)
         path_template_obj = publish_template["path"]
         template = path_template_obj.template.replace("\\", "/")
 

--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import os
 import logging
 import sys
 import copy
+from typing import Iterable, Any
 
 import clique
 import pyblish.api
@@ -29,6 +32,12 @@ from ayon_core.pipeline.publish import (
     get_publish_template_name,
 )
 from ayon_core.pipeline import is_product_base_type_supported
+from ayon_core.pipeline.anatomy import (
+    Anatomy,
+    AnatomyStringTemplate,
+    AnatomyTemplateResult,
+    AnatomyRoot,
+)
 
 log = logging.getLogger(__name__)
 
@@ -216,6 +225,16 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         anatomy = instance.context.data["anatomy"]
         publish_template = anatomy.get_template_item("publish", template_name)
 
+        # Prepare prefered root to use for representation files
+        path_template_obj: AnatomyStringTemplate = publish_template["path"]
+        result: AnatomyTemplateResult = path_template_obj.format(
+            {"root": anatomy.roots}
+        )
+        root_value = result.used_values.get("root")
+        prefered_root_name = None
+        if root_value:
+            prefered_root_name = next(iter(root_value.keys()))
+
         op_session = OperationsSession()
         product_entity = self.prepare_product(
             instance, op_session, project_name
@@ -295,7 +314,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         # version instance instead of an individual representation) so
         # we can reuse those file infos per representation
         resource_file_infos = self.get_files_info(
-            resource_destinations, anatomy
+            resource_destinations, anatomy, prefered_root_name
         )
 
         # Finalize the representations now the published files are integrated
@@ -306,8 +325,9 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             repre_update_data = prepared["repre_update_data"]
             transfers = prepared["transfers"]
             destinations = [dst for src, dst in transfers]
+            
             repre_files = self.get_files_info(
-                destinations, anatomy
+                destinations, anatomy, prefered_root_name
             )
             # Add the version resource file infos to each representation
             repre_files += resource_file_infos
@@ -986,38 +1006,66 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             ).format(path))
         return path
 
-    def get_files_info(self, filepaths, anatomy):
+    def get_files_info(
+        self,
+        filepaths: Iterable[str],
+        anatomy: Anatomy,
+        prefered_root_name: str | None,
+    ) -> list[dict[str, Any]]:
         """Prepare 'files' info portion for representations.
 
         Arguments:
             filepaths (Iterable[str]): List of transferred file paths.
             anatomy (Anatomy): Project anatomy.
+            prefered_root_name (str | None): If set, it will be tried as first
+                option for rootless path.
 
         Returns:
             list[dict[str, Any]]: Representation 'files' information.
 
         """
+        obj_root = None
+        if prefered_root_name:
+            obj_root = anatomy.roots[prefered_root_name]
         file_infos = []
         for filepath in filepaths:
-            file_info = self.prepare_file_info(filepath, anatomy)
+            file_info = self.prepare_file_info(
+                filepath, anatomy, obj_root
+            )
             file_infos.append(file_info)
         return file_infos
 
-    def prepare_file_info(self, path, anatomy):
+    def prepare_file_info(
+        self,
+        path: str,
+        anatomy: Anatomy,
+        root: AnatomyRoot | None,
+    ) -> dict[str, Any]:
         """ Prepare information for one file (asset or resource)
 
         Arguments:
             path (str): Destination url of published file.
             anatomy (Anatomy): Project anatomy part from instance.
+            root (AnatomyRoot | None): If set, it will be tried as first
+                option for rootless path.
 
         Returns:
             dict[str, Any]: Representation file info dictionary.
 
         """
+        rootless_path = None
+        if root is not None:
+            success, rootless_path = root.find_root_template_from_path(path)
+            if not success:
+                rootless_path = None
+
+        if rootless_path is None:
+            rootless_path = self.get_rootless_path(anatomy, path)
+
         return {
             "id": create_entity_id(),
             "name": os.path.basename(path),
-            "path": self.get_rootless_path(anatomy, path),
+            "path": rootless_path,
             "size": os.path.getsize(path),
             "hash": source_hash(path),
             "hash_type": "op3",

--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -325,7 +325,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             repre_update_data = prepared["repre_update_data"]
             transfers = prepared["transfers"]
             destinations = [dst for src, dst in transfers]
-            
+
             repre_files = self.get_files_info(
                 destinations, anatomy, prefered_root_name
             )

--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -225,7 +225,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         anatomy = instance.context.data["anatomy"]
         publish_template = anatomy.get_template_item("publish", template_name)
 
-        # Prepare prefered root to use for representation files
+        # Prepare preferred root to use for representation files
         path_template_obj: AnatomyStringTemplate = publish_template["path"]
         result: AnatomyTemplateResult = path_template_obj.format(
             {"root": anatomy.roots}


### PR DESCRIPTION
## Changelog Description
Prefer root from publish template for representation files information.

## Additional info
In case someone has 2 roots that are the same or one is nested under other one the `find_root_template_from_path` might not return the root which was actually used for publishing. In my case I had `publish` and `delivery` roots set to similar paths, the representation template attribute had `{root[publish]}` but rootless paths on representation files info have `{root[delivery]}`.

Renamed `RootItem` in antomy code to `AnatomyRoot` as it makes more sense. Kept `RootItem` for backwards compatibility but it should not be used anywhere, yet.

Bug discovered during https://github.com/ynput/ayon-core/pull/1852 . I was not able to push to other project because of that.

## Testing notes:
1. Define 2 roots with the same path on a project.
2. Use the second (alphabetically) in publish template.
3. Publish a representation.
4. Check the representation `attrib.template` and `files.0.path` if the root used in the template is the same.