### PR TITLE
Workfile templates: Save workfile entity when template is used

### DIFF
--- a/client/ayon_core/hooks/pre_copy_template_workfile.py
+++ b/client/ayon_core/hooks/pre_copy_template_workfile.py
@@ -1,11 +1,19 @@
 import os
 import shutil
+
 from ayon_core.settings import get_project_settings
-from ayon_applications import PreLaunchHook, LaunchTypes
+
+from ayon_core.pipeline.template_data import get_template_data
 from ayon_core.pipeline.workfile import (
     get_custom_workfile_template,
-    get_custom_workfile_template_by_string_context
+    get_custom_workfile_template_by_string_context,
+    save_workfile_info,
+    find_workfile_rootless_path,
+    get_last_workfile_with_version_from_paths,
+    get_workfile_template_key,
 )
+
+from ayon_applications import PreLaunchHook, LaunchTypes
 
 
 class CopyTemplateWorkfile(PreLaunchHook):
@@ -111,4 +119,50 @@ class CopyTemplateWorkfile(PreLaunchHook):
         shutil.copy2(
             os.path.normpath(template_path),
             os.path.normpath(last_workfile)
+        )
+
+        # TODO Collect all the the information to hook data when last workfile
+        #   is being prepared
+        # NOTE Right now data needed to store workfile entity
+        #   (rootless path, version) are not available and has to be guessed
+        rootless_path = find_workfile_rootless_path(
+            last_workfile,
+            project_name,
+            folder_entity,
+            task_entity,
+            host_name,
+            project_entity=project_entity,
+            project_settings=project_settings,
+            anatomy=anatomy,
+        )
+        template_key = get_workfile_template_key(
+            project_name,
+            task_entity["taskType"],
+            host_name,
+            project_settings=project_settings,
+        )
+        # Find last workfile
+        file_template = anatomy.get_template_item(
+            "work", template_key, "file"
+        ).template
+        template_data = get_template_data(
+            project_entity,
+            folder_entity,
+            task_entity,
+            host_name,
+            settings=project_settings,
+        )
+        ext = os.path.splitext(last_workfile)[1]
+        _, version = get_last_workfile_with_version_from_paths(
+            [last_workfile],
+            file_template,
+            template_data,
+            {ext},
+        )
+        save_workfile_info(
+            project_name,
+            task_entity["id"],
+            rootless_path,
+            host_name,
+            version=version,
         )


### PR DESCRIPTION
## Changelog Description
Save workfile entity when template is being used.

## Additional info
Because we do store only last workfile path, which can actually not hold last workfile ATM, we don't have access to rootless path and version available. We should change what we actually do store to launch context and store also additional information that are available when last workfile is being prepared so we don't have to parse it out recursively which can lead to use wrong rootless path (wrong root in the path) or wront version.

## Testing notes:
1. Make sure you don't have any workfiles yet available for a task.
2. Make sure to have set up settings to use template for first version.
3. Start a host on the task.
4. First workfile should be copied using the template and workfile entity should be created (can be validated in launcher tool).

Resolves https://github.com/ynput/ayon-core/issues/1817