### PR TITLE
Remove `hosts` and `families` filtering from `ExtractThumbnail`

### DIFF
--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -93,24 +93,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
 
     label = "Extract Thumbnail"
     order = pyblish.api.ExtractorOrder + 0.49
-    families = [
-        "imagesequence", "render", "render2d", "prerender",
-        "source", "clip", "take", "online", "image"
-    ]
-    hosts = [
-        "shell",
-        "fusion",
-        "resolve",
-        "traypublisher",
-        "substancepainter",
-        "substancedesigner",
-        "nuke",
-        "aftereffects",
-        "photoshop",
-        "unreal",
-        "houdini",
-        "batchdelivery",
-    ]
+
     settings_category = "core"
     enabled = False
 


### PR DESCRIPTION
## Changelog Description

Remove `hosts` and `families` filtering from `ExtractThumbnail`

## Additional info

Follow up to: https://github.com/ynput/ayon-core/pull/1860#discussion_r3332652060

This will need some follow up changes. The class name for example is not unique. Same class name exists in:
```
client/ayon_core/plugins/publish/extract_thumbnail.py
client/ayon_maya/plugins/publish/extract_thumbnail.py
client/ayon_hiero/plugins/publish/extract_thumbnail.py
client/ayon_blender/plugins/publish/extract_thumbnail.py
client/ayon_max/plugins/publish/extract_thumbnail.py
```

This will also need thorough testing whether it does not conflict with logic in certain DCCs like e.g. the ones mentioned here that also roll their own Extract Thumbnail plug-in.

## Testing notes:

1. Extract Thumbnail should work
2. Extract Thumbnail should not cause issues in any of the DCCs/integrations.
