### PR TITLE
Launcher: Use first index with workfile id

### DIFF
--- a/client/ayon_core/tools/launcher/ui/workfiles_page.py
+++ b/client/ayon_core/tools/launcher/ui/workfiles_page.py
@@ -351,10 +351,13 @@ class WorkfilesPage(QtWidgets.QWidget):
         view_header.resizeSection(view_header.logicalIndex(0), col_1_width)
 
     def _on_selection_changed(self, selected, _deselected) -> None:
-        workfile_id = None
         for index in selected.indexes():
-            workfile_id = index.data(WORKFILE_ID_ROLE)
-        self._controller.set_selected_workfile(workfile_id)
+            if workfile_id := index.data(WORKFILE_ID_ROLE):
+                self._controller.set_selected_workfile(workfile_id)
+                return
+
+        # no workfile selected
+        self._controller.set_selected_workfile(None)
 
     def _on_view_clicked(self, index) -> None:
         if not index.isValid() or index.data(ITEM_TYPE_ROLE) != 1:


### PR DESCRIPTION
## Changelog Description
Fixes a bug where the "Modified" Column would clear the selected workfile

## Additional info
`selected.indexes()` returns both columns, but only column 0 returns a value for `WORKFILE_ID_ROLE`
Column 1 returns `None`

to verify a few print statements can be added as such:
```py
def _on_selection_changed(self, selected, _deselected) -> None:
    for index in selected.indexes():
        workfile_id = index.data(WORKFILE_ID_ROLE)
        print(f"{index.row()}/{index.column()} {workfile_id=}")
```
result:
```txt
108/0 workfile_id='be1123e2d66c4ca2b99d9c79b883124d'
108/1 workfile_id=None
116/0 workfile_id='1dcdfeffa5dd45cf9c86d6a7ba6454ce'
116/1 workfile_id=None
105/0 workfile_id='fc1b449577da42989435a43487ec7777'
105/1 workfile_id=None
113/0 workfile_id='88be2d760d9046589b6aca934ccd77b0'
113/1 workfile_id=None
103/0 workfile_id='d573e5a3425b408297de92ed4391e84c'
103/1 workfile_id=None
```

This fixes two issues:
1. selecting a workfile + opening an App opens the selected workfile (currently its always using the latest)
2. selecting a workfile filters the shown app's based on which app is compatible


## Testing notes:
1. open launcher
2. select a workfile
3. open an app
4. expected result: the **selected** workfile will be opened


