### PR TITLE
Placeholders filter on product base types

### DIFF
--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1678,12 +1678,10 @@ class PlaceholderLoadMixin(object):
         if not folder_ids:
             return []
 
-        # TODO this should filter by product_base_types
-        # - that can change only when AYON server 1.14.0 is required
         products = list(get_products(
             project_name,
             folder_ids=folder_ids,
-            product_types={product_base_type},
+            product_base_types={product_base_type},
             fields={"id", "name"}
         ))
         filtered_product_ids = set()


### PR DESCRIPTION
## Description
Use product base type for product entity filtering instead of product type.

## Additional information
Now that ayon-core requires ayon_launcher_version >=1.5.4, the load placeholder should be able to correctly filter based on product_base_type rather than product_type.