### PR TITLE
fix: allow skipping usd default variant selection

### DIFF
--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -50,6 +50,28 @@ from ayon_core.pipeline import publish, KnownPublishError
 # all the time at the same time
 BUILD_INTO_LAST_VERSIONS = True
 
+VARIANT_DEFAULT_MODE_NEVER = "never"
+VARIANT_DEFAULT_MODE_IF_NOT_SET = "if_not_set"
+VARIANT_DEFAULT_MODE_ALWAYS = "always"
+
+VARIANT_DEFAULT_MODE_ITEMS = [
+    {
+        "value": VARIANT_DEFAULT_MODE_NEVER,
+        "label": "Do not set"
+    },
+    {
+        "value": VARIANT_DEFAULT_MODE_IF_NOT_SET,
+        "label": "Set if no current default"
+    },
+    {
+        "value": VARIANT_DEFAULT_MODE_ALWAYS,
+        "label": "Set as default"
+    },
+]
+
+VARIANT_DEFAULT_MODE_KEY = "contribution_variant_default_mode"
+LEGACY_VARIANT_IS_DEFAULT_KEY = "contribution_variant_is_default"
+
 
 @dataclasses.dataclass
 class _BaseContribution:
@@ -74,7 +96,41 @@ class VariantContribution(_BaseContribution):
     # Variant
     variant_set_name: str
     variant_name: str
-    variant_is_default: bool  # Whether to author variant selection opinion
+    variant_default_mode: str  # When to author variant selection opinion
+
+
+def _variant_default_mode_from_value(value):
+    """Return default-variant mode, including legacy bool values."""
+    if value is True:
+        return VARIANT_DEFAULT_MODE_ALWAYS
+    if value is False or value is None:
+        return VARIANT_DEFAULT_MODE_IF_NOT_SET
+    if value in {
+        VARIANT_DEFAULT_MODE_NEVER,
+        VARIANT_DEFAULT_MODE_IF_NOT_SET,
+        VARIANT_DEFAULT_MODE_ALWAYS,
+    }:
+        return value
+    return VARIANT_DEFAULT_MODE_IF_NOT_SET
+
+
+def _should_set_variant_default(mode, variant_set_name, variant_selections):
+    mode = _variant_default_mode_from_value(mode)
+    if mode == VARIANT_DEFAULT_MODE_ALWAYS:
+        return True
+    if mode == VARIANT_DEFAULT_MODE_NEVER:
+        return False
+    return variant_set_name not in variant_selections
+
+
+def _get_variant_default_mode(attr_values):
+    if VARIANT_DEFAULT_MODE_KEY in attr_values:
+        return _variant_default_mode_from_value(
+            attr_values[VARIANT_DEFAULT_MODE_KEY]
+        )
+    return _variant_default_mode_from_value(
+        attr_values.get(LEGACY_VARIANT_IS_DEFAULT_KEY)
+    )
 
 
 def get_representation_path_in_publish_context(
@@ -355,7 +411,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                 target_product=attr_values["contribution_target_product"],
                 variant_set_name=attr_values["contribution_variant_set_name"],
                 variant_name=attr_values["contribution_variant"],
-                variant_is_default=attr_values["contribution_variant_is_default"],  # noqa: E501
+                variant_default_mode=_get_variant_default_mode(attr_values),
                 order=in_layer_order
             )
         else:
@@ -520,6 +576,34 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
         return new_instance
 
     @classmethod
+    def convert_attribute_values(cls, create_context, instance):
+        if instance is None:
+            return
+
+        publish_attributes = instance.publish_attributes
+        plugin_values = publish_attributes.get(cls.__name__)
+        if not plugin_values:
+            return
+
+        if VARIANT_DEFAULT_MODE_KEY in plugin_values:
+            if LEGACY_VARIANT_IS_DEFAULT_KEY in plugin_values:
+                plugin_values = dict(plugin_values)
+                plugin_values.pop(LEGACY_VARIANT_IS_DEFAULT_KEY, None)
+                publish_attributes[cls.__name__] = plugin_values
+            return
+
+        legacy_value = plugin_values.get(LEGACY_VARIANT_IS_DEFAULT_KEY)
+        if legacy_value is None:
+            return
+
+        plugin_values = dict(plugin_values)
+        plugin_values.pop(LEGACY_VARIANT_IS_DEFAULT_KEY, None)
+        plugin_values[VARIANT_DEFAULT_MODE_KEY] = (
+            _variant_default_mode_from_value(legacy_value)
+        )
+        publish_attributes[cls.__name__] = plugin_values
+
+    @classmethod
     def get_attr_defs_for_instance(cls, create_context, instance):
         # Filtering of instance, if needed, can be customized
         if not cls.instance_matches_plugin_families(instance):
@@ -544,7 +628,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                 "contribution_apply_as_variant": False,
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
-                "contribution_variant_is_default": False,
+                VARIANT_DEFAULT_MODE_KEY: VARIANT_DEFAULT_MODE_IF_NOT_SET,
             }
 
         # Define defaults
@@ -654,17 +738,19 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                     label="Variant Name",
                     default=profile["contribution_variant"],
                     visible=variant_visible),
-            BoolDef("contribution_variant_is_default",
-                    label="Set as default variant selection",
+            EnumDef(VARIANT_DEFAULT_MODE_KEY,
+                    label="Default variant selection",
                     tooltip=(
-                        "Whether to set this instance's variant name as the "
-                        "default selected variant name for the variant set.\n"
-                        "It is always expected to be enabled for only one "
-                        "variant name in the variant set.\n"
-                        "The behavior is unpredictable if multiple instances "
-                        "for the same variant set have this enabled."
+                        "Choose whether this instance's variant name should "
+                        "be authored as the default selected variant for the "
+                        "variant set.\n"
+                        "'Set if no current default' preserves the previous "
+                        "behavior.\n"
+                        "'Set as default' should be used for only one "
+                        "variant name in the variant set."
                     ),
-                    default=profile["contribution_variant_is_default"],
+                    items=VARIANT_DEFAULT_MODE_ITEMS,
+                    default=_get_variant_default_mode(profile),
                     visible=variant_visible),
             UISeparatorDef("usd_container_settings3"),
         ]
@@ -790,8 +876,11 @@ class ExtractUSDLayerContribution(publish.Extractor):
                 # Set default variant selection
                 variant_set_name = contribution.variant_set_name
                 variant_name = contribution.variant_name
-                if contribution.variant_is_default or \
-                        variant_set_name not in prim_spec.variantSelections:
+                if _should_set_variant_default(
+                    contribution.variant_default_mode,
+                    variant_set_name,
+                    prim_spec.variantSelections
+                ):
                     prim_spec.variantSelections[variant_set_name] = variant_name  # noqa: E501
 
             elif isinstance(contribution, SublayerContribution):

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -286,11 +286,32 @@ def _convert_oiio_transcode_0_4_5(publish_overrides):
             }
 
 
+def _convert_usd_variant_default_mode(publish_overrides):
+    """Convert legacy USD variant default bool to the new three-state mode."""
+    plugin_settings = publish_overrides.get("CollectUSDLayerContributions")
+    if not plugin_settings:
+        return
+
+    profiles = plugin_settings.get("profiles")
+    if not profiles:
+        return
+
+    for profile in profiles:
+        is_default = profile.pop("contribution_variant_is_default", None)
+        if "contribution_variant_default_mode" in profile:
+            continue
+
+        profile["contribution_variant_default_mode"] = (
+            "always" if is_default is True else "if_not_set"
+        )
+
+
 def _convert_publish_plugins(overrides):
     if "publish" not in overrides:
         return
     _convert_validate_version_0_3_3(overrides["publish"])
     _convert_oiio_transcode_0_4_5(overrides["publish"])
+    _convert_usd_variant_default_mode(overrides["publish"])
 
 
 def _convert_extract_thumbnail(overrides):

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -88,6 +88,14 @@ def usd_contribution_layer_types():
     ]
 
 
+def usd_variant_default_modes():
+    return [
+        {"value": "never", "label": "Do not set"},
+        {"value": "if_not_set", "label": "Set if no current default"},
+        {"value": "always", "label": "Set as default"},
+    ]
+
+
 class ContributionLayersModel(BaseSettingsModel):
     _layout = "compact"
     name: str = SettingsField(
@@ -189,16 +197,16 @@ class CollectUSDLayerContributionsProfileModel(BaseSettingsModel):
             "The default variant name for instances matching this profile."
         ),
     )
-    contribution_variant_is_default: bool = SettingsField(
-        False,
-        title="Set as default variant selection",
+    contribution_variant_default_mode: str = SettingsField(
+        "if_not_set",
+        title="Default variant selection",
+        enum_resolver=usd_variant_default_modes,
         description=(
-            "Whether to set this instance's variant name as the "
-            "default selected variant name for the variant set.\n"
-            "It is always expected to be enabled for only one "
-            "variant name in the variant set.\n"
-            "The behavior is unpredictable if multiple instances "
-            "for the same variant set have this enabled."
+            "Choose whether this instance's variant name should be authored "
+            "as the default selected variant for the variant set.\n"
+            "'Set if no current default' preserves the previous behavior.\n"
+            "'Set as default' should be used for only one variant name in "
+            "the variant set."
         ),
     )
 
@@ -1527,7 +1535,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_apply_as_variant": True,
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
-                "contribution_variant_is_default": False,
+                "contribution_variant_default_mode": "if_not_set",
             },
             {
                 "product_base_types": ["look"],
@@ -1539,7 +1547,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_apply_as_variant": True,
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
-                "contribution_variant_is_default": False,
+                "contribution_variant_default_mode": "if_not_set",
             },
             {
                 "product_base_types": ["groom"],
@@ -1551,7 +1559,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_apply_as_variant": True,
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
-                "contribution_variant_is_default": False,
+                "contribution_variant_default_mode": "if_not_set",
             },
             {
                 "product_base_types": ["rig"],
@@ -1563,7 +1571,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_apply_as_variant": True,
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
-                "contribution_variant_is_default": False,
+                "contribution_variant_default_mode": "if_not_set",
             },
             {
                 "product_base_types": ["usd"],
@@ -1575,7 +1583,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_apply_as_variant": False,
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
-                "contribution_variant_is_default": False,
+                "contribution_variant_default_mode": "if_not_set",
             },
         ]
     },

--- a/tests/client/ayon_core/plugins/publish/test_usd_layer_contributions.py
+++ b/tests/client/ayon_core/plugins/publish/test_usd_layer_contributions.py
@@ -1,0 +1,111 @@
+from ayon_core.plugins.publish.extract_usd_layer_contributions import (
+    CollectUSDLayerContributions,
+    LEGACY_VARIANT_IS_DEFAULT_KEY,
+    VARIANT_DEFAULT_MODE_ALWAYS,
+    VARIANT_DEFAULT_MODE_IF_NOT_SET,
+    VARIANT_DEFAULT_MODE_KEY,
+    VARIANT_DEFAULT_MODE_NEVER,
+    _get_variant_default_mode,
+    _should_set_variant_default,
+    _variant_default_mode_from_value,
+)
+
+
+class _DummyInstance:
+    def __init__(self, publish_attributes):
+        self.publish_attributes = publish_attributes
+
+
+def test_variant_default_mode_preserves_legacy_values():
+    assert _variant_default_mode_from_value(True) == VARIANT_DEFAULT_MODE_ALWAYS
+    assert (
+        _variant_default_mode_from_value(False)
+        == VARIANT_DEFAULT_MODE_IF_NOT_SET
+    )
+    assert (
+        _variant_default_mode_from_value(None)
+        == VARIANT_DEFAULT_MODE_IF_NOT_SET
+    )
+
+
+def test_variant_default_mode_accepts_new_values():
+    assert (
+        _variant_default_mode_from_value(VARIANT_DEFAULT_MODE_NEVER)
+        == VARIANT_DEFAULT_MODE_NEVER
+    )
+    assert (
+        _variant_default_mode_from_value(VARIANT_DEFAULT_MODE_IF_NOT_SET)
+        == VARIANT_DEFAULT_MODE_IF_NOT_SET
+    )
+    assert (
+        _variant_default_mode_from_value(VARIANT_DEFAULT_MODE_ALWAYS)
+        == VARIANT_DEFAULT_MODE_ALWAYS
+    )
+
+
+def test_variant_default_mode_reads_new_key_before_legacy_key():
+    assert _get_variant_default_mode({
+        VARIANT_DEFAULT_MODE_KEY: VARIANT_DEFAULT_MODE_NEVER,
+        LEGACY_VARIANT_IS_DEFAULT_KEY: True,
+    }) == VARIANT_DEFAULT_MODE_NEVER
+
+
+def test_variant_default_mode_falls_back_to_legacy_key():
+    assert _get_variant_default_mode({
+        LEGACY_VARIANT_IS_DEFAULT_KEY: True,
+    }) == VARIANT_DEFAULT_MODE_ALWAYS
+    assert _get_variant_default_mode({
+        LEGACY_VARIANT_IS_DEFAULT_KEY: False,
+    }) == VARIANT_DEFAULT_MODE_IF_NOT_SET
+
+
+def test_convert_attribute_values_migrates_legacy_default_flag():
+    instance = _DummyInstance({
+        CollectUSDLayerContributions.__name__: {
+            LEGACY_VARIANT_IS_DEFAULT_KEY: True,
+        },
+    })
+
+    CollectUSDLayerContributions.convert_attribute_values(None, instance)
+
+    plugin_values = instance.publish_attributes[
+        CollectUSDLayerContributions.__name__
+    ]
+    assert plugin_values == {
+        VARIANT_DEFAULT_MODE_KEY: VARIANT_DEFAULT_MODE_ALWAYS,
+    }
+
+
+def test_convert_attribute_values_keeps_new_default_mode():
+    instance = _DummyInstance({
+        CollectUSDLayerContributions.__name__: {
+            VARIANT_DEFAULT_MODE_KEY: VARIANT_DEFAULT_MODE_NEVER,
+            LEGACY_VARIANT_IS_DEFAULT_KEY: True,
+        },
+    })
+
+    CollectUSDLayerContributions.convert_attribute_values(None, instance)
+
+    plugin_values = instance.publish_attributes[
+        CollectUSDLayerContributions.__name__
+    ]
+    assert plugin_values == {
+        VARIANT_DEFAULT_MODE_KEY: VARIANT_DEFAULT_MODE_NEVER,
+    }
+
+
+def test_should_set_variant_default_only_when_requested():
+    existing_selections = {"model": "main"}
+
+    assert not _should_set_variant_default(
+        VARIANT_DEFAULT_MODE_NEVER, "model", existing_selections
+    )
+    assert not _should_set_variant_default(
+        VARIANT_DEFAULT_MODE_IF_NOT_SET, "model", existing_selections
+    )
+    assert _should_set_variant_default(
+        VARIANT_DEFAULT_MODE_IF_NOT_SET, "look", existing_selections
+    )
+    assert _should_set_variant_default(
+        VARIANT_DEFAULT_MODE_ALWAYS, "model", existing_selections
+    )


### PR DESCRIPTION
Fixes #1666

## Changelog Description
Adds a configurable USD contribution default variant selection mode so projects can choose whether an extracted contribution should become the default variant selection.

The new mode supports:
- `never`: leave the variant set without changing its default selection.
- `if_not_set`: keep the existing behavior by selecting the contribution only when no default is set yet.
- `always`: force the contribution to become the default variant selection.

The legacy `contribution_variant_is_default` boolean is still honored as a fallback, so existing settings keep their previous behavior.

## Additional info
This keeps the previous default behavior for current profiles while allowing workflows that need no default variant selection at all.

## Testing notes
- `python -m py_compile client/ayon_core/plugins/publish/extract_usd_layer_contributions.py tests/client/ayon_core/plugins/publish/test_usd_layer_contributions.py`
- `git diff --check`
- Dependency-stub smoke test for the new default-mode helper logic

Full pytest was not run locally because the bundled Python environment does not include the project test dependencies such as pytest/pyblish.