### PR TITLE
Settings: Fix label for FFMPEG output arguments

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -462,7 +462,7 @@ class ExtractThumbnailFFmpegModel(BaseSettingsModel):
     )
     output: list[str] = SettingsField(
         default_factory=list,
-        title="FFmpeg input arguments"
+        title="FFmpeg output arguments"
     )
 
 


### PR DESCRIPTION
## Changelog Description
Fix #1880: Fix settings label for FFMPEG output arguments

## Additional info

Fix #1880 

## Testing notes:

1. Label should be good now
