### PR TITLE
Add Extract Thumbnail to workflow host

### DIFF
--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -110,6 +110,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         "unreal",
         "houdini",
         "batchdelivery",
+        "workflow",
     ]
     settings_category = "core"
     enabled = False


### PR DESCRIPTION
## Changelog Description

Add Extract Thumbnail to workflow host

## Additional info

Generate thumbnails for the renders published via workflow addon.

This would technically be superseded by PR https://github.com/ynput/ayon-core/pull/1863 but because that may need much more thorough testing and will affect way more things this is the easier fix for now.

## Testing notes:

1. Thumbnails should be generated on publish via workflows addon.
