### PR TITLE
USD Contributions: Allow more control in settings over defaults for variants

### DIFF
--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -544,7 +544,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                 "contribution_apply_as_variant": False,
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
-                "contribution_variant_as_default": False,
+                "contribution_variant_is_default": False,
             }
 
         # Define defaults

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -540,8 +540,11 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
             profile = {
                 "contribution_enabled": True,
                 "contribution_layer": None,
-                "contribution_apply_as_variant": False,
                 "contribution_target_product": "usdAsset",
+                "contribution_apply_as_variant": False,
+                "contribution_variant_set_name": "{layer}",
+                "contribution_variant": "{variant}",
+                "contribution_variant_as_default": False,
             }
 
         # Define defaults
@@ -645,11 +648,11 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                     visible=visible),
             TextDef("contribution_variant_set_name",
                     label="Variant Set Name",
-                    default="{layer}",
+                    default=profile["contribution_variant_set_name"],
                     visible=variant_visible),
             TextDef("contribution_variant",
                     label="Variant Name",
-                    default="{variant}",
+                    default=profile["contribution_variant"],
                     visible=variant_visible),
             BoolDef("contribution_variant_is_default",
                     label="Set as default variant selection",
@@ -661,7 +664,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                         "The behavior is unpredictable if multiple instances "
                         "for the same variant set have this enabled."
                     ),
-                    default=False,
+                    default=profile["contribution_variant_is_default"],
                     visible=variant_visible),
             UISeparatorDef("usd_container_settings3"),
         ]

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -157,6 +157,15 @@ class CollectUSDLayerContributionsProfileModel(BaseSettingsModel):
             " 'Department Layer Orders' list to get a sensible order."
         ),
     )
+    contribution_target_product: str = SettingsField(
+        "usdAsset",
+        title="Target Product",
+        description=(
+            "The default destination product name to apply the contribution to"
+            " when matching this profile."
+            " Usually e.g. 'usdAsset' or 'usdShot'."
+        ),
+    )
     contribution_apply_as_variant: bool = SettingsField(
         True,
         title="Apply as variant",
@@ -166,13 +175,30 @@ class CollectUSDLayerContributionsProfileModel(BaseSettingsModel):
             " for shot contributions."
         ),
     )
-    contribution_target_product: str = SettingsField(
-        "usdAsset",
-        title="Target Product",
+    contribution_variant_set_name: str = SettingsField(
+        "{layer}",
+        title="Variant Set name",
         description=(
-            "The default destination product name to apply the contribution to"
-            " when matching this profile."
-            " Usually e.g. 'usdAsset' or 'usdShot'."
+            "The default variant set name for instances matching this profile."
+        ),
+    )
+    contribution_variant: str = SettingsField(
+        "{variant}",
+        title="Variant Name",
+        description=(
+            "The default variant name for instances matching this profile."
+        ),
+    )
+    contribution_variant_is_default: bool = SettingsField(
+        False,
+        title="Set as default variant selection",
+        description=(
+            "Whether to set this instance's variant name as the "
+            "default selected variant name for the variant set.\n"
+            "It is always expected to be enabled for only one "
+            "variant name in the variant set.\n"
+            "The behavior is unpredictable if multiple instances "
+            "for the same variant set have this enabled."
         ),
     )
 
@@ -1388,8 +1414,11 @@ DEFAULT_PUBLISH_VALUES = {
                 "task_names": [],
                 "contribution_enabled": True,
                 "contribution_layer": "model",
+                "contribution_target_product": "usdAsset",
                 "contribution_apply_as_variant": True,
-                "contribution_target_product": "usdAsset"
+                "contribution_variant_set_name": "{layer}",
+                "contribution_variant": "{variant}",
+                "contribution_variant_is_default": False,
             },
             {
                 "product_base_types": ["look"],
@@ -1397,8 +1426,11 @@ DEFAULT_PUBLISH_VALUES = {
                 "task_names": [],
                 "contribution_enabled": True,
                 "contribution_layer": "look",
+                "contribution_target_product": "usdAsset",
                 "contribution_apply_as_variant": True,
-                "contribution_target_product": "usdAsset"
+                "contribution_variant_set_name": "{layer}",
+                "contribution_variant": "{variant}",
+                "contribution_variant_is_default": False,
             },
             {
                 "product_base_types": ["groom"],
@@ -1406,8 +1438,11 @@ DEFAULT_PUBLISH_VALUES = {
                 "task_names": [],
                 "contribution_enabled": True,
                 "contribution_layer": "groom",
+                "contribution_target_product": "usdAsset",
                 "contribution_apply_as_variant": True,
-                "contribution_target_product": "usdAsset"
+                "contribution_variant_set_name": "{layer}",
+                "contribution_variant": "{variant}",
+                "contribution_variant_is_default": False,
             },
             {
                 "product_base_types": ["rig"],
@@ -1415,8 +1450,11 @@ DEFAULT_PUBLISH_VALUES = {
                 "task_names": [],
                 "contribution_enabled": True,
                 "contribution_layer": "rig",
+                "contribution_target_product": "usdAsset",
                 "contribution_apply_as_variant": True,
-                "contribution_target_product": "usdAsset"
+                "contribution_variant_set_name": "{layer}",
+                "contribution_variant": "{variant}",
+                "contribution_variant_is_default": False,
             },
             {
                 "product_base_types": ["usd"],
@@ -1424,8 +1462,11 @@ DEFAULT_PUBLISH_VALUES = {
                 "task_names": [],
                 "contribution_enabled": True,
                 "contribution_layer": "assembly",
+                "contribution_target_product": "usdShot",
                 "contribution_apply_as_variant": False,
-                "contribution_target_product": "usdShot"
+                "contribution_variant_set_name": "{layer}",
+                "contribution_variant": "{variant}",
+                "contribution_variant_is_default": False,
             },
         ]
     },


### PR DESCRIPTION
## Changelog Description

USD Contributions: Allow more control in settings over defaults for variant set names and variant set.

## Additional info

Settings are at `ayon+settings://core/publish/CollectUSDLayerContributions/profiles/0/contribution_variant_set_name` etc.

Fix https://github.com/ynput/ayon-core/issues/1827

## Testing notes:
1. Defaults for Variant Set name and variant name should be working
