### PR TITLE
Add `editorial_pkg` product type to thumbnail extractor

### DIFF
--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -95,7 +95,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
     order = pyblish.api.ExtractorOrder + 0.49
     families = [
         "imagesequence", "render", "render2d", "prerender",
-        "source", "clip", "take", "online", "image"
+        "source", "clip", "take", "online", "image", "editorial_pkg"
     ]
     hosts = [
         "shell",


### PR DESCRIPTION
## Changelog Description
`editorial_pkg` was missing from the supported `families` in the `ExtractThumbnail` plugin, causing editorial package products to never generate thumbnails.

## Additional info
Single-line change in `client/ayon_core/plugins/publish/extract_thumbnail.py` — `"editorial_pkg"` appended to the `families` list of the `ExtractThumbnail` pyblish plugin.

## Testing notes:
1. Publish an editorial package product (e.g. from a host that produces `editorial_pkg` instances).
2. Confirm a thumbnail is extracted and visible in the target tracker (e.g. ftrack).

## Dependency
Close #1859
[YN-0626](https://support.ayon.app/projects/Active_Clients/overview?project=Active_Clients&type=task&id=da676290325a11f1b5cd3f72ee2f91ca)
