### PR TITLE
Push To Project: Use task type capitalisation matched in destination project

### DIFF
--- a/client/ayon_core/tools/push_to_project/models/integrate.py
+++ b/client/ayon_core/tools/push_to_project/models/integrate.py
@@ -882,11 +882,11 @@ class ProjectPushItemProcess:
         # Fill rest of task information based on task type
         task_type_name = task_info["taskType"]
         task_types_by_name = {
-            task_type["name"]: task_type
+            task_type["name"].lower(): task_type
             for task_type in self._project_entity["taskTypes"]
         }
         task_type_info = copy.deepcopy(
-            task_types_by_name.get(task_type_name, {})
+            task_types_by_name.get(task_type_name.lower(), {})
         )
         task_type_info.pop("name")  # do not overwrite real task name
         task_info.update(task_type_info)
@@ -1110,11 +1110,11 @@ class ProjectPushItemProcess:
     ) -> dict[str, Any]:
         """Creates destination task from source task information"""
         project_name = self._item.dst_project_name
-        found_task_type = False
+        found_task_type = None
         src_task_type = task_info["taskType"]
         for task_type in self._project_entity["taskTypes"]:
             if task_type["name"].lower() == src_task_type.lower():
-                found_task_type = True
+                found_task_type = task_type["name"]
                 break
 
         if not found_task_type:
@@ -1129,7 +1129,7 @@ class ProjectPushItemProcess:
             project_name,
             task_info["name"],
             folder_id=folder_entity["id"],
-            task_type=src_task_type,
+            task_type=found_task_type,
             attrib=task_info["attrib"],
         )
         self._task_info = task_info.data

--- a/client/ayon_core/tools/push_to_project/models/integrate.py
+++ b/client/ayon_core/tools/push_to_project/models/integrate.py
@@ -882,11 +882,11 @@ class ProjectPushItemProcess:
         # Fill rest of task information based on task type
         task_type_name = task_info["taskType"]
         task_types_by_name = {
-            task_type["name"].lower(): task_type
+            task_type["name"]: task_type
             for task_type in self._project_entity["taskTypes"]
         }
         task_type_info = copy.deepcopy(
-            task_types_by_name.get(task_type_name.lower(), {})
+            task_types_by_name.get(task_type_name, {})
         )
         task_type_info.pop("name")  # do not overwrite real task name
         task_info.update(task_type_info)


### PR DESCRIPTION
## Changelog Description
changes the task_type lookup to use the capitalisation found on the destination project

## Additional info
Fixes an issue where the same task type uses different capitalisation across projects.

task type matching is already case-insensitive in most places, but the created/returned `taskType` did still use the capitalisation from the source project.
With this change, the task type returned will use the capitalisation found in the destination project.


## Testing notes:
1. publish an asset to project A using a task_type with 1 capitalisation (eg.: ``"Animation"`)
2. update anatomy on project B to have a different capitalisation for the same task type (eg.: `"ANIMation"`)
3. push the product from project A to B
