### PR TITLE
Farm: soft fail CollectRenderedFiles if env var not set

### DIFF
--- a/client/ayon_core/plugins/publish/collect_rendered_files.py
+++ b/client/ayon_core/plugins/publish/collect_rendered_files.py
@@ -152,7 +152,7 @@ class CollectRenderedFiles(pyblish.api.ContextPlugin):
         publish_data_paths = os.environ.get("AYON_PUBLISH_DATA")
         if not publish_data_paths:
             self.log.warning(
-                "Environment variable `AYON_PUBLISH_DATA` is not set. ")
+                "Environment variable `AYON_PUBLISH_DATA` is not set.")
             return
 
         # QUESTION

--- a/client/ayon_core/plugins/publish/collect_rendered_files.py
+++ b/client/ayon_core/plugins/publish/collect_rendered_files.py
@@ -12,7 +12,6 @@ import json
 
 import pyblish.api
 
-from ayon_core.pipeline import KnownPublishError
 from ayon_core.pipeline.publish.input_versions import (
     deserialize_input_versions
 )

--- a/client/ayon_core/plugins/publish/collect_rendered_files.py
+++ b/client/ayon_core/plugins/publish/collect_rendered_files.py
@@ -152,7 +152,9 @@ class CollectRenderedFiles(pyblish.api.ContextPlugin):
 
         publish_data_paths = os.environ.get("AYON_PUBLISH_DATA")
         if not publish_data_paths:
-            raise KnownPublishError("Missing `AYON_PUBLISH_DATA`")
+            self.log.warning(
+                "Environment variable `AYON_PUBLISH_DATA` is not set. ")
+            return
 
         # QUESTION
         #   Do we support (or want support) multiple files in the variable?


### PR DESCRIPTION
## Changelog Description
soft-fail when  `AYON_PUBLISH_DATA` is not set with *farm* target and *shell* host.

## Additional info
Unsuccessful check for the `AYON_PUBLISH_DATA` var crash the whole publishing on target *farm* even if this plugin is not used at all. This plugin is used only for publishing with *metadata.json*. This allows publishing on Deadline Cloud.

## Testing notes:
Nothing should really fail as `AYON_PUBLISH_DATA` is set when needed (and if it is not, it is probably bug of the publish job submitter).

>[!NOTE]
>This is needed for testing ynput/ayon-deadline-cloud#19
