### PR TITLE
Integrate published versions into AYON entity lists

### DIFF
--- a/client/ayon_core/pipeline/structures.py
+++ b/client/ayon_core/pipeline/structures.py
@@ -7,8 +7,16 @@ ListType = Literal["generic", "review-session"]
 
 
 @dataclass
+class ListConfigFolder:
+    label: str
+    scope: list[str] = field(default_factory=list)
+    color: str | None = None
+    icon: str | None = None
+
+
+@dataclass
 class ListConfig:
     """Define a list."""
     name: str
     list_type: ListType = "generic"
-    list_folders: list[str] = field(default_factory=list)
+    list_folders: list[ListConfigFolder] = field(default_factory=list)

--- a/client/ayon_core/pipeline/structures.py
+++ b/client/ayon_core/pipeline/structures.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+ListType = Literal["generic", "review-session"]
+
+@dataclass
+class ListConfig:
+    """Define a list."""
+    name: str
+    parent_folders: list[str] | None = None
+    list_type: ListType = "generic"

--- a/client/ayon_core/pipeline/structures.py
+++ b/client/ayon_core/pipeline/structures.py
@@ -10,5 +10,5 @@ ListType = Literal["generic", "review-session"]
 class ListConfig:
     """Define a list."""
     name: str
-    parent_folders: list[str] = field(default_factory=list)
     list_type: ListType = "generic"
+    list_folders: list[str] = field(default_factory=list)

--- a/client/ayon_core/pipeline/structures.py
+++ b/client/ayon_core/pipeline/structures.py
@@ -9,7 +9,8 @@ ListType = Literal["generic", "review-session"]
 @dataclass
 class ListConfigFolder:
     label: str
-    scope: list[str] = field(default_factory=list)
+    # Empty list means the folder is visible for all list types
+    scope: list[ListType] = field(default_factory=list)
     color: str | None = None
     icon: str | None = None
 

--- a/client/ayon_core/pipeline/structures.py
+++ b/client/ayon_core/pipeline/structures.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 ListType = Literal["generic", "review-session"]
@@ -10,5 +10,5 @@ ListType = Literal["generic", "review-session"]
 class ListConfig:
     """Define a list."""
     name: str
-    parent_folders: list[str] | None = None
+    parent_folders: list[str] = field(default_factory=list)
     list_type: ListType = "generic"

--- a/client/ayon_core/pipeline/structures.py
+++ b/client/ayon_core/pipeline/structures.py
@@ -18,6 +18,6 @@ class ListConfigFolder:
 @dataclass
 class ListConfig:
     """Define a list."""
-    name: str
+    label: str
     list_type: ListType = "generic"
     list_folders: list[ListConfigFolder] = field(default_factory=list)

--- a/client/ayon_core/pipeline/structures.py
+++ b/client/ayon_core/pipeline/structures.py
@@ -5,6 +5,7 @@ from typing import Literal
 
 ListType = Literal["generic", "review-session"]
 
+
 @dataclass
 class ListConfig:
     """Define a list."""

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -42,9 +42,8 @@ class CollectVersionToList(pyblish.api.InstancePlugin):
         if profile:
             processing_items.append(profile)
 
-        anatomy_data: dict[str, Any] = instance.data["anatomyData"]
         anatomy: Anatomy = instance.context.data["anatomy"]
-        template_data = deepcopy(anatomy_data)
+        template_data = deepcopy(instance.data["anatomyData"])
         template_data.update({
             "root": anatomy.roots,
             "platform": platform.system().lower(),

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -29,31 +29,43 @@ class CollectVersionToList(pyblish.api.InstancePlugin):
     profiles = []
 
     def process(self, instance):
+        version_lists_templates = instance.data.get(
+            "versionListsTemplates", [])
         profile = self._get_config_from_profile(instance)
-        if not profile:
+        if not profile and not version_lists_templates:
             self.log.debug(f"No profile found for instance {instance}")
             return
 
+        processing_items = []
+        if version_lists_templates:
+            processing_items += version_lists_templates
+        if profile:
+            processing_items.append(profile)
+
         anatomy_data: dict[str, Any] = instance.data["anatomyData"]
         anatomy: Anatomy = instance.context.data["anatomy"]
-        name_template = profile["name_template"]
         template_data = deepcopy(anatomy_data)
         template_data.update({
             "root": anatomy.roots,
             "platform": platform.system().lower(),
         })
-
-        list_name = StringTemplate.format_strict_template(
-            name_template, template_data)
         version_lists: list[ListConfig] = instance.data.setdefault(
             "versionLists", [])
-        version_lists.append(
-            ListConfig(
-                name=list_name,
-                parent_folders=profile.get("parent_folders", None),
-                is_review_list=profile.get("is_review_list", False),
+        for item in processing_items:
+            name_template = item["name_template"]
+            data = item.get("data", {})
+            if data:
+                template_data.update(data)
+            list_name = StringTemplate.format_strict_template(
+                name_template, template_data)
+            version_lists.append(
+                ListConfig(
+                    name=list_name,
+                    parent_folders=item.get("parent_folders", None),
+                    is_review_list=item.get("is_review_list", False),
+                )
             )
-        )
+        self.log.debug(f"Collected version lists: {version_lists}")
 
     def _get_config_from_profile(
         self,

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -28,14 +28,24 @@ class CollectVersionToList(pyblish.api.InstancePlugin):
             self.log.debug(f"No profile found for instance {instance}")
             return
 
+        list_folders = []
+        for item in profile["list_folders"]:
+            scope = []
+            if item["scope_def"] == "list_type":
+                scope.append(profile["list_type"])
+
+            list_folders.append(
+                ListConfigFolder(
+                    label=item["label"],
+                    scope=scope,
+                )
+            )
+
         version_lists.append(
             ListConfig(
                 name=profile["list_name"],
                 list_type=profile["list_type"],
-                list_folders=[
-                    ListConfigFolder(label=name)
-                    for name in profile["parent_folders"]
-                ],
+                list_folders=list_folders,
             )
         )
         self.log.debug(f"Collected version lists: {version_lists}")

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -25,10 +25,10 @@ class CollectVersionToList(pyblish.api.InstancePlugin):
             self.log.debug(f"Version lists already collected: {version_lists}")
             return
 
-        name_template = profile["name_template"]
+        name = profile["name"]
         version_lists.append(
             ListConfig(
-                name=name_template,
+                name=name,
                 parent_folders=profile.get("parent_folders", None),
                 list_type=profile["list_type"],
             )

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -43,7 +43,7 @@ class CollectVersionToList(pyblish.api.InstancePlugin):
 
         version_lists.append(
             ListConfig(
-                name=profile["list_name"],
+                label=profile["list_name"],
                 list_type=profile["list_type"],
                 list_folders=list_folders,
             )

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -45,7 +45,6 @@ class CollectVersionToList(pyblish.api.InstancePlugin):
 
         list_name = StringTemplate.format_strict_template(
             name_template, template_data)
-
         version_lists: list[ListConfig] = instance.data.setdefault(
             "versionLists", [])
         version_lists.append(

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -10,6 +10,7 @@ class CollectVersionToList(pyblish.api.InstancePlugin):
 
     order = pyblish.api.CollectorOrder + 0.499
     label = "Collect Version to List"
+    settings_category = "core"
 
     profiles = []
 

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -30,7 +30,7 @@ class CollectVersionToList(pyblish.api.InstancePlugin):
         version_lists.append(
             ListConfig(
                 name=name,
-                parent_folders=profile.get("parent_folders", None),
+                parent_folders=profile["parent_folders"],
                 list_type=profile["list_type"],
             )
         )

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -25,7 +25,7 @@ class CollectVersionToList(pyblish.api.InstancePlugin):
             self.log.debug(f"Version lists already collected: {version_lists}")
             return
 
-        name = profile["name"]
+        name = profile["list_name"]
         version_lists.append(
             ListConfig(
                 name=name,

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -15,15 +15,17 @@ class CollectVersionToList(pyblish.api.InstancePlugin):
     profiles = []
 
     def process(self, instance):
+        if "versionLists" in instance.data:
+            version_lists = instance.data["versionLists"]
+            self.log.debug(f"Version lists already collected: {version_lists}")
+            return
+
+        version_lists: list[ListConfig] = []
+        instance.data["versionLists"] = version_lists
+
         profile = self._get_profile_for_instance(instance)
         if not profile:
             self.log.debug(f"No profile found for instance {instance}")
-            return
-        version_lists: list[ListConfig] = instance.data.setdefault(
-            "versionLists", [])
-
-        if version_lists:
-            self.log.debug(f"Version lists already collected: {version_lists}")
             return
 
         name = profile["list_name"]

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import platform
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import pyblish.api
+from ayon_core.lib import StringTemplate, filter_profiles
+
+if TYPE_CHECKING:
+    from ayon_core.pipeline import Anatomy
+
+
+@dataclass
+class ListConfig:
+    """Define a list."""
+    name: str
+    parent_folders: list[str] | None = None
+    is_review_list: bool = False
+
+
+class CollectVersionToList(pyblish.api.InstancePlugin):
+    """Collect Version to List."""
+
+    order = pyblish.api.CollectorOrder + 0.499
+    label = "Collect Version to List"
+
+    profiles = []
+
+    def process(self, instance):
+        profile = self._get_config_from_profile(instance)
+        if not profile:
+            self.log.debug(f"No profile found for instance {instance}")
+            return
+
+        anatomy_data: dict[str, Any] = instance.data["anatomyData"]
+        anatomy: Anatomy = instance.context.data["anatomy"]
+        name_template = profile["name_template"]
+        template_data = deepcopy(anatomy_data)
+        template_data.update({
+            "root": anatomy.roots,
+            "platform": platform.system().lower(),
+        })
+
+        list_name = StringTemplate.format_strict_template(
+            name_template, template_data)
+
+        version_lists: list[ListConfig] = instance.data.setdefault(
+            "versionLists", [])
+        version_lists.append(
+            ListConfig(
+                name=list_name,
+                parent_folders=profile.get("parent_folders", None),
+                is_review_list=profile.get("is_review_list", False),
+            )
+        )
+
+    def _get_config_from_profile(
+        self,
+        instance: pyblish.api.Instance
+    ) -> dict | None:
+        """Returns profile for the given instance."""
+        host_name = instance.context.data["hostName"]
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
+        product_name = instance.data["productName"]
+        task_data = instance.data["anatomyData"].get("task", {})
+        task_name = task_data.get("name")
+        task_type = task_data.get("type")
+        filtering_criteria = {
+            "host_names": host_name,
+            "product_base_types": product_base_type,
+            "product_names": product_name,
+            "task_names": task_name,
+            "task_types": task_type,
+        }
+        profile = filter_profiles(
+            self.profiles,
+            filtering_criteria,
+            logger=self.log
+        )
+
+        if not profile:
+            self.log.debug(
+                "Skipped instance. None of profiles in presets are for"
+                f' Host name: "{host_name}"'
+                f' | Product base type: "{product_base_type}"'
+                f' | Product name: "{product_name}"'
+                f' | Task name "{task_name}"'
+                f' | Task type "{task_type}"'
+            )
+            return None
+
+        return profile

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -31,7 +31,7 @@ class CollectVersionToList(pyblish.api.InstancePlugin):
     def process(self, instance):
         version_lists_templates = instance.data.get(
             "versionListsTemplates", [])
-        profile = self._get_config_from_profile(instance)
+        profile = self._get_profile_for_instance(instance)
         if not profile and not version_lists_templates:
             self.log.debug(f"No profile found for instance {instance}")
             return
@@ -67,7 +67,7 @@ class CollectVersionToList(pyblish.api.InstancePlugin):
             )
         self.log.debug(f"Collected version lists: {version_lists}")
 
-    def _get_config_from_profile(
+    def _get_profile_for_instance(
         self,
         instance: pyblish.api.Instance
     ) -> dict | None:

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pyblish.api
 from ayon_core.lib import filter_profiles
-from ayon_core.pipeline.structures import ListConfig
+from ayon_core.pipeline.structures import ListConfig, ListConfigFolder
 
 
 class CollectVersionToList(pyblish.api.InstancePlugin):
@@ -31,8 +31,11 @@ class CollectVersionToList(pyblish.api.InstancePlugin):
         version_lists.append(
             ListConfig(
                 name=profile["list_name"],
-                parent_folders=profile["parent_folders"],
                 list_type=profile["list_type"],
+                list_folders=[
+                    ListConfigFolder(label=name)
+                    for name in profile["parent_folders"]
+                ],
             )
         )
         self.log.debug(f"Collected version lists: {version_lists}")

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -28,10 +28,9 @@ class CollectVersionToList(pyblish.api.InstancePlugin):
             self.log.debug(f"No profile found for instance {instance}")
             return
 
-        name = profile["list_name"]
         version_lists.append(
             ListConfig(
-                name=name,
+                name=profile["list_name"],
                 parent_folders=profile["parent_folders"],
                 list_type=profile["list_type"],
             )

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -1,15 +1,8 @@
 from __future__ import annotations
 
-import platform
-from copy import deepcopy
-from typing import TYPE_CHECKING, Any
-
 import pyblish.api
-from ayon_core.lib import StringTemplate, filter_profiles
+from ayon_core.lib import filter_profiles
 from ayon_core.pipeline.structures import ListConfig
-
-if TYPE_CHECKING:
-    from ayon_core.pipeline import Anatomy
 
 
 class CollectVersionToList(pyblish.api.InstancePlugin):
@@ -21,41 +14,25 @@ class CollectVersionToList(pyblish.api.InstancePlugin):
     profiles = []
 
     def process(self, instance):
-        version_lists_templates = instance.data.get(
-            "versionListsTemplates", [])
         profile = self._get_profile_for_instance(instance)
-        if not profile and not version_lists_templates:
+        if not profile:
             self.log.debug(f"No profile found for instance {instance}")
             return
-
-        processing_items = []
-        if version_lists_templates:
-            processing_items += version_lists_templates
-        if profile:
-            processing_items.append(profile)
-
-        anatomy: Anatomy = instance.context.data["anatomy"]
-        template_data = deepcopy(instance.data["anatomyData"])
-        template_data.update({
-            "root": anatomy.roots,
-            "platform": platform.system().lower(),
-        })
         version_lists: list[ListConfig] = instance.data.setdefault(
             "versionLists", [])
-        for item in processing_items:
-            name_template = item["name_template"]
-            data = item.get("data", {})
-            if data:
-                template_data.update(data)
-            list_name = StringTemplate.format_strict_template(
-                name_template, template_data)
-            version_lists.append(
-                ListConfig(
-                    name=list_name,
-                    parent_folders=item.get("parent_folders", None),
-                    is_review_list=item.get("is_review_list", False),
-                )
+
+        if version_lists:
+            self.log.debug(f"Version lists already collected: {version_lists}")
+            return
+
+        name_template = profile["name_template"]
+        version_lists.append(
+            ListConfig(
+                name=name_template,
+                parent_folders=profile.get("parent_folders", None),
+                list_type=profile["list_type"],
             )
+        )
         self.log.debug(f"Collected version lists: {version_lists}")
 
     def _get_profile_for_instance(

--- a/client/ayon_core/plugins/publish/collect_version_to_list.py
+++ b/client/ayon_core/plugins/publish/collect_version_to_list.py
@@ -2,22 +2,14 @@ from __future__ import annotations
 
 import platform
 from copy import deepcopy
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import pyblish.api
 from ayon_core.lib import StringTemplate, filter_profiles
+from ayon_core.pipeline.structures import ListConfig
 
 if TYPE_CHECKING:
     from ayon_core.pipeline import Anatomy
-
-
-@dataclass
-class ListConfig:
-    """Define a list."""
-    name: str
-    parent_folders: list[str] | None = None
-    is_review_list: bool = False
 
 
 class CollectVersionToList(pyblish.api.InstancePlugin):

--- a/client/ayon_core/plugins/publish/integrate_review.py
+++ b/client/ayon_core/plugins/publish/integrate_review.py
@@ -77,6 +77,7 @@ class IntegrateAYONReview(pyblish.api.InstancePlugin):
                     # Pass headers to fix bug in ayon-api (fixed in 1.2.15)
                     headers={},
                 )
+                instance.data["hasWebreview"] = True
             except Exception as exc:
                 self.log.warning(
                     f"Review upload failed after {time.time() - start}s.",

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -310,6 +310,14 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                     scope = existing_list_folder["data"].get("scope")
                     if scope and list_config.list_type not in scope:
                         scope.append(list_config.list_type)
+                        # --- Temporary bypass ---
+                        # TODO remove when fixed in frontend
+                        # There is an issue with list folder having both
+                        #   'generic' and 'review-session' in scope. The
+                        #   folder is not visible in Lists UI.
+                        scope = []
+                        existing_list_folder["data"]["scope"] = scope
+                        # ------------------------
                         update_entity_list_folder(
                             project_name,
                             existing_list_folder["id"],

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -137,12 +137,28 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                         for folder in parent_folders
                     ]
 
-                # Define the list config, and add the version id to the list
-                list_config_by_list_name[list_name] = ListConfig(
+                candidate_config = ListConfig(
                     name=list_name,
                     parent_folders=parent_folders,
                     list_type=list_config.list_type,
                 )
+
+                existing_config = list_config_by_list_name.get(list_name)
+                if existing_config:
+                    if existing_config.list_type != candidate_config.list_type:
+                        self.log.error(
+                            "Conflicting list_type for entity list label "
+                            f"'{list_name}': '{existing_config.list_type}' vs "
+                            f"'{candidate_config.list_type}'. Skipping."
+                        )
+                        continue
+                    if (existing_config.parent_folders or None) != (candidate_config.parent_folders or None):
+                        self.log.warning(
+                            "Multiple parent_folders configured for entity list "
+                            f"'{list_name}'. Using the first: {existing_config.parent_folders}"
+                        )
+                else:
+                    list_config_by_list_name[list_name] = candidate_config
                 version_ids_by_list_name[list_name].append(
                     version_entity["id"]
                 )

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -1,0 +1,43 @@
+import time
+
+import ayon_api
+import pyblish.api
+
+
+class IntegrateVersionToList(pyblish.api.ContextPlugin):
+    """Integrate published versions to a list
+
+    This plugin integrates published versions to a list in the server.
+    """
+
+    label = "Integrate Versions to List"
+    order = pyblish.api.IntegratorOrder + 0.49
+
+    def process(self, context):
+        # formatted timestamp YYYYMMDD-HHMMSS
+        # e.g. 20230101-120000
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+        project_name = context.data["projectName"]
+        list_name_mapping = {}
+        list_tags: list[str] = []
+        for instance in context:
+            version_entity = instance.data.get("versionEntity")
+            if not version_entity:
+                continue
+            list_name = instance.data.get("addToListName")
+            if list_name:
+                list_tags = instance.data.get("addToListTags", [])
+                list_name = f"{list_name}_{timestamp}"
+                list_name_mapping[list_name] = [
+                    *list_name_mapping.get(list_name, []),
+                    version_entity["id"]
+                ]
+
+        for list_label, version_ids in list_name_mapping.items():
+            ayon_api.create_entity_list(
+                project_name=project_name,
+                entity_type="version",
+                label=list_label,
+                items=[{"entityId": version_id} for version_id in version_ids],
+                tags=list_tags,
+            )

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -114,11 +114,19 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                     "root": anatomy.roots,
                     "platform": platform.system().lower(),
                 })
-                list_name: str = str(
-                    StringTemplate.format_strict_template(
-                        list_config.name, template_keys
+                try:
+                    list_name: str = str(
+                        StringTemplate.format_strict_template(
+                            list_config.name, template_keys
+                        )
                     )
-                )
+                except Exception:
+                    self.log.error(
+                        "Failed to format entity list name template: "
+                        f"{list_config.name}",
+                        exc_info=True,
+                    )
+                    continue
                 parent_folders: list[str] | None
                 if parent_folders := list_config.parent_folders:
                     parent_folders = [

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -96,6 +96,7 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
     label = "Integrate Versions to List"
     order = pyblish.api.IntegratorOrder + 0.49
     settings_category = "core"
+
     def process(self, context):
         list_config_by_list_name: dict[str, ListConfig] = {}
         version_ids_by_list_name: dict[str, list[str]] = defaultdict(list)

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -163,9 +163,8 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                         )
                         continue
                     if (
-                        existing_config.parent_folders or None
-                    ) != (
-                        candidate_config.parent_folders or None
+                        existing_config.parent_folders
+                        != candidate_config.parent_folders
                     ):
                         self.log.warning(
                             "Multiple parent_folders configured for "

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -16,10 +16,10 @@ import ayon_api
 import pyblish.api
 from ayon_api.utils import create_entity_id
 from ayon_core.lib import StringTemplate
-from ayon_core.pipeline.structures import ListConfig
 
 if TYPE_CHECKING:
     from ayon_core.pipeline import Anatomy
+    from ayon_core.pipeline.structures import ListConfig, ListConfigFolder
 
 
 # TODO: ayon_api future compatibility, remove once ayon_api supports it
@@ -54,15 +54,40 @@ def create_entity_list_item(
 
 
 # TODO: ayon_api future compatibility, remove once ayon_api supports it
+def update_entity_list_folder(
+    project_name: str,
+    folder_id: str,
+    data: dict,
+) -> None:
+    response = ayon_api.patch(
+        f"projects/{project_name}/entityListFolders/{folder_id}",
+        data=data,
+    )
+    response.raise_for_status()
+
+
+# TODO: ayon_api future compatibility, remove once ayon_api supports it
 def create_entity_list_folder(
     project_name: str,
-    folder_name: str,
-    parent_folder_id: str | None = None,
+    list_folder: ListConfigFolder,
+    parent_folder_id: str | None,
 ) -> str:
+    data = {}
+    for key, value in (
+        ("color", list_folder.color),
+        ("icon", list_folder.icon),
+        ("scope", list_folder.scope),
+    ):
+        if value is not None:
+            data[key] = value
+
     kwargs = {
         "id": create_entity_id(),
-        "label": folder_name,
+        "label": list_folder.label,
     }
+    if data:
+        kwargs["data"] = data
+
     if parent_folder_id:
         kwargs["parentId"] = parent_folder_id
     response = ayon_api.post(
@@ -100,25 +125,29 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
     def process(self, context):
         list_config_by_list_name: dict[str, ListConfig] = {}
         version_ids_by_list_name: dict[str, list[str]] = defaultdict(list)
+
+        anatomy: Anatomy = context.data["anatomy"]
         for instance in context:
-            has_webreview = instance.data.get("hasWebreview", False)
             version_lists: list[ListConfig] = instance.data.get(
                 "versionLists", []
             )
             if not version_lists:
                 continue
+
             version_entity = instance.data.get("versionEntity")
-            if not version_entity or not version_lists:
+            if not version_entity:
                 continue
+
+            has_webreview = instance.data.get("hasWebreview", False)
             for list_config in version_lists:
+                # Skip review-session lists if instance does not have review
                 if (
-                    list_config.list_type == "review-session"
-                    and has_webreview is False
+                    not has_webreview
+                    and list_config.list_type == "review-session"
                 ):
                     continue
                 # Construct the list config with the formatted name and parent
                 # folder names
-                anatomy: Anatomy = instance.context.data["anatomy"]
                 template_data = deepcopy(instance.data["anatomyData"])
                 template_data.update({
                     "root": anatomy.roots,
@@ -132,50 +161,59 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                     )
                 except Exception:
                     self.log.error(
-                        "Failed to format entity list name template: "
+                        "Failed to fill entity list name template: "
                         f"{list_config.name}",
                         exc_info=True,
                     )
                     continue
-                parent_folders: list[str] | None
-                if parent_folders := list_config.parent_folders:
-                    parent_folders = [
-                        str(StringTemplate.format_template(
-                            folder,
-                            template_data
-                        ))
-                        for folder in parent_folders
-                    ]
-
-                candidate_config = ListConfig(
-                    name=list_name,
-                    parent_folders=parent_folders,
-                    list_type=list_config.list_type,
-                )
 
                 existing_config = list_config_by_list_name.get(list_name)
-                if existing_config:
-                    if existing_config.list_type != candidate_config.list_type:
-                        self.log.error(
-                            "Conflicting list_type for entity list label "
-                            f"'{list_name}': '{existing_config.list_type}' vs "
-                            f"'{candidate_config.list_type}'. Skipping."
-                        )
-                        continue
-                    if (
-                        existing_config.parent_folders
-                        != candidate_config.parent_folders
-                    ):
-                        self.log.warning(
-                            "Multiple parent_folders configured for "
-                            f"entity list '{list_name}'. Using the "
-                            f"first: {existing_config.parent_folders}"
-                        )
-                else:
-                    list_config_by_list_name[list_name] = candidate_config
+                if (
+                    existing_config
+                    and existing_config.list_type != list_config.list_type
+                ):
+                    self.log.error(
+                        "Conflicting list_type for entity list label "
+                        f"'{list_name}': '{existing_config.list_type}' vs "
+                        f"'{list_config.list_type}'. Skipping."
+                    )
+                    continue
+
+                # Add version to lists mapping
                 version_ids_by_list_name[list_name].append(
                     version_entity["id"]
                 )
+
+                # Fill label using template data
+                candidate_config = deepcopy(list_config)
+                for folder in list_config.list_folders:
+                    folder.label = str(StringTemplate.format_template(
+                        folder.label, template_data
+                    ))
+
+                # Use candadate config
+                if existing_config is None:
+                    list_config_by_list_name[list_name] = candidate_config
+                    continue
+
+                # Compare folders of the existing config and the candidate
+                #   config. Does not affect output but logs a warning if
+                #   they differ.
+                existing_labels = [
+                    folder.label
+                    for folder in existing_config.list_folders
+                ]
+                candidate_labels = [
+                    folder.label
+                    for folder in candidate_config.list_folders
+                ]
+                if existing_labels != candidate_labels:
+                    self.log.warning(
+                        "Configuration does contain different folders from"
+                        f" existing list '{list_name}'. Keeping existing list"
+                        f" folders. Existing: {existing_labels}"
+                        f" vs Candidate: {candidate_labels}"
+                    )
 
         if not list_config_by_list_name:
             return
@@ -184,10 +222,10 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
         project_name: str = context.data["projectName"]
         existing_list_entities_by_label: dict[str, dict] = {
             entity_list["label"]: entity_list
-            for entity_list in ayon_api.get_entity_lists(
-                project_name=project_name
-            )
+            for entity_list in ayon_api.get_entity_lists(project_name)
         }
+        existing_list_folders = get_entity_list_folders(project_name)
+
         for list_name, list_config in list_config_by_list_name.items():
             version_ids = version_ids_by_list_name[list_name]
             if not version_ids:
@@ -224,9 +262,10 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
             # Else create the new list
             else:
                 # make sure parent folder exists
-                entity_list_folder_id = self._get_or_create_parent_folder(
+                entity_list_folder_id = self._create_list_folders(
                     project_name=project_name,
-                    parent_folders=list_config.parent_folders,
+                    list_config=list_config,
+                    existing_list_folders=existing_list_folders,
                 )
                 # then create list under a parent folder
                 self._create_entity_list(
@@ -241,57 +280,73 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                     ],
                 )
 
-    def _get_or_create_parent_folder(
+    def _create_list_folders(
         self,
         project_name: str,
-        parent_folders: list[str] | None,
+        list_config: ListConfig,
+        existing_list_folders: list[dict],
     ) -> str | None:
-        # TODO: Should we apply 'data.scopes' to the folder to make the folder
-        #  list only under e.g. generic list or review-sessions lists instead
-        #  of scoped to both.
-        if not parent_folders:
+        """Returns folder id of the last folder in the hierarchy."""
+        if not list_config.list_folders:
             return None
 
-        existing_list_folders = get_entity_list_folders(
-            project_name=project_name
-        )
         parent_folder_id = None
-        for folder_name in parent_folders:
+        for list_folder in list_config.list_folders:
             # make sure to get existing folder id if it exists
             # and use it instead of creating a new one
-            for list_folder in existing_list_folders:
-                if list_folder["parentId"] != parent_folder_id:
-                    continue
-                if list_folder["label"] != folder_name:
-                    continue
-                parent_folder_id = list_folder["id"]
-                break
+            for existing_list_folder in existing_list_folders:
+                if (
+                    existing_list_folder["parentId"] == parent_folder_id
+                    and existing_list_folder["label"] == list_folder.label
+                ):
+                    # If folder exists, check if scope needs to be updated
+                    #   with the list type.
+                    # NOTE If scope is None or empty list it is scoped for
+                    #   everything. So the list type is added to scope only
+                    #   if scope exists and does not contain the list type.
+                    scope = existing_list_folder["data"].get("scope")
+                    if scope and list_config.list_type not in scope:
+                        scope.append(list_config.list_type)
+                        update_entity_list_folder(
+                            project_name,
+                            existing_list_folder["id"],
+                            data={"scope": scope},
+                        )
+                    parent_folder_id = existing_list_folder["id"]
+                    break
             else:
                 # if folder does not exist, create it under the parent folder
-                parent_folder_id = create_entity_list_folder(
+                new_folder_id = create_entity_list_folder(
                     project_name=project_name,
-                    folder_name=folder_name,
+                    list_folder=list_folder,
                     parent_folder_id=parent_folder_id,
                 )
+                # Add new fake folder entity to existing folders
+                existing_list_folders.append({
+                    "label": list_folder.label,
+                    "parentId": parent_folder_id,
+                    "id": new_folder_id,
+                    "data": {
+                        "scope": list(list_folder.scope),
+                    },
+                })
+                parent_folder_id = new_folder_id
         return parent_folder_id
 
     def _append_to_entity_list(
         self,
         project_name: str,
         list_entity: dict,
-        version_ids: list[str] | None = None,
-    ):
+        version_ids: list[str],
+    ) -> None:
         """Append version ids to the entity list as items."""
-        if version_ids is None:
-            return
-
         for entity_id in version_ids:
             item_id = create_entity_list_item(
                 project_name=project_name,
                 list_id=list_entity["id"],
                 entity_id=entity_id,
             )
-            self.log.info(
+            self.log.debug(
                 f"Created entity list item {item_id} for version {entity_id}"
                 f" in list {list_entity['label']}"
             )
@@ -302,8 +357,8 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
         entity_type: str,
         label: str,
         items: list[dict],
-        list_type: str | None = None,
-        entity_list_folder_id: str | None = None,
+        list_type: str,
+        entity_list_folder_id: str | None,
     ) -> dict:
         """Create a new list parented to the entity list folder."""
         kwargs = {
@@ -311,9 +366,9 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
             "entityType": entity_type,
             "label": label,
             "items": items,
+            "entityListType": list_type,
         }
         for key, value in (
-            ("entityListType", list_type),
             ("entityListFolderId", entity_list_folder_id),
         ):
             if value is not None:

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -101,6 +101,7 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
         list_config_by_list_name: dict[str, ListConfig] = {}
         version_ids_by_list_name: dict[str, list[str]] = defaultdict(list)
         for instance in context:
+            has_webreview = instance.data.get("hasWebreview", False)
             version_lists: list[ListConfig] = instance.data.get(
                 "versionLists"
             )
@@ -110,6 +111,11 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
             if not version_entity or not version_lists:
                 continue
             for list_config in version_lists:
+                if (
+                    list_config.list_type == "review-session"
+                    and has_webreview is False
+                ):
+                    continue
                 # Construct the list config with the formatted name and parent
                 # folder names
                 anatomy: Anatomy = instance.context.data["anatomy"]

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -152,10 +152,15 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                             f"'{candidate_config.list_type}'. Skipping."
                         )
                         continue
-                    if (existing_config.parent_folders or None) != (candidate_config.parent_folders or None):
+                    if (
+                        existing_config.parent_folders or None
+                    ) != (
+                        candidate_config.parent_folders or None
+                    ):
                         self.log.warning(
-                            "Multiple parent_folders configured for entity list "
-                            f"'{list_name}'. Using the first: {existing_config.parent_folders}"
+                            "Multiple parent_folders configured for "
+                            f"entity list '{list_name}'. Using the "
+                            f"first: {existing_config.parent_folders}"
                         )
                 else:
                     list_config_by_list_name[list_name] = candidate_config

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -1,7 +1,7 @@
 """Pyblish context plugin that adds published versions to AYON entity lists.
 
 For each instance with ``versionLists`` data, creates or updates the named
-lists (optionally typed as ``review-session``) and organises them under the
+lists (optionally typed as ``review-session``) and organizes them under the
 requested folder hierarchy on the server.
 """
 
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import platform
 from copy import deepcopy
+from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Generator
 
 import ayon_api
@@ -19,229 +20,6 @@ from ayon_core.lib import StringTemplate
 if TYPE_CHECKING:
     from ayon_core.pipeline import Anatomy
     from ayon_core.pipeline.structures import ListConfig
-
-
-class IntegrateVersionToList(pyblish.api.ContextPlugin):
-    """Integrate published versions to a list.
-
-    This plugin integrates published versions to a list in the server.
-    """
-
-    label = "Integrate Versions to List"
-    order = pyblish.api.IntegratorOrder + 0.49
-
-    def process(self, context):
-        project_name = context.data["projectName"]
-        list_name_mapping = {}
-        for instance in context:
-            version_lists: list[ListConfig] = instance.data.get(
-                "versionLists", [])
-            version_entity = instance.data.get("versionEntity")
-            if not version_entity or not version_lists:
-                continue
-            for list_config in version_lists:
-                anatomy: Anatomy = instance.context.data["anatomy"]
-                template_keys = deepcopy(instance.data["anatomyData"])
-                template_keys.update({
-                    "root": anatomy.roots,
-                    "platform": platform.system().lower(),
-                })
-                list_name = StringTemplate.format_strict_template(
-                    list_config.name, template_keys)
-
-                list_data = list_name_mapping.setdefault(
-                    list_name, {})
-                parent_folders: list[str] | None
-                if parent_folders := list_config.parent_folders:
-                    parent_folders = [
-                        StringTemplate.format_template(
-                            folder,
-                            template_keys
-                        )
-                        for folder in parent_folders
-                    ]
-                list_data.update({
-                    "parent_folders": parent_folders,
-                    "list_type": list_config.list_type,
-                })
-                version_ids = list_data.setdefault(
-                    "version_ids", [])
-                version_ids.append(version_entity["id"])
-
-        # Get all list entities for the project from server
-        all_list_entities = ayon_api.get_entity_lists(
-            project_name=project_name,
-        )
-        for list_label, list_data in list_name_mapping.items():
-            version_ids = list_data["version_ids"]
-            if not version_ids:
-                self.log.debug(f"No version ids for list: {list_label}")
-                continue
-
-            parent_folders = list_data["parent_folders"]
-            # check first if list exists
-            existing_list = self._existing_list(
-                all_list_entities=all_list_entities,
-                list_label=list_label,
-                list_type=list_data["list_type"],
-            )
-            if existing_list:
-                self._update_entity_list(
-                    project_name=project_name,
-                    list_entity=existing_list,
-                    version_ids=version_ids,
-                )
-            else:
-                entity_list_folder_id = None
-                # make sure parent folder exists
-                if parent_folders:
-                    entity_list_folder_id = self._get_or_create_parent_folder(
-                        project_name=project_name,
-                        parent_folders=parent_folders,
-                    )
-                # then create list under a parent folder
-                self._create_entity_list(
-                    list_type=list_data["list_type"],
-                    project_name=project_name,
-                    entity_type="version",
-                    label=list_label,
-                    entity_list_folder_id=entity_list_folder_id,
-                    items=[
-                        {"entityId": version_id}
-                        for version_id in version_ids
-                    ],
-                )
-
-    def _get_or_create_parent_folder(
-        self,
-        project_name: str,
-        parent_folders: list[str],
-    ) -> str | None:
-        if not parent_folders:
-            return None
-        existing_list_folders = self._get_list_folders_helper(
-            project_name=project_name
-        )
-        parent_folder_id = None
-        for folder_name in parent_folders:
-            # make sure to get existing folder id if it exists
-            # and use it instead of creating a new one
-            existing_list_folder_id = None
-            for list_folder in existing_list_folders:
-                if list_folder["label"] == folder_name:
-                    existing_list_folder_id = list_folder["id"]
-                    break
-            if existing_list_folder_id:
-                parent_folder_id = existing_list_folder_id
-                continue
-            # if folder does not exist, create it
-            # under the existing parent folder
-            parent_folder_id = self._create_list_folder_helper(
-                project_name=project_name,
-                folder_name=folder_name,
-                parent_folder_id=parent_folder_id,
-            )
-        return parent_folder_id
-
-    # TODO: ayon_api future compatibility, remove once ayon_api supports it
-    def _create_list_folder_helper(
-        self,
-        project_name: str,
-        folder_name: str,
-        parent_folder_id: str | None = None,
-    ) -> str:
-        kwargs = {
-            "id": create_entity_id(),
-            "label": folder_name,
-        }
-        if parent_folder_id:
-            kwargs["parentId"] = parent_folder_id
-        response = ayon_api.post(
-            f"projects/{project_name}/entityListFolders",
-            **kwargs,
-        )
-        response.raise_for_status()
-        self.log.debug(f"List folder created: {response.data}")
-        return response.data["id"]
-
-    # TODO: ayon_api future compatibility, remove once ayon_api supports it
-    def _get_list_folders_helper(
-        self,
-        project_name: str,
-    ) -> list[dict]:
-        response = ayon_api.get(
-            f"projects/{project_name}/entityListFolders",
-        )
-        response.raise_for_status()
-        self.log.debug(f"List folders: {response.data}")
-        return response.data["folders"]
-
-    def _update_entity_list(
-        self,
-        project_name: str,
-        list_entity: dict,
-        version_ids: list[str] | None = None,
-    ):
-        if version_ids is None:
-            return
-
-        for entity_id in version_ids:
-            item_id = create_entity_list_item(
-                project_name=project_name,
-                list_id=list_entity["id"],
-                entity_id=entity_id,
-            )
-            self.log.info(
-                f"Created entity list item {item_id} for version {entity_id}"
-                f" in list {list_entity['label']}"
-            )
-
-    def _create_entity_list(
-        self,
-        project_name: str,
-        entity_type: str,
-        label: str,
-        items: list[dict],
-        list_type: str | None = None,
-        entity_list_folder_id: str | None = None,
-    ) -> dict:
-        kwargs = {
-            "id": create_entity_id(),
-            "entityType": entity_type,
-            "label": label,
-            "items": items,
-        }
-        for key, value in (
-            ("entityListType", list_type),
-            ("entityListFolderId", entity_list_folder_id),
-        ):
-            if value is not None:
-                kwargs[key] = value
-
-        self.log.debug(f"Creating entity list: {kwargs}")
-        response = ayon_api.post(
-            f"projects/{project_name}/lists",
-            **kwargs
-        )
-        response.raise_for_status()
-        self.log.debug(f"Entity list created: {response.data}")
-        return response.data
-
-    @staticmethod
-    def _existing_list(
-        all_list_entities: Generator[dict[str, Any], None, None],
-        list_label: str,
-        list_type: str,
-    ) -> dict | None:
-
-        # iterate via all lists and check if the label matches
-        for list_data in all_list_entities:
-            if list_data["entityListType"] != list_type:
-                continue
-            if list_data["label"] != list_label:
-                continue
-            return list_data
-        return None
 
 
 # TODO: ayon_api future compatibility, remove once ayon_api supports it
@@ -273,3 +51,238 @@ def create_entity_list_item(
     )
     response.raise_for_status()
     return item_id
+
+
+# TODO: ayon_api future compatibility, remove once ayon_api supports it
+def create_entity_list_folder(
+    project_name: str,
+    folder_name: str,
+    parent_folder_id: str | None = None,
+) -> str:
+    kwargs = {
+        "id": create_entity_id(),
+        "label": folder_name,
+    }
+    if parent_folder_id:
+        kwargs["parentId"] = parent_folder_id
+    response = ayon_api.post(
+        f"projects/{project_name}/entityListFolders",
+        **kwargs,
+    )
+    response.raise_for_status()
+    return response.data["id"]
+
+
+# TODO: ayon_api future compatibility, remove once ayon_api supports it
+def get_entity_list_folders(project_name: str) -> list[dict]:
+    response = ayon_api.get(
+        f"projects/{project_name}/entityListFolders",
+    )
+    response.raise_for_status()
+    return response.data["folders"]
+
+
+class IntegrateVersionToList(pyblish.api.ContextPlugin):
+    """Integrate published versions to a list.
+
+    This plugin integrates published versions to a list in the server.
+
+    Note that list names are unique; as such, even if multiple list configs
+    are set to go to different folders but with the same list name - then all
+    versions will be integrated to the same list regardless of what list folder
+    it is in.
+    """
+
+    label = "Integrate Versions to List"
+    order = pyblish.api.IntegratorOrder + 0.49
+
+    def process(self, context):
+        list_config_by_list_name: dict[str, ListConfig] = {}
+        version_ids_by_list_name: dict[str, list[str]] = defaultdict(list)
+        for instance in context:
+            version_lists: list[ListConfig] = instance.data.get(
+                "versionLists", [])
+            version_entity = instance.data.get("versionEntity")
+            if not version_entity or not version_lists:
+                continue
+            for list_config in version_lists:
+                # Construct the list config with the formatted name and parent
+                # folder names
+                anatomy: Anatomy = instance.context.data["anatomy"]
+                template_keys = deepcopy(instance.data["anatomyData"])
+                template_keys.update({
+                    "root": anatomy.roots,
+                    "platform": platform.system().lower(),
+                })
+                list_name: str = str(
+                    StringTemplate.format_strict_template(
+                        list_config.name, template_keys
+                    )
+                )
+                parent_folders: list[str] | None
+                if parent_folders := list_config.parent_folders:
+                    parent_folders = [
+                        str(StringTemplate.format_template(
+                            folder,
+                            template_keys
+                        ))
+                        for folder in parent_folders
+                    ]
+
+                # Define the list config, and add the version id to the list
+                list_config_by_list_name[list_name] = ListConfig(
+                    name=list_name,
+                    parent_folders=parent_folders,
+                    list_type=list_config.list_type,
+                )
+                version_ids_by_list_name[list_name].append(
+                    version_entity["id"]
+                )
+
+        # Get all list entities for the project from server
+        project_name: str = context.data["projectName"]
+        existing_list_entities_by_label: dict[str, dict] = {
+            entity_list["label"]: entity_list
+            for entity_list in ayon_api.get_entity_lists(
+                project_name=project_name
+            )
+        }
+        for list_name, list_config in list_config_by_list_name.items():
+            version_ids = version_ids_by_list_name[list_name]
+            if not version_ids:
+                self.log.debug(f"No version ids for list: {list_name}")
+                continue
+
+            # If list exists, append to it but ensure it is of correct type
+            existing_list = existing_list_entities_by_label.get(list_name)
+            if existing_list:
+                if existing_list["entityListType"] != list_config.list_type:
+                    entity_list_type = existing_list["entityListType"]
+                    self.log.error(
+                        "Can't add versions to list because another entity"
+                        f" list type '{entity_list_type}' with that label"
+                        f" already exists: {list_config.name}"
+                    )
+                    continue
+
+                if existing_list["entityType"] != "version":
+                    entity_type = existing_list["entityType"]
+                    self.log.error(
+                        f"Can't add versions to list because a '{entity_type}'"
+                        " list type with that label already exists: "
+                        f"{list_config.name}"
+                    )
+                    continue
+
+                self._append_to_entity_list(
+                    project_name=project_name,
+                    list_entity=existing_list,
+                    version_ids=version_ids,
+                )
+
+            # Else create the new list
+            else:
+                # make sure parent folder exists
+                entity_list_folder_id = self._get_or_create_parent_folder(
+                    project_name=project_name,
+                    parent_folders=list_config.parent_folders,
+                )
+                # then create list under a parent folder
+                self._create_entity_list(
+                    project_name=project_name,
+                    entity_type="version",
+                    label=list_config.name,
+                    list_type=list_config.list_type,
+                    entity_list_folder_id=entity_list_folder_id,
+                    items=[
+                        {"entityId": version_id}
+                        for version_id in version_ids
+                    ],
+                )
+
+    def _get_or_create_parent_folder(
+        self,
+        project_name: str,
+        parent_folders: list[str] | None,
+    ) -> str | None:
+        # TODO: Should we apply 'data.scopes' to the folder to make the folder
+        #  list only under e.g. generic list or review-sessions lists instead
+        #  of scoped to both.
+        if not parent_folders:
+            return None
+
+        existing_list_folders = get_entity_list_folders(
+            project_name=project_name
+        )
+        parent_folder_id = None
+        for folder_name in parent_folders:
+            # make sure to get existing folder id if it exists
+            # and use it instead of creating a new one
+            for list_folder in existing_list_folders:
+                if list_folder["parentId"] != parent_folder_id:
+                    continue
+                if list_folder["label"] != folder_name:
+                    continue
+                parent_folder_id = list_folder["id"]
+                break
+            else:
+                # if folder does not exist, create it under the parent folder
+                parent_folder_id = create_entity_list_folder(
+                    project_name=project_name,
+                    folder_name=folder_name,
+                    parent_folder_id=parent_folder_id,
+                )
+        return parent_folder_id
+
+    def _append_to_entity_list(
+        self,
+        project_name: str,
+        list_entity: dict,
+        version_ids: list[str] | None = None,
+    ):
+        """Append version ids to the entity list as items."""
+        if version_ids is None:
+            return
+
+        for entity_id in version_ids:
+            item_id = create_entity_list_item(
+                project_name=project_name,
+                list_id=list_entity["id"],
+                entity_id=entity_id,
+            )
+            self.log.info(
+                f"Created entity list item {item_id} for version {entity_id}"
+                f" in list {list_entity['label']}"
+            )
+
+    def _create_entity_list(
+        self,
+        project_name: str,
+        entity_type: str,
+        label: str,
+        items: list[dict],
+        list_type: str | None = None,
+        entity_list_folder_id: str | None = None,
+    ) -> dict:
+        """Create a new list parented to the entity list folder."""
+        kwargs = {
+            "id": create_entity_id(),
+            "entityType": entity_type,
+            "label": label,
+            "items": items,
+        }
+        for key, value in (
+            ("entityListType", list_type),
+            ("entityListFolderId", entity_list_folder_id),
+        ):
+            if value is not None:
+                kwargs[key] = value
+
+        self.log.debug(f"Creating entity list: {kwargs}")
+        response = ayon_api.post(
+            f"projects/{project_name}/lists",
+            **kwargs
+        )
+        response.raise_for_status()
+        self.log.debug(f"Entity list created: {response.data}")
+        return response.data

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -102,7 +102,10 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
         version_ids_by_list_name: dict[str, list[str]] = defaultdict(list)
         for instance in context:
             version_lists: list[ListConfig] = instance.data.get(
-                "versionLists", [])
+                "versionLists"
+            )
+            if not version_lists:
+                continue
             version_entity = instance.data.get("versionEntity")
             if not version_entity or not version_lists:
                 continue
@@ -110,15 +113,15 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                 # Construct the list config with the formatted name and parent
                 # folder names
                 anatomy: Anatomy = instance.context.data["anatomy"]
-                template_keys = deepcopy(instance.data["anatomyData"])
-                template_keys.update({
+                template_data = deepcopy(instance.data["anatomyData"])
+                template_data.update({
                     "root": anatomy.roots,
                     "platform": platform.system().lower(),
                 })
                 try:
                     list_name: str = str(
                         StringTemplate.format_strict_template(
-                            list_config.name, template_keys
+                            list_config.name, template_data
                         )
                     )
                 except Exception:
@@ -133,7 +136,7 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                     parent_folders = [
                         str(StringTemplate.format_template(
                             folder,
-                            template_keys
+                            template_data
                         ))
                         for folder in parent_folders
                     ]

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -131,8 +131,8 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
             **kwargs,
         )
         response.raise_for_status()
-        self.log.debug(f"List folder created: {response.json()}")
-        return response.json()["id"]
+        self.log.debug(f"List folder created: {response.data}")
+        return response.data["id"]
 
     def _get_list_folders_helper(
         self,
@@ -142,8 +142,8 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
             f"projects/{project_name}/entityListFolders",
         )
         response.raise_for_status()
-        self.log.debug(f"List folders: {response.json()}")
-        return response.json()["folders"]
+        self.log.debug(f"List folders: {response.data}")
+        return response.data["folders"]
 
     def _update_entity_list(
         self,
@@ -192,8 +192,8 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
             **kwargs
         )
         response.raise_for_status()
-        self.log.debug(f"Entity list created: {response.json()}")
-        return response.json()
+        self.log.debug(f"Entity list created: {response.data}")
+        return response.data
 
     @staticmethod
     def _existing_list(

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -1,18 +1,24 @@
+"""Pyblish context plugin that adds published versions to AYON entity lists.
+
+For each instance with ``versionLists`` data, creates or updates the named
+lists (optionally typed as ``review-session``) and organises them under the
+requested folder hierarchy on the server.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
 import ayon_api
-from ayon_api.utils import create_entity_id
 import pyblish.api
+from ayon_api.utils import create_entity_id
 
 if TYPE_CHECKING:
     from ayon_core.plugins.publish.collect_version_to_list import ListConfig
 
 
-
 class IntegrateVersionToList(pyblish.api.ContextPlugin):
-    """Integrate published versions to a list
+    """Integrate published versions to a list.
 
     This plugin integrates published versions to a list in the server.
     """
@@ -23,14 +29,6 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
     def process(self, context):
         project_name = context.data["projectName"]
         list_name_mapping = {}
-        # TODO:
-        #    - check if list with the name already exists
-        #    - if exists:
-        #         - append version to the list
-        #         - parent folders are ignored
-        #    - if not exists:
-        #         - create a new list and create
-        #         - create parent folders if specified
         for instance in context:
             version_lists: list[ListConfig] = instance.data.get(
                 "versionLists", [])

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -14,7 +14,7 @@ import pyblish.api
 from ayon_api.utils import create_entity_id
 
 if TYPE_CHECKING:
-    from ayon_core.plugins.publish.collect_version_to_list import ListConfig
+    from ayon_core.pipeline.structures import ListConfig
 
 
 class IntegrateVersionToList(pyblish.api.ContextPlugin):

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -1,7 +1,14 @@
-import time
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import ayon_api
+from ayon_api.utils import create_entity_id
 import pyblish.api
+
+if TYPE_CHECKING:
+    from ayon_core.plugins.publish.collect_version_to_list import ListConfig
+
 
 
 class IntegrateVersionToList(pyblish.api.ContextPlugin):
@@ -14,30 +21,196 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
     order = pyblish.api.IntegratorOrder + 0.49
 
     def process(self, context):
-        # formatted timestamp YYYYMMDD-HHMMSS
-        # e.g. 20230101-120000
-        timestamp = time.strftime("%Y%m%d-%H%M%S")
         project_name = context.data["projectName"]
         list_name_mapping = {}
-        list_tags: list[str] = []
+        # TODO:
+        #    - check if list with the name already exists
+        #    - if exists:
+        #         - append version to the list
+        #         - parent folders are ignored
+        #    - if not exists:
+        #         - create a new list and create
+        #         - create parent folders if specified
         for instance in context:
+            version_lists: list[ListConfig] = instance.data.get(
+                "versionLists", [])
             version_entity = instance.data.get("versionEntity")
-            if not version_entity:
+            if not version_entity or not version_lists:
                 continue
-            list_name = instance.data.get("addToListName")
-            if list_name:
-                list_tags = instance.data.get("addToListTags", [])
-                list_name = f"{list_name}_{timestamp}"
-                list_name_mapping[list_name] = [
-                    *list_name_mapping.get(list_name, []),
-                    version_entity["id"]
-                ]
+            for list_config in version_lists:
+                list_data = list_name_mapping.setdefault(
+                    list_config.name, {})
+                list_data.update({
+                    "parent_folders": list_config.parent_folders,
+                    "is_review_list": list_config.is_review_list,
+                })
+                version_ids = list_data.setdefault(
+                    "version_ids", [])
+                version_ids.append(version_entity["id"])
 
-        for list_label, version_ids in list_name_mapping.items():
-            ayon_api.create_entity_list(
+        for list_label, list_data in list_name_mapping.items():
+            version_ids = list_data["version_ids"]
+            is_review_list = list_data["is_review_list"]
+            parent_folders = list_data["parent_folders"]
+            # check first if list exists
+            existing_list = self._existing_list(
                 project_name=project_name,
-                entity_type="version",
-                label=list_label,
-                items=[{"entityId": version_id} for version_id in version_ids],
-                tags=list_tags,
+                list_label=list_label,
+                list_type="review-session" if is_review_list else None,
             )
+            if existing_list:
+                self._update_entity_list(
+                    project_name=project_name,
+                    list_entity=existing_list,
+                    version_ids=version_ids,
+                )
+            else:
+                entity_list_folder_id = None
+                # make sure parent folder exists
+                if parent_folders:
+                    entity_list_folder_id = self._get_or_create_parent_folder(
+                        project_name=project_name,
+                        parent_folders=parent_folders,
+                    )
+                # then create list under a parent folder
+                self._create_entity_list(
+                    list_type="review-session" if is_review_list else None,
+                    project_name=project_name,
+                    entity_type="version",
+                    label=list_label,
+                    entity_list_folder_id=entity_list_folder_id,
+                    items=[
+                        {"entityId": version_id}
+                        for version_id in version_ids
+                    ],
+                )
+
+    def _get_or_create_parent_folder(
+        self,
+        project_name: str,
+        parent_folders: list[str],
+    ) -> str | None:
+        if not parent_folders:
+            return None
+        existing_list_folders = self._get_list_folders_helper(
+            project_name=project_name
+        )
+        parent_folder_id = None
+        for folder_name in parent_folders:
+            # make sure to get existing folder id if it exists
+            # and use it instead of creating a new one
+            existing_list_folder_id = None
+            for list_folder in existing_list_folders:
+                if list_folder["label"] == folder_name:
+                    existing_list_folder_id = list_folder["id"]
+                    break
+            if existing_list_folder_id:
+                parent_folder_id = existing_list_folder_id
+                continue
+            # if folder does not exist, create it
+            # under the existing parent folder
+            parent_folder_id = self._create_list_folder_helper(
+                project_name=project_name,
+                folder_name=folder_name,
+                parent_folder_id=parent_folder_id,
+            )
+        return parent_folder_id
+
+    def _create_list_folder_helper(
+        self,
+        project_name: str,
+        folder_name: str,
+        parent_folder_id: str | None = None,
+    ) -> str:
+        kwargs = {
+            "id": create_entity_id(),
+            "label": folder_name,
+        }
+        if parent_folder_id:
+            kwargs["parentId"] = parent_folder_id
+        response = ayon_api.post(
+            f"projects/{project_name}/entityListFolders",
+            **kwargs,
+        )
+        response.raise_for_status()
+        self.log.debug(f"List folder created: {response.json()}")
+        return response.json()["id"]
+
+    def _get_list_folders_helper(
+        self,
+        project_name: str,
+    ) -> list[dict]:
+        response = ayon_api.get(
+            f"projects/{project_name}/entityListFolders",
+        )
+        response.raise_for_status()
+        self.log.debug(f"List folders: {response.json()}")
+        return response.json()["folders"]
+
+    def _update_entity_list(
+        self,
+        project_name: str,
+        list_entity: dict,
+        version_ids: list[str] | None = None,
+    ):
+        if version_ids is None:
+            return
+
+        for entity_id in version_ids:
+            item_id = ayon_api.create_entity_list_item(
+                project_name=project_name,
+                list_id=list_entity["id"],
+                entity_id=entity_id,
+            )
+            self.log.info(
+                f"Created entity list item {item_id} for version {entity_id}"
+                f" in list {list_entity['label']}"
+            )
+
+    def _create_entity_list(
+        self,
+        project_name: str,
+        entity_type: str,
+        label: str,
+        list_type: str | None = None,
+        entity_list_folder_id: str | None = None,
+        items: list[dict] | None = None,
+    ) -> dict:
+        kwargs = {
+            "id": create_entity_id(),
+            "entityType": entity_type,
+            "label": label,
+        }
+        for key, value in (
+            ("entityListType", list_type),
+            ("entityListFolderId", entity_list_folder_id),
+        ):
+            if value is not None:
+                kwargs[key] = value
+
+        self.log.debug(f"Creating entity list: {kwargs}")
+        response = ayon_api.post(
+            f"projects/{project_name}/lists",
+            **kwargs
+        )
+        response.raise_for_status()
+        self.log.debug(f"Entity list created: {response.json()}")
+        return response.json()
+
+    @staticmethod
+    def _existing_list(
+        project_name: str,
+        list_label: str,
+        list_type: str | None = None,
+    ) -> dict | None:
+        all_lists = ayon_api.get_entity_lists(
+            project_name=project_name,
+        )
+        # iterate via all lists and check if the label matches
+        for list_data in all_lists:
+            if list_type and list_data["entityListType"] != list_type:
+                continue
+            if list_data["label"] != list_label:
+                continue
+            return list_data
+        return None

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import platform
 from copy import deepcopy
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Generator
+from typing import TYPE_CHECKING
 
 import ayon_api
 import pyblish.api

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -7,13 +7,17 @@ requested folder hierarchy on the server.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import platform
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any, Generator
 
 import ayon_api
 import pyblish.api
 from ayon_api.utils import create_entity_id
+from ayon_core.lib import StringTemplate
 
 if TYPE_CHECKING:
+    from ayon_core.pipeline import Anatomy
     from ayon_core.pipeline.structures import ListConfig
 
 
@@ -36,29 +40,50 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
             if not version_entity or not version_lists:
                 continue
             for list_config in version_lists:
+                anatomy: Anatomy = instance.context.data["anatomy"]
+                template_keys = deepcopy(instance.data["anatomyData"])
+                template_keys.update({
+                    "root": anatomy.roots,
+                    "platform": platform.system().lower(),
+                })
+                list_name = StringTemplate.format_strict_template(
+                    list_config.name, template_keys)
+
                 list_data = list_name_mapping.setdefault(
-                    list_config.name, {})
+                    list_name, {})
+                parent_folders: list[str] | None
+                if parent_folders := list_config.parent_folders:
+                    parent_folders = [
+                        StringTemplate.format_template(
+                            folder,
+                            template_keys
+                        )
+                        for folder in parent_folders
+                    ]
                 list_data.update({
-                    "parent_folders": list_config.parent_folders,
-                    "is_review_list": list_config.is_review_list,
+                    "parent_folders": parent_folders,
+                    "list_type": list_config.list_type,
                 })
                 version_ids = list_data.setdefault(
                     "version_ids", [])
                 version_ids.append(version_entity["id"])
 
+        # Get all list entities for the project from server
+        all_list_entities = ayon_api.get_entity_lists(
+            project_name=project_name,
+        )
         for list_label, list_data in list_name_mapping.items():
             version_ids = list_data["version_ids"]
             if not version_ids:
                 self.log.debug(f"No version ids for list: {list_label}")
                 continue
 
-            is_review_list = list_data["is_review_list"]
             parent_folders = list_data["parent_folders"]
             # check first if list exists
             existing_list = self._existing_list(
-                project_name=project_name,
+                all_list_entities=all_list_entities,
                 list_label=list_label,
-                list_type="review-session" if is_review_list else None,
+                list_type=list_data["list_type"],
             )
             if existing_list:
                 self._update_entity_list(
@@ -204,16 +229,14 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
 
     @staticmethod
     def _existing_list(
-        project_name: str,
+        all_list_entities: Generator[dict[str, Any], None, None],
         list_label: str,
-        list_type: str | None = None,
+        list_type: str,
     ) -> dict | None:
-        all_lists = ayon_api.get_entity_lists(
-            project_name=project_name,
-        )
+
         # iterate via all lists and check if the label matches
-        for list_data in all_lists:
-            if list_type and list_data["entityListType"] != list_type:
+        for list_data in all_list_entities:
+            if list_data["entityListType"] != list_type:
                 continue
             if list_data["label"] != list_label:
                 continue

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -123,8 +123,8 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
     settings_category = "core"
 
     def process(self, context):
-        list_config_by_list_name: dict[str, ListConfig] = {}
-        version_ids_by_list_name: dict[str, list[str]] = defaultdict(list)
+        list_config_by_list_label: dict[str, ListConfig] = {}
+        version_ids_by_list_label: dict[str, list[str]] = defaultdict(list)
 
         anatomy: Anatomy = context.data["anatomy"]
         for instance in context:
@@ -154,38 +154,39 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                     "platform": platform.system().lower(),
                 })
                 try:
-                    list_name: str = str(
+                    list_label: str = str(
                         StringTemplate.format_strict_template(
-                            list_config.name, template_data
+                            list_config.label, template_data
                         )
                     )
                 except Exception:
                     self.log.error(
                         "Failed to fill entity list name template: "
-                        f"{list_config.name}",
+                        f"{list_config.label}",
                         exc_info=True,
                     )
                     continue
 
-                existing_config = list_config_by_list_name.get(list_name)
+                existing_config = list_config_by_list_label.get(list_label)
                 if (
                     existing_config
                     and existing_config.list_type != list_config.list_type
                 ):
                     self.log.error(
                         "Conflicting list_type for entity list label "
-                        f"'{list_name}': '{existing_config.list_type}' vs "
+                        f"'{list_label}': '{existing_config.list_type}' vs "
                         f"'{list_config.list_type}'. Skipping."
                     )
                     continue
 
                 # Add version to lists mapping
-                version_ids_by_list_name[list_name].append(
+                version_ids_by_list_label[list_label].append(
                     version_entity["id"]
                 )
 
                 # Fill label using template data
                 candidate_config = deepcopy(list_config)
+                candidate_config.label = list_label
                 for folder in list_config.list_folders:
                     folder.label = str(StringTemplate.format_template(
                         folder.label, template_data
@@ -193,7 +194,7 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
 
                 # Use candadate config
                 if existing_config is None:
-                    list_config_by_list_name[list_name] = candidate_config
+                    list_config_by_list_label[list_label] = candidate_config
                     continue
 
                 # Compare folders of the existing config and the candidate
@@ -210,12 +211,12 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                 if existing_labels != candidate_labels:
                     self.log.warning(
                         "Configuration does contain different folders from"
-                        f" existing list '{list_name}'. Keeping existing list"
+                        f" existing list '{list_label}'. Keeping existing list"
                         f" folders. Existing: {existing_labels}"
                         f" vs Candidate: {candidate_labels}"
                     )
 
-        if not list_config_by_list_name:
+        if not list_config_by_list_label:
             return
 
         # Get all list entities for the project from server
@@ -226,21 +227,23 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
         }
         existing_list_folders = get_entity_list_folders(project_name)
 
-        for list_name, list_config in list_config_by_list_name.items():
-            version_ids = version_ids_by_list_name[list_name]
+        for list_config in list_config_by_list_label.values():
+            version_ids = version_ids_by_list_label[list_config.label]
             if not version_ids:
-                self.log.debug(f"No version ids for list: {list_name}")
+                self.log.debug(f"No version ids for list: {list_config.label}")
                 continue
 
             # If list exists, append to it but ensure it is of correct type
-            existing_list = existing_list_entities_by_label.get(list_name)
+            existing_list = existing_list_entities_by_label.get(
+                list_config.label
+            )
             if existing_list:
                 if existing_list["entityListType"] != list_config.list_type:
                     entity_list_type = existing_list["entityListType"]
                     self.log.error(
                         "Can't add versions to list because another entity"
                         f" list type '{entity_list_type}' with that label"
-                        f" already exists: {list_config.name}"
+                        f" already exists: {list_config.label}"
                     )
                     continue
 
@@ -249,7 +252,7 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                     self.log.error(
                         f"Can't add versions to list because a '{entity_type}'"
                         " list type with that label already exists: "
-                        f"{list_config.name}"
+                        f"{list_config.label}"
                     )
                     continue
 
@@ -271,7 +274,7 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                 self._create_entity_list(
                     project_name=project_name,
                     entity_type="version",
-                    label=list_config.name,
+                    label=list_config.label,
                     list_type=list_config.list_type,
                     entity_list_folder_id=entity_list_folder_id,
                     items=[

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -48,6 +48,10 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
 
         for list_label, list_data in list_name_mapping.items():
             version_ids = list_data["version_ids"]
+            if not version_ids:
+                self.log.debug(f"No version ids for list: {list_label}")
+                continue
+
             is_review_list = list_data["is_review_list"]
             parent_folders = list_data["parent_folders"]
             # check first if list exists
@@ -114,6 +118,7 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
             )
         return parent_folder_id
 
+    # TODO: ayon_api future compatibility, remove once ayon_api supports it
     def _create_list_folder_helper(
         self,
         project_name: str,
@@ -134,6 +139,7 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
         self.log.debug(f"List folder created: {response.data}")
         return response.data["id"]
 
+    # TODO: ayon_api future compatibility, remove once ayon_api supports it
     def _get_list_folders_helper(
         self,
         project_name: str,
@@ -155,7 +161,7 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
             return
 
         for entity_id in version_ids:
-            item_id = ayon_api.create_entity_list_item(
+            item_id = create_entity_list_item(
                 project_name=project_name,
                 list_id=list_entity["id"],
                 entity_id=entity_id,
@@ -170,14 +176,15 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
         project_name: str,
         entity_type: str,
         label: str,
+        items: list[dict],
         list_type: str | None = None,
         entity_list_folder_id: str | None = None,
-        items: list[dict] | None = None,
     ) -> dict:
         kwargs = {
             "id": create_entity_id(),
             "entityType": entity_type,
             "label": label,
+            "items": items,
         }
         for key, value in (
             ("entityListType", list_type),
@@ -212,3 +219,34 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                 continue
             return list_data
         return None
+
+
+# TODO: ayon_api future compatibility, remove once ayon_api supports it
+def create_entity_list_item(
+    project_name: str,
+    list_id: str,
+    entity_id: str,
+) -> str:
+    """Create entity list item.
+
+    Args:
+        project_name (str): Project name where entity list lives.
+        list_id (str): Entity list id where item will be added.
+        entity_id (str): Id of entity added to the list.
+
+    Returns:
+        str: Item id.
+
+    """
+    item_id = create_entity_id()
+    kwargs = {
+        "id": item_id,
+        "entityId": entity_id,
+    }
+
+    response = ayon_api.post(
+        f"projects/{project_name}/lists/{list_id}/items",
+        **kwargs
+    )
+    response.raise_for_status()
+    return item_id

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -101,7 +101,7 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                     )
                 # then create list under a parent folder
                 self._create_entity_list(
-                    list_type="review-session" if is_review_list else None,
+                    list_type=list_data["list_type"],
                     project_name=project_name,
                     entity_type="version",
                     label=list_label,

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -177,6 +177,9 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
                     version_entity["id"]
                 )
 
+        if not list_config_by_list_name:
+            return
+
         # Get all list entities for the project from server
         project_name: str = context.data["projectName"]
         existing_list_entities_by_label: dict[str, dict] = {

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -8,18 +8,18 @@ requested folder hierarchy on the server.
 from __future__ import annotations
 
 import platform
-from copy import deepcopy
 from collections import defaultdict
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import ayon_api
 import pyblish.api
 from ayon_api.utils import create_entity_id
 from ayon_core.lib import StringTemplate
+from ayon_core.pipeline.structures import ListConfig
 
 if TYPE_CHECKING:
     from ayon_core.pipeline import Anatomy
-    from ayon_core.pipeline.structures import ListConfig
 
 
 # TODO: ayon_api future compatibility, remove once ayon_api supports it

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -103,7 +103,7 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
         for instance in context:
             has_webreview = instance.data.get("hasWebreview", False)
             version_lists: list[ListConfig] = instance.data.get(
-                "versionLists"
+                "versionLists", []
             )
             if not version_lists:
                 continue

--- a/client/ayon_core/plugins/publish/integrate_versions_to_list.py
+++ b/client/ayon_core/plugins/publish/integrate_versions_to_list.py
@@ -95,7 +95,7 @@ class IntegrateVersionToList(pyblish.api.ContextPlugin):
 
     label = "Integrate Versions to List"
     order = pyblish.api.IntegratorOrder + 0.49
-
+    settings_category = "core"
     def process(self, context):
         list_config_by_list_name: dict[str, ListConfig] = {}
         version_ids_by_list_name: dict[str, list[str]] = defaultdict(list)

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -1501,15 +1501,7 @@ DEFAULT_PUBLISH_VALUES = {
     },
     "CollectVersionToList": {
         "enabled": True,
-        "profiles": [
-            {
-                "host_names": [],
-                "task_types": [],
-                "task_names": [],
-                "product_base_types": [],
-                "product_names": [],
-            }
-        ]
+        "profiles": []
     },
     "CollectExplicitResolution": {
         "enabled": True,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -208,6 +208,28 @@ def list_type_enum():
     ]
 
 
+def list_folder_scope_def():
+    return [
+        {"label": "Scope folder to all views", "value": "all"},
+        {"label": "Scope to the list type", "value": "list_type"},
+    ]
+
+
+class VersionListFolderModel(BaseSettingsModel):
+    """Folder must have label and can be scoped to views.
+
+    Scope of the folder can be defined for all views or use just the view
+        matching list type of created list.
+
+    """
+    label: str = SettingsField("", title="Folder label")
+    scope_def: str = SettingsField(
+        "all",
+        enum_resolver=list_folder_scope_def,
+        title="Scope",
+    )
+
+
 class CollectVersionToListProfileModel(BaseSettingsModel):
     """Collect version list profile model."""
     _layout = "expanded"
@@ -252,16 +274,16 @@ class CollectVersionToListProfileModel(BaseSettingsModel):
         description="Anatomy formattable template for the name.",
         section="List configuration",
     )
-    parent_folders: list[str] = SettingsField(
-        default_factory=list,
-        title="Parent folders",
-        description="Folder hierarchy formed from top to bottom.",
-    )
     list_type: str = SettingsField(
         "generic",
         title="List type",
         description="Define what type of list this profile represents.",
         enum_resolver=list_type_enum,
+    )
+    list_folders: list[VersionListFolderModel] = SettingsField(
+        default_factory=list,
+        title="List folders",
+        description="Folder hierarchy formed from top to bottom.",
     )
 
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -219,7 +219,9 @@ class EntityListFolderModel(BaseSettingsModel):
     """Folder must have label and can be scoped to views.
 
     Scope of the folder can be defined for all views or use just the view
-        matching list type of created list.
+        matching list type of created list. In case the list folder already
+        exists the settings are not used and we just make sure the list can
+        be seen under the folder.
 
     """
     _layout = "expanded"
@@ -232,7 +234,6 @@ class EntityListFolderModel(BaseSettingsModel):
 
 
 class CollectVersionToListProfileModel(BaseSettingsModel):
-    """Collect version list profile model."""
     _layout = "expanded"
     host_names: list[str] = SettingsField(
         default_factory=list,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -201,6 +201,72 @@ class CollectUSDLayerContributionsModel(BaseSettingsModel):
         return value
 
 
+class CollectVersionToListProfileModel(BaseSettingsModel):
+    """."""
+    _layout = "expanded"
+    host_names: list[str] = SettingsField(
+        default_factory=list,
+        title="Host names",
+        description="The host names to match this profile to.",
+        section="Filter",
+    )
+    task_types: list[str] = SettingsField(
+        default_factory=list,
+        title="Task Types",
+        enum_resolver=task_types_enum,
+        description=(
+            "The current create context task type to filter against. This"
+            " allows to filter the profile to only be valid if currently "
+            " creating from within that task type."
+        ),
+    )
+    task_names: list[str] = SettingsField(
+        default_factory=list,
+        title="Task names",
+        description="The task names to match this profile to.",
+    )
+    product_base_types: list[str] = SettingsField(
+        default_factory=list,
+        title="Product base types",
+        description=(
+            "The product base types to match this profile to. When matched,"
+            " the settings below would apply to the instance as default"
+            " attributes."
+        )
+    )
+    product_names: list[str] = SettingsField(
+        default_factory=list,
+        title="Product names",
+        description="The product names to match this profile to.",
+    )
+    name_template: str = SettingsField(
+        "",
+        title="Name template",
+        description="Anatomy formattable template for the name.",
+        section="List configuration",
+    )
+    parent_folders: list[str] = SettingsField(
+        default_factory=list,
+        title="Parent folders",
+        description="Folder hierarchy formed from top to bottom.",
+    )
+    is_review_list: bool = SettingsField(
+        False,
+        title="Is review list",
+        description="",
+    )
+
+
+class CollectVersionToListModel(BaseSettingsModel):
+    enabled: bool = SettingsField(True, title="Enabled")
+    profiles: list[CollectVersionToListProfileModel] = SettingsField(
+        default_factory=list,
+        title="Profiles",
+        description=(
+            ""
+        )
+    )
+
 class ResolutionOptionsModel(BaseSettingsModel):
     _layout = "compact"
     width: int = SettingsField(
@@ -1226,6 +1292,10 @@ class PublishPuginsModel(BaseSettingsModel):
             title="Collect USD Layer Contributions",
         )
     )
+    CollectVersionToList: CollectVersionToListModel = SettingsField(
+        default_factory=CollectVersionToListModel,
+        title="Collect Version to List",
+    )
     CollectExplicitResolution: CollectExplicitResolutionModel = SettingsField(
         default_factory=CollectExplicitResolutionModel,
         title="Collect Explicit Resolution"
@@ -1427,6 +1497,18 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_apply_as_variant": False,
                 "contribution_target_product": "usdShot"
             },
+        ]
+    },
+    "CollectVersionToList": {
+        "enabled": True,
+        "profiles": [
+            {
+                "host_names": [],
+                "task_types": [],
+                "task_names": [],
+                "product_base_types": [],
+                "product_names": [],
+            }
         ]
     },
     "CollectExplicitResolution": {

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -1506,7 +1506,7 @@ DEFAULT_PUBLISH_VALUES = {
         ]
     },
     "CollectVersionToList": {
-        "enabled": True,
+        "enabled": False,
         "profiles": []
     },
     "CollectExplicitResolution": {

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -207,6 +207,7 @@ def list_type_enum():
         {"label": "Review Session", "value": "review-session"},
     ]
 
+
 class CollectVersionToListProfileModel(BaseSettingsModel):
     """Collect version list profile model."""
     _layout = "expanded"

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -261,7 +261,6 @@ class CollectVersionToListProfileModel(BaseSettingsModel):
         title="List type",
         description="Define what type of list this profile represents.",
         enum_resolver=list_type_enum,
-
     )
 
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -245,9 +245,9 @@ class CollectVersionToListProfileModel(BaseSettingsModel):
         title="Product names",
         description="The product names to match this profile to.",
     )
-    name_template: str = SettingsField(
+    name: str = SettingsField(
         "",
-        title="Name template",
+        title="Name",
         description="Anatomy formattable template for the name.",
         section="List configuration",
     )

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -225,7 +225,14 @@ class EntityListFolderModel(BaseSettingsModel):
 
     """
     _layout = "expanded"
-    label: str = SettingsField("", title="Folder label")
+    label: str = SettingsField(
+        "",
+        title="Folder label",
+        description=(
+            "The label of the folder to create. "
+            "Anatomy formattable template for the name."
+        ),
+    )
     # Don't use explicit scope enum, rather ask if the folder should be seen
     #   everywhere or just in the list type matching created list.
     scope_def: str = SettingsField(

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -215,13 +215,14 @@ def list_folder_scope_def():
     ]
 
 
-class VersionListFolderModel(BaseSettingsModel):
+class EntityListFolderModel(BaseSettingsModel):
     """Folder must have label and can be scoped to views.
 
     Scope of the folder can be defined for all views or use just the view
         matching list type of created list.
 
     """
+    _layout = "expanded"
     label: str = SettingsField("", title="Folder label")
     scope_def: str = SettingsField(
         "all",
@@ -280,7 +281,7 @@ class CollectVersionToListProfileModel(BaseSettingsModel):
         description="Define what type of list this profile represents.",
         enum_resolver=list_type_enum,
     )
-    list_folders: list[VersionListFolderModel] = SettingsField(
+    list_folders: list[EntityListFolderModel] = SettingsField(
         default_factory=list,
         title="List folders",
         description="Folder hierarchy formed from top to bottom.",

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -201,6 +201,12 @@ class CollectUSDLayerContributionsModel(BaseSettingsModel):
         return value
 
 
+def list_type_enum():
+    return [
+        {"label": "Generic", "value": "generic"},
+        {"label": "Review Session", "value": "review-session"},
+    ]
+
 class CollectVersionToListProfileModel(BaseSettingsModel):
     """."""
     _layout = "expanded"
@@ -250,10 +256,12 @@ class CollectVersionToListProfileModel(BaseSettingsModel):
         title="Parent folders",
         description="Folder hierarchy formed from top to bottom.",
     )
-    is_review_list: bool = SettingsField(
-        False,
-        title="Is review list",
-        description="",
+    list_type: str = SettingsField(
+        "generic",
+        title="List type",
+        description="Define what type of list this profile represents.",
+        enum_resolver=list_type_enum,
+
     )
 
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -208,7 +208,7 @@ def list_type_enum():
     ]
 
 class CollectVersionToListProfileModel(BaseSettingsModel):
-    """."""
+    """Collect version list profile model."""
     _layout = "expanded"
     host_names: list[str] = SettingsField(
         default_factory=list,
@@ -245,9 +245,9 @@ class CollectVersionToListProfileModel(BaseSettingsModel):
         title="Product names",
         description="The product names to match this profile to.",
     )
-    name: str = SettingsField(
-        "",
-        title="Name",
+    list_name: str = SettingsField(
+        "{folder[name]}",
+        title="List Name",
         description="Anatomy formattable template for the name.",
         section="List configuration",
     )

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -267,6 +267,7 @@ class CollectVersionToListModel(BaseSettingsModel):
         )
     )
 
+
 class ResolutionOptionsModel(BaseSettingsModel):
     _layout = "compact"
     width: int = SettingsField(

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -226,6 +226,8 @@ class EntityListFolderModel(BaseSettingsModel):
     """
     _layout = "expanded"
     label: str = SettingsField("", title="Folder label")
+    # Don't use explicit scope enum, rather ask if the folder should be seen
+    #   everywhere or just in the list type matching created list.
     scope_def: str = SettingsField(
         "all",
         enum_resolver=list_folder_scope_def,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -270,9 +270,6 @@ class CollectVersionToListModel(BaseSettingsModel):
     profiles: list[CollectVersionToListProfileModel] = SettingsField(
         default_factory=list,
         title="Profiles",
-        description=(
-            ""
-        )
     )
 
 


### PR DESCRIPTION
## Changelog Description
Two new publish plugins enable automatic population of published versions into AYON entity lists. A collector resolves list names from anatomy templates and profile-based settings; an integrator creates or appends to those lists on the server — including on-demand folder hierarchy creation and `review-session` typing. 

## Additional info
- `IntegrateVersionToList` (`IntegratorOrder + 0.49`) groups version IDs by list name, then creates new lists or appends to existing ones. List folder hierarchies are created on demand via direct `ayon_api` calls (temporary workaround until `ayon_api` exposes these endpoints natively — marked with `TODO` comments).
- Server-side settings expose a `CollectVersionToList` profile model with per-host/task/product filtering and per-list configuration (label template, list folders, review list flag).

## Testing notes:
1. Configure a `CollectVersionToList` profile in AYON settings (Studio → Publish → Collect Version to List) targeting a host and product type.
2. Publish an asset matching that profile.
3. Verify a new entity list appears in the AYON server project with the expected name and the published version as a member.
4. Publish a second version with the same list name — confirm it appends to the existing list rather than creating a duplicate.
5. Test with `list_folders` configured — confirm the folder hierarchy is created on the server.
6. Test with `list_type:review-session` — confirm the list type is set to `review-session`.

## Dependency
Close ynput/ayon-traypublisher#148
[YN-0770](https://support.ayon.app/projects/Active_Clients/overview?project=Active_Clients&type=folder&id=b255809cc9a64de79c4617fc95d89256)
