### PR TITLE
ScrollMessageBox: add icon and prevent scroll_widget from stretching

### DIFF
--- a/client/ayon_core/tools/utils/dialogs.py
+++ b/client/ayon_core/tools/utils/dialogs.py
@@ -1,7 +1,27 @@
 import logging
-from qtpy import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore, QtGui
 
 log = logging.getLogger(__name__)
+
+
+def icon_widget(icon, size: int = 64) -> QtWidgets.QLabel:
+    """Wrap an Icon into a QLabel with a fixed size.
+
+    Args:
+        icon (QtWidgets.QMessageBox.Icon | QtGui.QIcon): Icon to display.
+        size (int): Size of the icon in pixels (default: 64).
+
+    Returns:
+        QtWidgets.QLabel: Label with the icon.
+
+    """
+    label = QtWidgets.QLabel()
+    if isinstance(icon, QtGui.QIcon):
+        label.setPixmap(icon.pixmap(size, size))
+    else:
+        label.setPixmap(QtWidgets.QMessageBox.standardIcon(icon))
+
+    return label
 
 
 def show_message_dialog(title, message, level=None, parent=None):
@@ -34,7 +54,7 @@ class ScrollMessageBox(QtWidgets.QDialog):
     No other existing dialog implementation is scrollable.
 
     Args:
-        icon (QtWidgets.QMessageBox.Icon): Icon to display.
+        icon (QtWidgets.QMessageBox.Icon | QtGui.QIcon): Icon to display.
         title (str): Window title.
         messages (list[str]): List of messages.
         cancelable (Optional[bool]): True if Cancel button should be added.
@@ -44,10 +64,11 @@ class ScrollMessageBox(QtWidgets.QDialog):
         super().__init__()
         self.setWindowTitle(title)
         self.icon = icon
-
         self._messages = messages
 
         self.setWindowFlags(QtCore.Qt.WindowTitleHint)
+
+        wrapped_icon = icon_widget(icon)
 
         scroll_widget = QtWidgets.QScrollArea(self)
         scroll_widget.setWidgetResizable(True)
@@ -60,6 +81,7 @@ class ScrollMessageBox(QtWidgets.QDialog):
             label_widget = QtWidgets.QLabel(message, content_widget)
             content_layout.addWidget(label_widget)
             message_len = max(message_len, len(message))
+        content_layout.addStretch(1)
 
         # Set minimum width
         scroll_widget.setMinimumWidth(360)
@@ -78,9 +100,12 @@ class ScrollMessageBox(QtWidgets.QDialog):
         btn.clicked.connect(self._on_copy_click)
         btn_box.addButton(btn, QtWidgets.QDialogButtonBox.NoRole)
 
-        main_layout = QtWidgets.QVBoxLayout(self)
-        main_layout.addWidget(scroll_widget, 1)
-        main_layout.addWidget(btn_box, 0)
+        main_layout = QtWidgets.QGridLayout(self)
+        main_layout.addWidget(wrapped_icon, 0, 0,
+            alignment=QtCore.Qt.AlignmentFlag.AlignTop,
+        )
+        main_layout.addWidget(scroll_widget, 0, 1)
+        main_layout.addWidget(btn_box, 1, 1)
 
     def _on_copy_click(self):
         clipboard = QtWidgets.QApplication.clipboard()

--- a/client/ayon_core/tools/utils/dialogs.py
+++ b/client/ayon_core/tools/utils/dialogs.py
@@ -108,6 +108,7 @@ class ScrollMessageBox(QtWidgets.QDialog):
         main_layout.addWidget(btn_box, 1, 1)
         main_layout.setRowStretch(0, 1)
         main_layout.setRowStretch(1, 0)
+
     def _on_copy_click(self):
         clipboard = QtWidgets.QApplication.clipboard()
         clipboard.setText("\n".join(self._messages))

--- a/client/ayon_core/tools/utils/dialogs.py
+++ b/client/ayon_core/tools/utils/dialogs.py
@@ -4,7 +4,7 @@ from qtpy import QtWidgets, QtCore, QtGui
 log = logging.getLogger(__name__)
 
 
-def icon_widget(icon, size: int = 64) -> QtWidgets.QLabel:
+def icon_widget(parent, icon, size: int = 64) -> QtWidgets.QLabel:
     """Wrap an Icon into a QLabel with a fixed size.
 
     Args:
@@ -15,7 +15,7 @@ def icon_widget(icon, size: int = 64) -> QtWidgets.QLabel:
         QtWidgets.QLabel: Label with the icon.
 
     """
-    label = QtWidgets.QLabel()
+    label = QtWidgets.QLabel(parent)
     if isinstance(icon, QtGui.QIcon):
         label.setPixmap(icon.pixmap(size, size))
     else:
@@ -68,7 +68,7 @@ class ScrollMessageBox(QtWidgets.QDialog):
 
         self.setWindowFlags(QtCore.Qt.WindowTitleHint)
 
-        wrapped_icon = icon_widget(icon)
+        wrapped_icon = icon_widget(self, icon)
 
         scroll_widget = QtWidgets.QScrollArea(self)
         scroll_widget.setWidgetResizable(True)
@@ -106,7 +106,8 @@ class ScrollMessageBox(QtWidgets.QDialog):
         )
         main_layout.addWidget(scroll_widget, 0, 1)
         main_layout.addWidget(btn_box, 1, 1)
-
+        main_layout.setRowStretch(0, 1)
+        main_layout.setRowStretch(1, 0)
     def _on_copy_click(self):
         clipboard = QtWidgets.QApplication.clipboard()
         clipboard.setText("\n".join(self._messages))


### PR DESCRIPTION
## Changelog Description
includes the given `icon` in the Dialog Layout and prevents the Messages from stretching beyond their required height

## Additional info

I'd have preferred to keep it simpler such as:
```diff
        main_layout = QtWidgets.QVBoxLayout(self)
        main_layout.addWidget(scroll_widget, 1)
+       main_layout.addStretch()
        main_layout.addWidget(btn_box, 0)
```
but... Qt can be annoying when it comes to combining multiple resizing widgets and I had to swap to a GridLayout anyways in order to include the icon.
The current approach does cause the box around the scroll area to grow too... but I'd say that acceptable


## Testing notes:

test dialog I've used for testing
```py
from ayon_core.tools.utils import dialogs
from qtpy import QtWidgets

from importlib import reload
reload(dialogs)

messages = [f"Hello {i}" for i in range(30)]

diag = dialogs.ScrollMessageBox(
    title="Hello",
    messages=messages,
    icon=QtWidgets.QMessageBox.Icon.Critical,
)
diag.show()
```


## before:

https://github.com/user-attachments/assets/bc52f638-c6f4-44b0-9890-303ef5ec92f2

## after:

https://github.com/user-attachments/assets/a3995695-773b-4ea9-80d8-0bfa9ad1d4ec


