### PR TITLE
Workfiles API: Safer rootless path calculation

### DIFF
--- a/client/ayon_core/tools/workfiles/models/workfiles.py
+++ b/client/ayon_core/tools/workfiles/models/workfiles.py
@@ -442,16 +442,9 @@ class WorkfilesModel:
 
         workdir = self._get_workdir(anatomy, template_key, fill_data)
 
-        rootless_workdir = workdir
+        rootless_workdir = workdir.rootless
         if platform.system().lower() == "windows":
             rootless_workdir = rootless_workdir.replace("\\", "/")
-
-        used_roots = workdir.used_values.get("root")
-        if used_roots:
-            used_root_name = next(iter(used_roots))
-            root_value = used_roots[used_root_name]
-            workdir_end = rootless_workdir[len(root_value):].lstrip("/")
-            rootless_workdir = f"{{root[{used_root_name}]}}/{workdir_end}"
 
         file_template = anatomy.get_template_item(
             "work", template_key, "file"


### PR DESCRIPTION
## Problem
When manually saving a workfile using the "Save As" button in AYON, the database entry was stripping leading zeros from folder names in the path.

**Example:**
- Expected: `M://01_production/research/jbloenni/bear/modeling/work/blender/jbloenni.bear.modeling.work.blender.v002.blend`
- Actual: `M://1_production/research/jbloenni/bear/modeling/work/blender/jbloenni.bear.modeling.work.blender.v002.blend`

This issue only occurred with manual saves; publishing workfiles incremented the path correctly.

## Root Cause
The `get_workarea_save_as_data()` method was reconstructing the `rootless_workdir` by extracting the root value from `used_values["root"]` and using string slicing. This logic was prone to conversion issues that lost the leading zero information.

## Solution
Use the pre-calculated `workdir.rootless` property directly instead of reconstructing it. The `AnatomyTemplateResult.rootless` property is already correctly calculated by the Anatomy system's `get_rootless_path_from_result()` method, which properly handles root placeholders and preserves all path components including leading zeros.

**Changes:**
- Replaced manual root extraction and string slicing logic with direct use of `workdir.rootless`
- Removed 6 lines of unnecessary code duplication
- Simplified and made the code more reliable

## Testing
1. Create a folder with a leading zero in the name (e.g., `01_production`)
2. Manually save a workfile using "Save As" button
3. Verify the database entry shows the correct path with `01_production`, not `1_production`
4. Compare with publish behavior (should now be consistent)

## Files Changed
- `tools/workfiles/models/workfiles.py` (lines 445-454)

Closes #1866 