### PR TITLE
Tools: show functions returning QWidget

### DIFF
--- a/client/ayon_core/tools/utils/host_tools.py
+++ b/client/ayon_core/tools/utils/host_tools.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import os
 
 import pyblish.api
-from typing import TYPE_CHECKING, Optional, Literal
+from typing import TYPE_CHECKING, Literal
 
 from ayon_core.host import ILoadHost, IPublishHost
 from ayon_core.lib import Logger
@@ -20,11 +20,10 @@ if TYPE_CHECKING:
     from qtpy.QtWidgets import QWidget
     from ayon_core.tools.publisher.abstract import AbstractPublisherFrontend
 
-TPublisherTabs = Literal["create", "publish", "report", "details"]
-TToolNames = Literal[
+PublisherTabs = Literal["create", "publish", "report", "details"]
+ToolName = Literal[
     "workfiles",
     "loader",
-    "libraryloader",
     "sceneinventory",
     "publisher",
     "experimental_tools",
@@ -70,13 +69,13 @@ class HostToolsHelper:
         return self._workfiles_tool
 
     def show_workfiles(
-            self,
-            parent=None,
-            *,
-            use_context: Optional[bool] = False,
-            save: Optional[bool] = None,
-            on_top: Optional[bool] = None
-    ) -> Optional[QWidget]:
+        self,
+        parent: QWidget | None = None,
+        *,
+        use_context: bool = False,
+        save: bool | None = None,
+        on_top: bool | None = None,
+    ) -> QWidget:
         """Workfiles tool for changing context and saving workfiles."""
 
         with qt_app_context():
@@ -105,8 +104,8 @@ class HostToolsHelper:
         return self._loader_tool
 
     def show_loader(
-            self,
-            parent: Optional[QWidget] = None) -> QWidget:
+        self, parent: QWidget | None = None
+    ) -> QWidget:
         """Loader tool for loading representations.
 
         Args:
@@ -143,7 +142,8 @@ class HostToolsHelper:
         return self._scene_inventory_tool
 
     def show_scene_inventory(
-            self, parent: Optional[QWidget] = None) -> QWidget:
+        self, parent: QWidget | None = None
+    ) -> QWidget:
         """Show tool maintain loaded containers."""
         with qt_app_context():
             scene_inventory_tool = self.get_scene_inventory_tool(parent)
@@ -161,7 +161,7 @@ class HostToolsHelper:
         """Create, cache and return library loader tool window."""
         return self.get_loader_tool(parent)
 
-    def show_library_loader(self, parent: Optional[QWidget] = None) -> QWidget:
+    def show_library_loader(self, parent: QWidget | None = None) -> QWidget:
         """Loader tool for loading representations from library project.
 
         Args:
@@ -174,7 +174,7 @@ class HostToolsHelper:
         return self.show_loader(parent)
 
     def show_publish(
-            self, parent: Optional[QWidget] = None) -> QWidget:
+            self, parent: QWidget | None = None) -> QWidget:
         """Try showing the most desirable publish GUI
 
         This function cycles through the currently registered
@@ -219,7 +219,8 @@ class HostToolsHelper:
         return self._experimental_tools_dialog
 
     def show_experimental_tools_dialog(
-            self, parent: Optional[QWidget] = None) -> QWidget:
+        self, parent: QWidget | None = None
+    ) -> QWidget:
         """Show dialog with experimental tools.
 
         Args:
@@ -257,10 +258,11 @@ class HostToolsHelper:
         return self._publisher_tool
 
     def show_publisher_tool(
-            self,
-            parent: Optional[QWidget] = None,
-            controller: Optional[AbstractPublisherFrontend] = None,
-            tab: Optional[TPublisherTabs] = None) -> QWidget:
+        self,
+        parent: QWidget | None = None,
+        controller: AbstractPublisherFrontend | None = None,
+        tab: PublisherTabs | None = None
+    ) -> QWidget:
         with qt_app_context():
             window = self.get_publisher_tool(parent, controller)
             if tab:
@@ -269,15 +271,27 @@ class HostToolsHelper:
             return window
 
     def get_tool_by_name(
-            self,
-            tool_name: TToolNames,
-            parent: Optional[QWidget] = None,
-            *args,
-            **kwargs
-    ) -> Optional[QWidget]:
+        self,
+        tool_name: PublisherTabs,
+        parent: QWidget | None = None,
+        *args,
+        **kwargs
+    ) -> QWidget | None:
         """Show tool by its name.
 
-        This is helper for
+        This is helper for `show_tool_by_name` if you need only get
+        tool window without showing it.
+
+        Args:
+            tool_name: name of the tool
+            parent: tool parent
+            *args: tool args
+            **kwargs: tool kwargs
+
+        Returns:
+            QWidget of the tool shown or None if tool name is unknown
+            or tool can't be created.
+
         """
         if tool_name == "workfiles":
             return self.get_workfiles_tool(parent)
@@ -307,42 +321,52 @@ class HostToolsHelper:
 
     def show_tool_by_name(
             self,
-            tool_name: TToolNames,
-            parent: Optional[QWidget] = None,
+            tool_name: ToolName,
+            parent: QWidget | None = None,
             *args,
             **kwargs
-    ) -> Optional[QWidget]:
+    ) -> QWidget | None:
         """Show tool by its name.
 
-        This is helper for
+        This is helper for showing tool window by its name. It is possible
+        to pass additional args and kwargs.
+
+        Args:
+            tool_name: name of the tool
+            parent: tool parent
+            *args: tool args
+            **kwargs: tool kwargs
+
+        Returns:
+            QWidget of the tool shown or None if tool name is unknown
+            or tool can't be created.
+
         """
-        tool = None
         if tool_name == "workfiles":
-            tool = self.show_workfiles(parent, *args, **kwargs)
+            return self.show_workfiles(parent, *args, **kwargs)
 
-        elif tool_name == "loader":
-            tool = self.show_loader(parent)
+        if tool_name == "loader":
+            return self.show_loader(parent)
 
-        elif tool_name == "libraryloader":
-            tool = self.show_library_loader(parent)
+        if tool_name == "libraryloader":
+            return self.show_library_loader(parent)
 
-        elif tool_name == "sceneinventory":
-            tool = self.show_scene_inventory(parent)
+        if tool_name == "sceneinventory":
+            return self.show_scene_inventory(parent)
 
-        elif tool_name == "publish":
-            tool = self.show_publish(parent)
+        if tool_name == "publish":
+            return self.show_publish(parent)
 
-        elif tool_name == "publisher":
-            tool = self.show_publisher_tool(parent, *args, **kwargs)
+        if tool_name == "publisher":
+            return self.show_publisher_tool(parent, *args, **kwargs)
 
-        elif tool_name == "experimental_tools":
-            tool = self.show_experimental_tools_dialog(parent)
+        if tool_name == "experimental_tools":
+            return self.show_experimental_tools_dialog(parent)
 
-        else:
-            self.log.warning(
-                "Can't show unknown tool name: \"%s\"", tool_name)
-            return None
-        return tool
+        self.log.warning(
+            "Can't show unknown tool name: \"%s\"", tool_name
+        )
+        return None
 
 
 class _SingletonPoint:
@@ -361,11 +385,12 @@ class _SingletonPoint:
 
     @classmethod
     def show_tool_by_name(
-            cls,
-            tool_name: TToolNames,
-            parent: Optional[QWidget] = None,
-            *args,
-            **kwargs) -> Optional[QWidget]:
+        cls,
+        tool_name: ToolName,
+        parent: QWidget | None = None,
+        *args,
+        **kwargs
+    ) -> QWidget | None:
         cls._create_helper()
         return cls.helper.show_tool_by_name(tool_name, parent, *args, **kwargs)
 
@@ -381,10 +406,11 @@ def get_tool_by_name(tool_name, parent=None, *args, **kwargs):
 
 
 def show_tool_by_name(
-        tool_name: TToolNames,
-        parent: Optional[QWidget] = None,
-        *args,
-        **kwargs) -> Optional[QWidget]:
+    tool_name: ToolName,
+    parent: QWidget | None = None,
+    *args,
+    **kwargs
+) -> QWidget | None:
     """Show tool by its name.
 
     Args:
@@ -401,7 +427,7 @@ def show_tool_by_name(
         tool_name, parent, *args, **kwargs)
 
 
-def show_workfiles(*args, **kwargs) -> Optional[QWidget]:
+def show_workfiles(*args, **kwargs) -> QWidget | None:
     """Show workfiles tool.
 
     Args:
@@ -417,9 +443,9 @@ def show_workfiles(*args, **kwargs) -> Optional[QWidget]:
 
 
 def show_loader(
-        parent: Optional[QWidget] = None,
+        parent: QWidget | None = None,
         *,
-        use_context: bool = False) -> Optional[QWidget]:
+        use_context: bool = False) -> QWidget | None:
     """Show loader tool.
 
     Args:
@@ -435,22 +461,8 @@ def show_loader(
     )
 
 
-def show_library_loader(
-        parent: Optional[QWidget] = None) -> Optional[QWidget]:
-    """Show library loader tool.
-
-    Args:
-        parent: tool parent,
-
-    Returns:
-        QWidget of the tool
-
-    """
-    return _SingletonPoint.show_tool_by_name("libraryloader", parent)
-
-
 def show_scene_inventory(
-        parent: Optional[QWidget] = None) -> Optional[QWidget]:
+        parent: QWidget | None = None) -> QWidget | None:
     """Show scene inventory tool.
 
     Args:
@@ -464,7 +476,7 @@ def show_scene_inventory(
         "sceneinventory", parent)
 
 
-def show_publish(parent: Optional[QWidget] = None) -> Optional[QWidget]:
+def show_publish(parent: QWidget | None = None) -> QWidget | None:
     """Show publish tool.
 
     Args:
@@ -478,8 +490,8 @@ def show_publish(parent: Optional[QWidget] = None) -> Optional[QWidget]:
 
 
 def show_publisher(
-        parent: Optional[QWidget] = None,
-        **kwargs) -> Optional[QWidget]:
+        parent: QWidget | None = None,
+        **kwargs) -> QWidget | None:
     """Show publisher tool.
 
     Args:
@@ -495,7 +507,7 @@ def show_publisher(
 
 
 def show_experimental_tools_dialog(
-        parent: Optional[QWidget] = None) -> Optional[QWidget]:
+        parent: QWidget | None = None) -> QWidget | None:
     """Show experimental tools dialog.
 
     Args:

--- a/client/ayon_core/tools/utils/host_tools.py
+++ b/client/ayon_core/tools/utils/host_tools.py
@@ -174,7 +174,8 @@ class HostToolsHelper:
         return self.show_loader(parent)
 
     def show_publish(
-            self, parent: QWidget | None = None) -> QWidget:
+        self, parent: QWidget | None = None
+    ) -> QWidget:
         """Try showing the most desirable publish GUI
 
         This function cycles through the currently registered
@@ -320,11 +321,11 @@ class HostToolsHelper:
         return None
 
     def show_tool_by_name(
-            self,
-            tool_name: ToolName,
-            parent: QWidget | None = None,
-            *args,
-            **kwargs
+        self,
+        tool_name: ToolName,
+        parent: QWidget | None = None,
+        *args,
+        **kwargs
     ) -> QWidget | None:
         """Show tool by its name.
 
@@ -392,7 +393,9 @@ class _SingletonPoint:
         **kwargs
     ) -> QWidget | None:
         cls._create_helper()
-        return cls.helper.show_tool_by_name(tool_name, parent, *args, **kwargs)
+        return cls.helper.show_tool_by_name(
+            tool_name, parent, *args, **kwargs
+        )
 
     @classmethod
     def get_tool_by_name(cls, tool_name, parent=None, *args, **kwargs):
@@ -402,7 +405,9 @@ class _SingletonPoint:
 
 # Function callbacks using singleton access point
 def get_tool_by_name(tool_name, parent=None, *args, **kwargs):
-    return _SingletonPoint.get_tool_by_name(tool_name, parent, *args, **kwargs)
+    return _SingletonPoint.get_tool_by_name(
+        tool_name, parent, *args, **kwargs
+    )
 
 
 def show_tool_by_name(
@@ -424,7 +429,8 @@ def show_tool_by_name(
 
     """
     return _SingletonPoint.show_tool_by_name(
-        tool_name, parent, *args, **kwargs)
+        tool_name, parent, *args, **kwargs
+    )
 
 
 def show_workfiles(*args, **kwargs) -> QWidget | None:
@@ -443,9 +449,10 @@ def show_workfiles(*args, **kwargs) -> QWidget | None:
 
 
 def show_loader(
-        parent: QWidget | None = None,
-        *,
-        use_context: bool = False) -> QWidget | None:
+    parent: QWidget | None = None,
+    *,
+    use_context: bool = False
+) -> QWidget | None:
     """Show loader tool.
 
     Args:
@@ -462,7 +469,8 @@ def show_loader(
 
 
 def show_scene_inventory(
-        parent: QWidget | None = None) -> QWidget | None:
+    parent: QWidget | None = None
+) -> QWidget | None:
     """Show scene inventory tool.
 
     Args:
@@ -473,7 +481,8 @@ def show_scene_inventory(
 
     """
     return _SingletonPoint.show_tool_by_name(
-        "sceneinventory", parent)
+        "sceneinventory", parent
+    )
 
 
 def show_publish(parent: QWidget | None = None) -> QWidget | None:
@@ -490,8 +499,9 @@ def show_publish(parent: QWidget | None = None) -> QWidget | None:
 
 
 def show_publisher(
-        parent: QWidget | None = None,
-        **kwargs) -> QWidget | None:
+    parent: QWidget | None = None,
+    **kwargs
+) -> QWidget | None:
     """Show publisher tool.
 
     Args:
@@ -503,11 +513,13 @@ def show_publisher(
 
     """
     return _SingletonPoint.show_tool_by_name(
-        "publisher", parent, **kwargs)
+        "publisher", parent, **kwargs
+    )
 
 
 def show_experimental_tools_dialog(
-        parent: QWidget | None = None) -> QWidget | None:
+    parent: QWidget | None = None
+) -> QWidget | None:
     """Show experimental tools dialog.
 
     Args:
@@ -518,7 +530,8 @@ def show_experimental_tools_dialog(
 
     """
     return _SingletonPoint.show_tool_by_name(
-        "experimental_tools", parent)
+        "experimental_tools", parent
+    )
 
 
 def get_pyblish_icon():

--- a/client/ayon_core/tools/utils/host_tools.py
+++ b/client/ayon_core/tools/utils/host_tools.py
@@ -3,15 +3,33 @@
 It is possible to create `HostToolsHelper` in host implementation or
 use singleton approach with global functions (using helper anyway).
 """
+from __future__ import annotations
+
 import os
 
 import pyblish.api
+from typing import TYPE_CHECKING, Optional, Literal
 
 from ayon_core.host import ILoadHost, IPublishHost
 from ayon_core.lib import Logger
 from ayon_core.pipeline import registered_host
 
 from .lib import qt_app_context
+
+if TYPE_CHECKING:
+    from qtpy.QtWidgets import QWidget
+    from ayon_core.tools.publisher.abstract import AbstractPublisherFrontend
+
+TPublisherTabs = Literal["create", "publish", "report", "details"]
+TToolNames = Literal[
+    "workfiles",
+    "loader",
+    "libraryloader",
+    "sceneinventory",
+    "publisher",
+    "experimental_tools",
+    "publish"
+]
 
 
 class HostToolsHelper:
@@ -52,13 +70,20 @@ class HostToolsHelper:
         return self._workfiles_tool
 
     def show_workfiles(
-        self, parent=None, use_context=None, save=None, on_top=None
-    ):
+            self,
+            parent=None,
+            *,
+            use_context: Optional[bool] = False,
+            save: Optional[bool] = None,
+            on_top: Optional[bool] = None
+    ) -> Optional[QWidget]:
         """Workfiles tool for changing context and saving workfiles."""
 
         with qt_app_context():
             workfiles_tool = self.get_workfiles_tool(parent)
             workfiles_tool.ensure_visible(use_context, save, on_top)
+
+        return workfiles_tool
 
     def get_loader_tool(self, parent):
         """Create, cache and return loader tool window."""
@@ -79,8 +104,18 @@ class HostToolsHelper:
 
         return self._loader_tool
 
-    def show_loader(self, parent=None, use_context=None):
-        """Loader tool for loading representations."""
+    def show_loader(
+            self,
+            parent: Optional[QWidget] = None) -> QWidget:
+        """Loader tool for loading representations.
+
+        Args:
+            parent (QWidget): parent widget
+
+        Returns:
+            QWidget of the tool shown.
+
+        """
         with qt_app_context():
             loader_tool = self.get_loader_tool(parent)
 
@@ -88,11 +123,8 @@ class HostToolsHelper:
             loader_tool.raise_()
             loader_tool.activateWindow()
             loader_tool.showNormal()
-
-            if use_context is None:
-                use_context = False
-
             loader_tool.refresh()
+        return loader_tool
 
     def get_scene_inventory_tool(self, parent):
         """Create, cache and return scene inventory tool window."""
@@ -110,7 +142,8 @@ class HostToolsHelper:
 
         return self._scene_inventory_tool
 
-    def show_scene_inventory(self, parent=None):
+    def show_scene_inventory(
+            self, parent: Optional[QWidget] = None) -> QWidget:
         """Show tool maintain loaded containers."""
         with qt_app_context():
             scene_inventory_tool = self.get_scene_inventory_tool(parent)
@@ -122,15 +155,26 @@ class HostToolsHelper:
             scene_inventory_tool.activateWindow()
             scene_inventory_tool.showNormal()
 
+        return scene_inventory_tool
+
     def get_library_loader_tool(self, parent):
         """Create, cache and return library loader tool window."""
         return self.get_loader_tool(parent)
 
-    def show_library_loader(self, parent=None):
-        """Loader tool for loading representations from library project."""
+    def show_library_loader(self, parent: Optional[QWidget] = None) -> QWidget:
+        """Loader tool for loading representations from library project.
+
+        Args:
+            parent (QWidget): parent widget
+
+        Returns:
+            QWidget of the tool shown.
+
+        """
         return self.show_loader(parent)
 
-    def show_publish(self, parent=None):
+    def show_publish(
+            self, parent: Optional[QWidget] = None) -> QWidget:
         """Try showing the most desirable publish GUI
 
         This function cycles through the currently registered
@@ -174,8 +218,17 @@ class HostToolsHelper:
             self._experimental_tools_dialog = ExperimentalToolsDialog(parent)
         return self._experimental_tools_dialog
 
-    def show_experimental_tools_dialog(self, parent=None):
-        """Show dialog with experimental tools."""
+    def show_experimental_tools_dialog(
+            self, parent: Optional[QWidget] = None) -> QWidget:
+        """Show dialog with experimental tools.
+
+        Args:
+            parent (QWidget): parent widget.
+
+        Returns:
+            QWidget of the tool shown.
+
+        """
         with qt_app_context():
             dialog = self.get_experimental_tools_dialog(parent)
 
@@ -183,6 +236,8 @@ class HostToolsHelper:
             dialog.raise_()
             dialog.activateWindow()
             dialog.showNormal()
+
+        return dialog
 
     def get_publisher_tool(self, parent=None, controller=None):
         """Create, cache and return publisher window."""
@@ -201,75 +256,93 @@ class HostToolsHelper:
 
         return self._publisher_tool
 
-    def show_publisher_tool(self, parent=None, controller=None, tab=None):
+    def show_publisher_tool(
+            self,
+            parent: Optional[QWidget] = None,
+            controller: Optional[AbstractPublisherFrontend] = None,
+            tab: Optional[TPublisherTabs] = None) -> QWidget:
         with qt_app_context():
             window = self.get_publisher_tool(parent, controller)
             if tab:
                 window.set_current_tab(tab)
             window.make_sure_is_visible()
+            return window
 
-    def get_tool_by_name(self, tool_name, parent=None, *args, **kwargs):
-        """Show tool by it's name.
+    def get_tool_by_name(
+            self,
+            tool_name: TToolNames,
+            parent: Optional[QWidget] = None,
+            *args,
+            **kwargs
+    ) -> Optional[QWidget]:
+        """Show tool by its name.
 
         This is helper for
         """
         if tool_name == "workfiles":
-            return self.get_workfiles_tool(parent, *args, **kwargs)
+            return self.get_workfiles_tool(parent)
 
         if tool_name == "loader":
-            return self.get_loader_tool(parent, *args, **kwargs)
+            return self.get_loader_tool(parent)
 
         if tool_name == "libraryloader":
-            return self.get_library_loader_tool(parent, *args, **kwargs)
+            return self.get_library_loader_tool(parent)
 
         if tool_name == "sceneinventory":
-            return self.get_scene_inventory_tool(parent, *args, **kwargs)
+            return self.get_scene_inventory_tool(parent)
 
         if tool_name == "publisher":
             return self.get_publisher_tool(parent, *args, **kwargs)
 
         if tool_name == "experimental_tools":
-            return self.get_experimental_tools_dialog(parent, *args, **kwargs)
+            return self.get_experimental_tools_dialog(parent)
 
         if tool_name == "publish":
             self.log.info("Can't return publish tool window.")
             return None
 
         self.log.warning(
-            "Can't show unknown tool name: \"{}\"".format(tool_name)
-        )
+            'Cannot show unknown tool name: "%s"', tool_name)
         return None
 
-    def show_tool_by_name(self, tool_name, parent=None, *args, **kwargs):
-        """Show tool by it's name.
+    def show_tool_by_name(
+            self,
+            tool_name: TToolNames,
+            parent: Optional[QWidget] = None,
+            *args,
+            **kwargs
+    ) -> Optional[QWidget]:
+        """Show tool by its name.
 
         This is helper for
         """
+        tool = None
         if tool_name == "workfiles":
-            self.show_workfiles(parent, *args, **kwargs)
+            tool = self.show_workfiles(parent, *args, **kwargs)
 
         elif tool_name == "loader":
-            self.show_loader(parent, *args, **kwargs)
+            tool = self.show_loader(parent)
 
         elif tool_name == "libraryloader":
-            self.show_library_loader(parent, *args, **kwargs)
+            tool = self.show_library_loader(parent)
 
         elif tool_name == "sceneinventory":
-            self.show_scene_inventory(parent, *args, **kwargs)
+            tool = self.show_scene_inventory(parent)
 
         elif tool_name == "publish":
-            self.show_publish(parent, *args, **kwargs)
+            tool = self.show_publish(parent)
 
         elif tool_name == "publisher":
-            self.show_publisher_tool(parent, *args, **kwargs)
+            tool = self.show_publisher_tool(parent, *args, **kwargs)
 
         elif tool_name == "experimental_tools":
-            self.show_experimental_tools_dialog(parent, *args, **kwargs)
+            tool = self.show_experimental_tools_dialog(parent)
 
         else:
             self.log.warning(
-                "Can't show unknown tool name: \"{}\"".format(tool_name)
-            )
+                "Can't show unknown tool name: \"%s\"", tool_name)
+            return None
+        return tool
 
 
 class _SingletonPoint:
@@ -287,9 +360,14 @@ class _SingletonPoint:
             cls.helper = HostToolsHelper()
 
     @classmethod
-    def show_tool_by_name(cls, tool_name, parent=None, *args, **kwargs):
+    def show_tool_by_name(
+            cls,
+            tool_name: TToolNames,
+            parent: Optional[QWidget] = None,
+            *args,
+            **kwargs) -> Optional[QWidget]:
         cls._create_helper()
-        cls.helper.show_tool_by_name(tool_name, parent, *args, **kwargs)
+        return cls.helper.show_tool_by_name(tool_name, parent, *args, **kwargs)
 
     @classmethod
     def get_tool_by_name(cls, tool_name, parent=None, *args, **kwargs):
@@ -302,40 +380,133 @@ def get_tool_by_name(tool_name, parent=None, *args, **kwargs):
     return _SingletonPoint.get_tool_by_name(tool_name, parent, *args, **kwargs)
 
 
-def show_tool_by_name(tool_name, parent=None, *args, **kwargs):
-    _SingletonPoint.show_tool_by_name(tool_name, parent, *args, **kwargs)
+def show_tool_by_name(
+        tool_name: TToolNames,
+        parent: Optional[QWidget] = None,
+        *args,
+        **kwargs) -> Optional[QWidget]:
+    """Show tool by its name.
+
+    Args:
+        tool_name: tool name,
+        parent: tool parent,
+        *args: tool args,
+        **kwargs: tool kwargs,
+
+    Returns:
+        QWidget of the tool
+
+    """
+    return _SingletonPoint.show_tool_by_name(
+        tool_name, parent, *args, **kwargs)
 
 
-def show_workfiles(*args, **kwargs):
-    _SingletonPoint.show_tool_by_name(
+def show_workfiles(*args, **kwargs) -> Optional[QWidget]:
+    """Show workfiles tool.
+
+    Args:
+        *args: tool args,
+        **kwargs: tool kwargs,
+
+    Returns:
+        QWidget of the tool
+    """
+    return _SingletonPoint.show_tool_by_name(
         "workfiles", *args, **kwargs
     )
 
 
-def show_loader(parent=None, use_context=None):
-    _SingletonPoint.show_tool_by_name(
+def show_loader(
+        parent: Optional[QWidget] = None,
+        *,
+        use_context: bool = False) -> Optional[QWidget]:
+    """Show loader tool.
+
+    Args:
+        parent: tool parent,
+        use_context: use context,
+
+    Returns:
+        QWidget of the tool
+
+    """
+    return _SingletonPoint.show_tool_by_name(
         "loader", parent, use_context=use_context
     )
 
 
-def show_library_loader(parent=None):
-    _SingletonPoint.show_tool_by_name("libraryloader", parent)
+def show_library_loader(
+        parent: Optional[QWidget] = None) -> Optional[QWidget]:
+    """Show library loader tool.
+
+    Args:
+        parent: tool parent,
+
+    Returns:
+        QWidget of the tool
+
+    """
+    return _SingletonPoint.show_tool_by_name("libraryloader", parent)
 
 
-def show_scene_inventory(parent=None):
-    _SingletonPoint.show_tool_by_name("sceneinventory", parent)
+def show_scene_inventory(
+        parent: Optional[QWidget] = None) -> Optional[QWidget]:
+    """Show scene inventory tool.
+
+    Args:
+        parent: tool parent,
+
+    Returns:
+        QWidget of the tool
+
+    """
+    return _SingletonPoint.show_tool_by_name(
+        "sceneinventory", parent)
 
 
-def show_publish(parent=None):
-    _SingletonPoint.show_tool_by_name("publish", parent)
+def show_publish(parent: Optional[QWidget] = None) -> Optional[QWidget]:
+    """Show publish tool.
+
+    Args:
+        parent: tool parent
+
+    Returns:
+        QWidget of the tool
+
+    """
+    return _SingletonPoint.show_tool_by_name("publish", parent)
 
 
-def show_publisher(parent=None, **kwargs):
-    _SingletonPoint.show_tool_by_name("publisher", parent, **kwargs)
+def show_publisher(
+        parent: Optional[QWidget] = None,
+        **kwargs) -> Optional[QWidget]:
+    """Show publisher tool.
+
+    Args:
+        parent: tool parent,
+        **kwargs: tool kwargs,
+
+    Returns:
+        QWidget of the tool
+
+    """
+    return _SingletonPoint.show_tool_by_name(
+        "publisher", parent, **kwargs)
 
 
-def show_experimental_tools_dialog(parent=None):
-    _SingletonPoint.show_tool_by_name("experimental_tools", parent)
+def show_experimental_tools_dialog(
+        parent: Optional[QWidget] = None) -> Optional[QWidget]:
+    """Show experimental tools dialog.
+
+    Args:
+        parent: tool parent
+
+    Returns:
+        QWidget of the tool
+
+    """
+    return _SingletonPoint.show_tool_by_name(
+        "experimental_tools", parent)
 
 
 def get_pyblish_icon():


### PR DESCRIPTION
## Changelog Description
Make all `show_*()` functions to return QWidget so the code calling it can work with it. Also add some type annotations and docstrings.

## Additional info
This is needed for example in Unreal, where you need to call `unreal.parent_external_window_to_slate()` on `winId()` of the widget. Might be useful for other things too.

> [!TIP]
> For PR that can make use of it, see https://github.com/ynput/ayon-unreal/pull/269

## Testing notes:
Without proper support this cannot be easily tested. However, all should work as before.