### PR TITLE
fix: expand user home in anatomy roots

### DIFF
--- a/client/ayon_core/pipeline/anatomy/roots.py
+++ b/client/ayon_core/pipeline/anatomy/roots.py
@@ -26,7 +26,7 @@ class RootItem(FormatObject):
         super().__init__()
         self._log = None
         lowered_platform_keys = {
-            key.lower(): value
+            key.lower(): self._expand_root_value(value)
             for key, value in root_raw_data.items()
         }
         self.raw_data = lowered_platform_keys
@@ -40,12 +40,15 @@ class RootItem(FormatObject):
         # WARNING: Using environment variables in roots is not considered
         #   as production safe. Some features may not work as expected, for
         #   example USD resolver or site sync.
+        current_root_value = lowered_platform_keys[current_platform]
         try:
-            self.value = lowered_platform_keys[current_platform].format_map(
-                os.environ
+            self.value = self._expand_root_value(
+                current_root_value.format_map(os.environ)
             )
         except KeyError:
-            result = StringTemplate(self.value).format(os.environ.copy())
+            result = StringTemplate(current_root_value).format(
+                os.environ.copy()
+            )
             is_are = "is" if len(result.missing_keys) == 1 else "are"
             missing_keys = ", ".join(result.missing_keys)
             raise RootMissingEnv(
@@ -110,6 +113,11 @@ class RootItem(FormatObject):
 
         """
         return str(path).replace("\\", "/")
+
+    @staticmethod
+    def _expand_root_value(value):
+        """Expand user home marker in configured root values."""
+        return os.path.expanduser(str(value))
 
     def _clean_root(self, root):
         """Clean root value.

--- a/tests/client/ayon_core/pipeline/anatomy/test_roots.py
+++ b/tests/client/ayon_core/pipeline/anatomy/test_roots.py
@@ -1,0 +1,58 @@
+import os
+import platform
+
+from ayon_core.pipeline.anatomy.roots import AnatomyRoots
+
+
+class DummyAnatomy:
+    def __init__(self, roots_data):
+        self.project_name = "TestProject"
+        self._roots_data = roots_data
+
+    def __getitem__(self, key):
+        if key == "roots":
+            return self._roots_data
+        raise KeyError(key)
+
+
+def test_root_values_expand_user_home(monkeypatch):
+    platform_name = platform.system().lower()
+    other_platform_name = "darwin" if platform_name != "darwin" else "linux"
+    monkeypatch.setenv("HOME", "/home/tester")
+    monkeypatch.setenv("USERPROFILE", "C:/Users/tester")
+
+    roots_data = {
+        "work": {
+            platform_name: "~/foo/bar",
+            other_platform_name: "~/other/foo",
+        }
+    }
+    roots = AnatomyRoots._parse_dict(roots_data, DummyAnatomy(roots_data))
+
+    work_root = roots["work"]
+    expanded_root = os.path.expanduser("~/foo/bar")
+
+    assert str(work_root) == expanded_root
+    assert work_root.raw_data[platform_name] == expanded_root
+    assert work_root.cleaned_data[platform_name] == (
+        expanded_root.replace("\\", "/").rstrip("/")
+    )
+
+
+def test_root_helpers_use_expanded_user_home(monkeypatch):
+    platform_name = platform.system().lower()
+    monkeypatch.setenv("HOME", "/home/tester")
+    monkeypatch.setenv("USERPROFILE", "C:/Users/tester")
+
+    roots_data = {"work": {platform_name: "~/foo/bar"}}
+    anatomy_roots = AnatomyRoots(DummyAnatomy(roots_data))
+
+    expanded_root = os.path.expanduser("~/foo/bar")
+    root_template_path = "{root[work]}/project/shot/file.ma"
+    expanded_file_path = f"{expanded_root}/project/shot/file.ma"
+
+    assert anatomy_roots.path_remapper(root_template_path) == expanded_file_path
+    assert anatomy_roots.all_root_paths() == [expanded_root]
+    assert anatomy_roots.root_environments() == {
+        "AYON_PROJECT_ROOT_WORK": expanded_root
+    }


### PR DESCRIPTION
## Changelog Description
Expand `~` in anatomy root definitions so paths like `~/foo/bar` resolve to the current user's home directory before root values are cleaned and exposed through helpers.

Fixes #1874.

## Additional info
This keeps the existing environment-variable formatting behavior for current-platform roots and applies home expansion to configured root values before they are stored in `raw_data` / `cleaned_data`.

## Testing notes:
1. `python -m pytest tests\client\ayon_core\pipeline\anatomy\test_roots.py -q`
2. `git diff --check`
3. `python -m py_compile client\ayon_core\pipeline\anatomy\roots.py tests\client\ayon_core\pipeline\anatomy\test_roots.py`