### PR TITLE
Load placeholders filter on product base types

### DIFF
--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1678,10 +1678,17 @@ class PlaceholderLoadMixin(object):
         if not folder_ids:
             return []
 
+        filter_key = "product_base_types"
+        if ayon_api.get_server_version_tuple() < (1, 14, 0):
+            filter_key = "product_types"
+        filter_kwargs = {
+            filter_key: {product_base_type},
+        }
+
         products = list(get_products(
             project_name,
             folder_ids=folder_ids,
-            product_base_types={product_base_type},
+            **filter_kwargs,
             fields={"id", "name"}
         ))
         filtered_product_ids = set()

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1678,12 +1678,10 @@ class PlaceholderLoadMixin(object):
         if not folder_ids:
             return []
 
-        # TODO this should filter by product_base_types
-        # - that can change only when AYON server 1.14.0 is required
         products = list(get_products(
             project_name,
             folder_ids=folder_ids,
-            product_types={product_base_type},
+            product_base_types={product_base_type},
             fields={"id", "name"}
         ))
         filtered_product_ids = set()


### PR DESCRIPTION
## Changelog Description

For workfile template builder load placeholder fix filtering by product base type with AYON Server 1.4.0+

## Additional info

Continuation of https://github.com/ynput/ayon-core/pull/1858

## Testing notes:

1. Load Placeholder should work and correctly filter by product base type instead of product type
