### PR TITLE
Anatomy: expand user and vars in root paths

### DIFF
--- a/client/ayon_core/pipeline/anatomy/roots.py
+++ b/client/ayon_core/pipeline/anatomy/roots.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import platform
 import numbers
@@ -17,13 +18,15 @@ class AnatomyRoot(FormatObject):
     is used for formatting of template.
 
     Args:
-        parent (AnatomyRoots): Parent object.
+        parent (AnatomyRoots | None): Parent object.
         root_raw_data (dict): Dictionary containing root values by platform
             names. ["windows", "linux" and "darwin"]
         name (str): Root name which is representing. Used with
             multi root setup otherwise None value is expected.
     """
-    def __init__(self, parent, root_raw_data, name):
+    def __init__(
+            self, parent: AnatomyRoots | None,
+            root_raw_data: dict, name: str):
         super().__init__()
         self._log = None
         lowered_platform_keys = {
@@ -45,12 +48,13 @@ class AnatomyRoot(FormatObject):
             self.value = (
                 os.path.expandvars(
                     os.path.expanduser(
-                        lowered_platform_keys[current_platform].format_map(
-                            os.environ
-                        )
-                    )
-                )
-            )
+                        lowered_platform_keys[current_platform])))
+        except AttributeError as e:
+            msg = f"Missing root definition for platform {current_platform}."
+            raise RootMissingEnv(msg) from e
+
+        try:
+            self.value = self.value.format_map(os.environ)
         except KeyError as e:
             result = StringTemplate(self.value).format(os.environ.copy())
             is_are = "is" if len(result.missing_keys) == 1 else "are"
@@ -208,7 +212,7 @@ class AnatomyRoot(FormatObject):
         ``os.path.expanduser``) so that the following mismatches are handled:
 
         - ``path`` is already expanded but the stored root still contains
-          ``~`` or ``%VAR%`` / ``$VAR`` tokens (or vice-versa).
+          ``~` / ``$VAR`` tokens (or vice-versa).
 
         Args:
             path (str): Path where root value should be found.

--- a/client/ayon_core/pipeline/anatomy/roots.py
+++ b/client/ayon_core/pipeline/anatomy/roots.py
@@ -41,17 +41,23 @@ class RootItem(FormatObject):
         #   as production safe. Some features may not work as expected, for
         #   example USD resolver or site sync.
         try:
-            self.value = lowered_platform_keys[current_platform].format_map(
-                os.environ
+            self.value = (
+                os.path.expandvars(
+                    os.path.expanduser(
+                        lowered_platform_keys[current_platform].format_map(
+                            os.environ
+                        )
+                    )
+                )
             )
-        except KeyError:
+        except KeyError as e:
             result = StringTemplate(self.value).format(os.environ.copy())
             is_are = "is" if len(result.missing_keys) == 1 else "are"
             missing_keys = ", ".join(result.missing_keys)
             raise RootMissingEnv(
                 f"Root \"{name}\" requires environment variable/s"
                 f" {missing_keys} which {is_are} not available."
-            )
+            ) from e
 
         self.clean_value = self._clean_root(self.value)
 
@@ -196,6 +202,13 @@ class RootItem(FormatObject):
 
         All platform values are checked for this replacement.
 
+        Both the input ``path`` and the stored root values are tried in their
+        original *and* expanded forms (via ``os.path.expandvars`` /
+        ``os.path.expanduser``) so that the following mismatches are handled:
+
+        - ``path`` is already expanded but the stored root still contains
+          ``~`` or ``%VAR%`` / ``$VAR`` tokens (or vice-versa).
+
         Args:
             path (str): Path where root value should be found.
 
@@ -224,20 +237,63 @@ class RootItem(FormatObject):
         output = str(path)
 
         mod_path = self._clean_path(path)
+        # Expanded version of the input path – used when the stored root value
+        # is already expanded while the caller passed an unexpanded path, or
+        # to normalise both sides consistently.
+        expanded_mod_path = self._clean_path(
+            os.path.expandvars(os.path.expanduser(path))
+        )
+
         for root_os, root_path in self.cleaned_data.items():
             # Skip empty paths
             if not root_path:
                 continue
 
-            _mod_path = mod_path  # reset to original cleaned value
-            if root_os == "windows":
-                root_path = root_path.lower()
-                _mod_path = _mod_path.lower()
+            # Expand variables in the stored root path so we can compare it
+            # against an already-expanded input path (and vice-versa).
+            expanded_root_path = self._clean_root(
+                os.path.expandvars(os.path.expanduser(root_path))
+            )
 
-            if _mod_path.startswith(root_path):
+            _mod_path = mod_path
+            _expanded_mod_path = expanded_mod_path
+            _root_path = root_path
+            _expanded_root_path = expanded_root_path
+            if root_os == "windows":
+                _mod_path = _mod_path.lower()
+                _expanded_mod_path = _expanded_mod_path.lower()
+                _root_path = _root_path.lower()
+                _expanded_root_path = _expanded_root_path.lower()
+
+            replacement = "{" + self.full_key + "}"
+
+            # 1) original path vs original root  (existing behaviour)
+            if _mod_path.startswith(_root_path):
                 result = True
-                replacement = "{" + self.full_key + "}"
                 output = replacement + mod_path[len(root_path):]
+                break
+
+            # 2) original path vs expanded root
+            #    (root stored with vars, path already expanded)
+            if _mod_path.startswith(_expanded_root_path):
+                result = True
+                output = replacement + mod_path[len(expanded_root_path):]
+                break
+
+            # 3) expanded path vs original root
+            #    (path stored with vars, root already expanded)
+            if _expanded_mod_path.startswith(_root_path):
+                result = True
+                output = replacement + expanded_mod_path[len(root_path):]
+                break
+
+            # 4) expanded path vs expanded root  (both sides have vars)
+            if _expanded_mod_path.startswith(_expanded_root_path):
+                result = True
+                output = (
+                    replacement
+                    + expanded_mod_path[len(expanded_root_path):]
+                )
                 break
 
         return (result, output)

--- a/client/ayon_core/pipeline/anatomy/roots.py
+++ b/client/ayon_core/pipeline/anatomy/roots.py
@@ -18,15 +18,13 @@ class AnatomyRoot(FormatObject):
     is used for formatting of template.
 
     Args:
-        parent (AnatomyRoots | None): Parent object.
+        parent (AnatomyRoots): Parent object.
         root_raw_data (dict): Dictionary containing root values by platform
             names. ["windows", "linux" and "darwin"]
         name (str): Root name which is representing. Used with
             multi root setup otherwise None value is expected.
     """
-    def __init__(
-            self, parent: AnatomyRoots | None,
-            root_raw_data: dict, name: str):
+    def __init__(self, parent, root_raw_data, name):
         super().__init__()
         self._log = None
         lowered_platform_keys = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,8 @@ log_cli = true
 log_cli_level = "INFO"
 addopts = "-ra -q"
 testpaths = [
-    "client/ayon_core/tests"
+    "client/ayon_core/tests",
+    "tests"
 ]
 markers = [
     "unit: Unit tests",

--- a/tests/client/ayon_core/pipeline/anatomy/test_root_item.py
+++ b/tests/client/ayon_core/pipeline/anatomy/test_root_item.py
@@ -1,4 +1,4 @@
-"""Tests for RootItem and its find_root_template_from_path logic.
+"""Tests for AnatomyRoot and its find_root_template_from_path logic.
 
 These tests are intentionally isolated from the rest of Anatomy / AYON server
 so they can run without any network connection or AYON credentials.
@@ -9,7 +9,7 @@ import os
 import pytest
 from unittest.mock import patch
 
-from ayon_core.pipeline.anatomy.roots import RootItem
+from ayon_core.pipeline.anatomy.roots import AnatomyRoot
 
 
 def make_root_item(
@@ -18,8 +18,8 @@ def make_root_item(
     darwin: str = "/Volumes/projects",
     name: str = "work",
     platform_override: str | None = None,
-) -> RootItem:
-    """Create a RootItem, optionally forcing the *current* platform.
+) -> AnatomyRoot:
+    """Create a AnatomyRoot, optionally forcing the *current* platform.
 
     Helper function for testing.
 
@@ -31,30 +31,30 @@ def make_root_item(
         platform_override (str, optional): Platform override. Defaults to None.
 
     Returns:
-        RootItem: Root Item.
+        AnatomyRoot: Root Item.
 
     """
     raw_data = {"windows": windows, "linux": linux, "darwin": darwin}
     target_platform = platform_override or "linux"
     with patch("platform.system", return_value=target_platform):
-        return RootItem(parent=None, root_raw_data=raw_data, name=name)
+        return AnatomyRoot(parent=None, root_raw_data=raw_data, name=name)
 
 
 @pytest.fixture
 def linux_root():
-    """RootItem configured for Linux."""
+    """AnatomyRoot configured for Linux."""
     return make_root_item(linux="/mnt/projects", platform_override="linux")
 
 
 @pytest.fixture
 def windows_root():
-    """RootItem configured for Windows."""
+    """AnatomyRoot configured for Windows."""
     return make_root_item(windows="C:/projects", platform_override="windows")
 
 
 @pytest.fixture
 def darwin_root():
-    """RootItem configured for macOS (Darwin)."""
+    """AnatomyRoot configured for macOS (Darwin)."""
     return make_root_item(
         darwin="/Volumes/projects", platform_override="darwin"
     )
@@ -62,7 +62,7 @@ def darwin_root():
 
 @pytest.fixture
 def multi_platform_root():
-    """RootItem with all platforms set, current platform Linux."""
+    """AnatomyRoot with all platforms set, current platform Linux."""
     return make_root_item(
         windows="C:/projects",
         linux="/mnt/projects",
@@ -73,7 +73,7 @@ def multi_platform_root():
 
 @pytest.fixture
 def cross_platform_root():
-    """RootItem with Linux and Windows paths, running on Linux."""
+    """AnatomyRoot with Linux and Windows paths, running on Linux."""
     return make_root_item(
         windows="C:/projects",
         linux="/mnt/projects",
@@ -119,7 +119,7 @@ def test_full_key_with_name():
 def test_value_expands_env_var():
     with patch.dict(os.environ, {"MY_ROOT": "/env/root"}, clear=False):
         with patch("platform.system", return_value="linux"):
-            item = RootItem(
+            item = AnatomyRoot(
                 parent=None,
                 root_raw_data={"linux": "$MY_ROOT/projects"},
                 name="work",
@@ -132,7 +132,7 @@ def test_value_expands_user_home():
     expand = lambda p: p.replace("~", fake_home)  # noqa: E731
     with patch("os.path.expanduser", side_effect=expand):
         with patch("platform.system", return_value="linux"):
-            item = RootItem(
+            item = AnatomyRoot(
                 parent=None,
                 root_raw_data={"linux": "~/projects"},
                 name="work",
@@ -205,7 +205,7 @@ def test_expanded_path_matches_unexpanded_root_with_envvar():
     fake_env = {"MY_ROOT": "/mnt"}
     with patch.dict(os.environ, fake_env, clear=False):
         with patch("platform.system", return_value="linux"):
-            item = RootItem(
+            item = AnatomyRoot(
                 parent=None,
                 root_raw_data={
                     "linux": "$MY_ROOT/projects",
@@ -226,7 +226,7 @@ def test_expanded_path_matches_unexpanded_root_with_tilde():
     expand = lambda p: p.replace("~", fake_home)  # noqa: E731
     with patch("os.path.expanduser", side_effect=expand):
         with patch("platform.system", return_value="linux"):
-            item = RootItem(
+            item = AnatomyRoot(
                 parent=None,
                 root_raw_data={"linux": "~/projects"},
                 name="work",
@@ -244,7 +244,7 @@ def test_unexpanded_path_matches_expanded_root():
     fake_home = "/home/user"
     expand = lambda p: p.replace("~", fake_home)  # noqa: E731
     with patch("platform.system", return_value="linux"):
-        item = RootItem(
+        item = AnatomyRoot(
             parent=None,
             root_raw_data={"linux": "/home/user/projects"},
             name="work",
@@ -261,7 +261,7 @@ def test_unexpanded_envvar_path_matches_expanded_root():
     """Root already expanded, path contains ``$MY_ROOT``."""
     fake_env = {"MY_ROOT": "/mnt"}
     with patch("platform.system", return_value="linux"):
-        item = RootItem(
+        item = AnatomyRoot(
             parent=None,
             root_raw_data={"linux": "/mnt/projects"},
             name="work",
@@ -280,7 +280,7 @@ def test_both_sides_need_expanding():
     expand = lambda p: p.replace("~", fake_home)  # noqa: E731
     with patch("os.path.expanduser", side_effect=expand):
         with patch("platform.system", return_value="linux"):
-            item = RootItem(
+            item = AnatomyRoot(
                 parent=None,
                 root_raw_data={"linux": "~/projects"},
                 name="work",
@@ -297,7 +297,7 @@ def test_no_match_with_expansion_returns_false():
     fake_env = {"MY_ROOT": "/mnt"}
     with patch.dict(os.environ, fake_env, clear=False):
         with patch("platform.system", return_value="linux"):
-            item = RootItem(
+            item = AnatomyRoot(
                 parent=None,
                 root_raw_data={"linux": "$MY_ROOT/projects"},
                 name="work",
@@ -310,7 +310,7 @@ def test_no_match_with_expansion_returns_false():
 
 
 # ---------------------------------------------------------------------------
-# RootItem.path_remapper
+# AnatomyRoot.path_remapper
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("input_path,dst_platform,src_platform,expected", [
@@ -350,7 +350,3 @@ def test_path_remapper_success(
 def test_path_remapper_returns_none(linux_root, input_path, remap_kwargs):
     result = linux_root.path_remapper(input_path, **remap_kwargs)
     assert result is None
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])

--- a/tests/client/ayon_core/pipeline/anatomy/test_root_item.py
+++ b/tests/client/ayon_core/pipeline/anatomy/test_root_item.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import os
 import pytest
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 from ayon_core.pipeline.anatomy import Anatomy
@@ -15,6 +15,29 @@ from ayon_core.pipeline.anatomy.roots import AnatomyRoot, AnatomyRoots
 
 if TYPE_CHECKING:
     from ayon_api.typing import ProjectDict
+
+
+@pytest.fixture
+def anatomy_roots() -> AnatomyRoots:
+    """AnatomyRoots instance with a test project entity."""
+    project_entity: ProjectDict = {
+        "name": "Test",
+        "code": "test",
+        "type": "project",
+        "config": {},
+        "taskTypes": {},
+        "attrib": {},
+    }
+    with patch(
+        (
+            "ayon_core.pipeline.anatomy.anatomy.Anatomy."
+            "_get_studio_roots_overrides"
+        ),
+        return_value={},
+    ):
+        return AnatomyRoots(Anatomy(
+            project_name="Test",
+            project_entity=project_entity))
 
 
 def make_root_item(
@@ -62,19 +85,19 @@ def make_root_item(
 
 
 @pytest.fixture
-def linux_root():
+def linux_root() -> AnatomyRoot:
     """AnatomyRoot configured for Linux."""
     return make_root_item(linux="/mnt/projects", platform_override="linux")
 
 
 @pytest.fixture
-def windows_root():
+def windows_root() -> AnatomyRoot:
     """AnatomyRoot configured for Windows."""
     return make_root_item(windows="C:/projects", platform_override="windows")
 
 
 @pytest.fixture
-def darwin_root():
+def darwin_root() -> AnatomyRoot:
     """AnatomyRoot configured for macOS (Darwin)."""
     return make_root_item(
         darwin="/Volumes/projects", platform_override="darwin"
@@ -82,7 +105,7 @@ def darwin_root():
 
 
 @pytest.fixture
-def multi_platform_root():
+def multi_platform_root() -> AnatomyRoot:
     """AnatomyRoot with all platforms set, current platform Linux."""
     return make_root_item(
         windows="C:/projects",
@@ -93,7 +116,7 @@ def multi_platform_root():
 
 
 @pytest.fixture
-def cross_platform_root():
+def cross_platform_root() -> AnatomyRoot:
     """AnatomyRoot with Linux and Windows paths, running on Linux."""
     return make_root_item(
         windows="C:/projects",
@@ -107,7 +130,15 @@ def cross_platform_root():
     ("windows", "C:/projects"),
     ("darwin", "/Volumes/projects"),
 ])
-def test_value_uses_current_platform(platform, expected_value):
+def test_value_uses_current_platform(
+        platform: str, expected_value: str) -> None:
+    """Test if item values are using current platform.
+
+    Args:
+        platform (str): Platform to test.
+        expected_value (str): Expected value for the platform.
+
+    """
     item = make_root_item(
         windows="C:/projects",
         linux="/mnt/projects",
@@ -127,41 +158,43 @@ def test_value_uses_current_platform(platform, expected_value):
         "C:/projects/work",
     ),
 ])
-def test_clean_value(make_kwargs, expected_clean):
+def test_clean_value(make_kwargs: dict[str, str], expected_clean: str) -> None:
     item = make_root_item(**make_kwargs)
     assert item.clean_value == expected_clean
 
 
-def test_full_key_with_name():
+def test_full_key_with_name() -> None:
     item = make_root_item(name="publish", platform_override="linux")
     assert item.full_key == "root[publish]"
 
 
-def test_value_expands_env_var():
+def test_value_expands_env_var(anatomy_roots: AnatomyRoots) -> None:
     with patch.dict(os.environ, {"MY_ROOT": "/env/root"}, clear=False):
         with patch("platform.system", return_value="linux"):
             item = AnatomyRoot(
-                parent=None,
+                parent=anatomy_roots,
                 root_raw_data={"linux": "$MY_ROOT/projects"},
                 name="work",
             )
     assert item.value == "/env/root/projects"
 
 
-def test_value_expands_user_home():
+def test_value_expands_user_home(anatomy_roots: AnatomyRoots) -> None:
     fake_home = "/home/testuser"
     expand = lambda p: p.replace("~", fake_home)  # noqa: E731
     with patch("os.path.expanduser", side_effect=expand):
         with patch("platform.system", return_value="linux"):
             item = AnatomyRoot(
-                parent=None,
+                parent=anatomy_roots,
                 root_raw_data={"linux": "~/projects"},
                 name="work",
             )
     assert item.value == "/home/testuser/projects"
 
 
-def test_available_platforms_populated(multi_platform_root):
+def test_available_platforms_populated(
+        multi_platform_root: AnatomyRoot) -> None:
+    """Test if plaform are populated correctly."""
     expected = {"windows", "linux", "darwin"}
     assert expected == multi_platform_root.available_platforms
 
@@ -199,14 +232,19 @@ def test_available_platforms_populated(multi_platform_root):
         "{root[work]}",
     ),
 ])
-def test_find_root_template_matches(make_kwargs, input_path, expected_result):
+def test_find_root_template_matches(
+        make_kwargs: dict[str, str],
+        input_path: str,
+        expected_result: str) -> None:
+    """Find root template that matched input path."""
     item = make_root_item(**make_kwargs)
     success, result = item.find_root_template_from_path(input_path)
     assert success is True
     assert result == expected_result
 
 
-def test_find_root_template_cross_platform(cross_platform_root):
+def test_find_root_template_cross_platform(
+        cross_platform_root: AnatomyRoot) -> None:
     """Windows root entry is tried even when the current platform is Linux."""
     success, result = cross_platform_root.find_root_template_from_path(
         "C:/projects/myproject/file.ma"
@@ -214,20 +252,22 @@ def test_find_root_template_cross_platform(cross_platform_root):
     assert success is True
 
 
-def test_find_root_template_no_match(linux_root):
+def test_find_root_template_no_match(linux_root: AnatomyRoot) -> None:
+    """Test condition when root template doesn't match."""
     path = "/completely/different/path/file.ma"
     success, result = linux_root.find_root_template_from_path(path)
     assert success is False
     assert result == path
 
 
-def test_expanded_path_matches_unexpanded_root_with_envvar():
+def test_expanded_path_matches_unexpanded_root_with_envvar(
+        anatomy_roots: AnatomyRoots) -> None:
     """Root stored as ``$MY_ROOT/projects``, path already expanded."""
     fake_env = {"MY_ROOT": "/mnt"}
     with patch.dict(os.environ, fake_env, clear=False):
         with patch("platform.system", return_value="linux"):
             item = AnatomyRoot(
-                parent=None,
+                parent=anatomy_roots,
                 root_raw_data={
                     "linux": "$MY_ROOT/projects",
                     "windows": "C:/projects",
@@ -241,14 +281,15 @@ def test_expanded_path_matches_unexpanded_root_with_envvar():
     assert result == "{root[work]}/myproject/file.ma"
 
 
-def test_expanded_path_matches_unexpanded_root_with_tilde():
+def test_expanded_path_matches_unexpanded_root_with_tilde(
+        anatomy_roots: AnatomyRoots) -> None:
     """Root stored as ``~/projects``, path already expanded."""
     fake_home = "/home/user"
     expand = lambda p: p.replace("~", fake_home)  # noqa: E731
     with patch("os.path.expanduser", side_effect=expand):
         with patch("platform.system", return_value="linux"):
             item = AnatomyRoot(
-                parent=None,
+                parent=anatomy_roots,
                 root_raw_data={"linux": "~/projects"},
                 name="work",
             )
@@ -260,13 +301,14 @@ def test_expanded_path_matches_unexpanded_root_with_tilde():
     assert result == "{root[work]}/shot/file.ma"
 
 
-def test_unexpanded_path_matches_expanded_root():
+def test_unexpanded_path_matches_expanded_root(
+        anatomy_roots: AnatomyRoots) -> None:
     """Root already expanded, path passed as ``~/projects/...``."""
     fake_home = "/home/user"
     expand = lambda p: p.replace("~", fake_home)  # noqa: E731
     with patch("platform.system", return_value="linux"):
         item = AnatomyRoot(
-            parent=None,
+            parent=anatomy_roots,
             root_raw_data={"linux": "/home/user/projects"},
             name="work",
         )
@@ -278,12 +320,13 @@ def test_unexpanded_path_matches_expanded_root():
     assert result == "{root[work]}/shot/file.ma"
 
 
-def test_unexpanded_envvar_path_matches_expanded_root():
+def test_unexpanded_envvar_path_matches_expanded_root(
+        anatomy_roots: AnatomyRoots) -> None:
     """Root already expanded, path contains ``$MY_ROOT``."""
     fake_env = {"MY_ROOT": "/mnt"}
     with patch("platform.system", return_value="linux"):
         item = AnatomyRoot(
-            parent=None,
+            parent=anatomy_roots,
             root_raw_data={"linux": "/mnt/projects"},
             name="work",
         )
@@ -295,14 +338,14 @@ def test_unexpanded_envvar_path_matches_expanded_root():
     assert result == "{root[work]}/shot/file.ma"
 
 
-def test_both_sides_need_expanding():
+def test_both_sides_need_expanding(anatomy_roots: AnatomyRoots) -> None:
     """Both root and path contain ``~``."""
     fake_home = "/home/user"
     expand = lambda p: p.replace("~", fake_home)  # noqa: E731
     with patch("os.path.expanduser", side_effect=expand):
         with patch("platform.system", return_value="linux"):
             item = AnatomyRoot(
-                parent=None,
+                parent=anatomy_roots,
                 root_raw_data={"linux": "~/projects"},
                 name="work",
             )
@@ -314,12 +357,13 @@ def test_both_sides_need_expanding():
     assert success is True
 
 
-def test_no_match_with_expansion_returns_false():
+def test_no_match_with_expansion_returns_false(
+        anatomy_roots: AnatomyRoots) -> None:
     fake_env = {"MY_ROOT": "/mnt"}
     with patch.dict(os.environ, fake_env, clear=False):
         with patch("platform.system", return_value="linux"):
             item = AnatomyRoot(
-                parent=None,
+                parent=anatomy_roots,
                 root_raw_data={"linux": "$MY_ROOT/projects"},
                 name="work",
             )
@@ -349,8 +393,12 @@ def test_no_match_with_expansion_returns_false():
     ),
 ])
 def test_path_remapper_success(
-    cross_platform_root, input_path, dst_platform, src_platform, expected
-):
+        cross_platform_root: AnatomyRoot,
+        input_path: str,
+        dst_platform: str,
+        src_platform: str | None,
+        expected: str
+) -> None:
     kwargs = {"dst_platform": dst_platform}
     if src_platform is not None:
         kwargs["src_platform"] = src_platform
@@ -368,6 +416,9 @@ def test_path_remapper_success(
         {},                          # no matching root
     ),
 ])
-def test_path_remapper_returns_none(linux_root, input_path, remap_kwargs):
+def test_path_remapper_returns_none(
+        linux_root: AnatomyRoot,
+        input_path: str,
+        remap_kwargs: Any) -> None:
     result = linux_root.path_remapper(input_path, **remap_kwargs)
     assert result is None

--- a/tests/client/ayon_core/pipeline/anatomy/test_root_item.py
+++ b/tests/client/ayon_core/pipeline/anatomy/test_root_item.py
@@ -5,9 +5,10 @@ so they can run without any network connection or AYON credentials.
 """
 from __future__ import annotations
 
+from contextlib import ExitStack, contextmanager
 import os
 import pytest
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 from unittest.mock import patch
 
 from ayon_core.pipeline.anatomy import Anatomy
@@ -15,6 +16,12 @@ from ayon_core.pipeline.anatomy.roots import AnatomyRoot, AnatomyRoots
 
 if TYPE_CHECKING:
     from ayon_api.typing import ProjectDict
+
+
+@contextmanager
+def multi_patch(*patches: list[Callable]):
+    with ExitStack() as stack:
+        yield [stack.enter_context(_patch) for _patch in patches]
 
 
 @pytest.fixture
@@ -28,13 +35,24 @@ def anatomy_roots() -> AnatomyRoots:
         "taskTypes": {},
         "attrib": {},
     }
-    with patch(
-        (
-            "ayon_core.pipeline.anatomy.anatomy.Anatomy."
-            "_get_studio_roots_overrides"
+    patches = [
+        patch(
+            (
+                "ayon_core.pipeline.anatomy.anatomy.Anatomy."
+                "_get_studio_roots_overrides"
+            ),
+            return_value={},
         ),
-        return_value={},
-    ):
+        patch(
+            (
+                "ayon_core.pipeline.anatomy.anatomy.Anatomy."
+                "_get_site_root_overrides"
+            ),
+            return_value={},
+        )
+    ]
+
+    with multi_patch(*patches) as _mp:
         return AnatomyRoots(Anatomy(
             project_name="Test",
             project_entity=project_entity))
@@ -70,18 +88,34 @@ def make_root_item(
         "taskTypes": {},
         "attrib": {},
     }
+    target_platform = platform_override or "linux"
 
-    with patch((
-            "ayon_core.pipeline.anatomy.anatomy.Anatomy."
-            "_get_studio_roots_overrides"), return_value={}):
+    patches = [
+        patch(
+            (
+                "ayon_core.pipeline.anatomy.anatomy.Anatomy."
+                "_get_studio_roots_overrides"
+            ),
+            return_value={},
+        ),
+        patch(
+            (
+                "ayon_core.pipeline.anatomy.anatomy.Anatomy."
+                "_get_site_root_overrides"
+            ),
+            return_value={},
+        ),
+        patch("platform.system", return_value=target_platform),
+    ]
+
+    with multi_patch(*patches) as _:
         parent = AnatomyRoots(Anatomy(
             project_name="Test",
             project_entity=project_entity))
         raw_data = {"windows": windows, "linux": linux, "darwin": darwin}
         target_platform = platform_override or "linux"
-        with patch("platform.system", return_value=target_platform):
-            return AnatomyRoot(
-                parent=parent, root_raw_data=raw_data, name=name)
+        return AnatomyRoot(
+            parent=parent, root_raw_data=raw_data, name=name)
 
 
 @pytest.fixture

--- a/tests/client/ayon_core/pipeline/anatomy/test_root_item.py
+++ b/tests/client/ayon_core/pipeline/anatomy/test_root_item.py
@@ -1,0 +1,356 @@
+"""Tests for RootItem and its find_root_template_from_path logic.
+
+These tests are intentionally isolated from the rest of Anatomy / AYON server
+so they can run without any network connection or AYON credentials.
+"""
+from __future__ import annotations
+
+import os
+import pytest
+from unittest.mock import patch
+
+from ayon_core.pipeline.anatomy.roots import RootItem
+
+
+def make_root_item(
+    windows: str = "C:/projects",
+    linux: str = "/mnt/projects",
+    darwin: str = "/Volumes/projects",
+    name: str = "work",
+    platform_override: str | None = None,
+) -> RootItem:
+    """Create a RootItem, optionally forcing the *current* platform.
+
+    Helper function for testing.
+
+    Args:
+        windows (str, optional): Windows path. Defaults to "C:/projects".
+        linux (str, optional): Linux path. Defaults to "/mnt/projects".
+        darwin (str, optional): macOS path. Defaults to "/Volumes/projects".
+        name (str, optional): Name of the root item. Defaults to "work".
+        platform_override (str, optional): Platform override. Defaults to None.
+
+    Returns:
+        RootItem: Root Item.
+
+    """
+    raw_data = {"windows": windows, "linux": linux, "darwin": darwin}
+    target_platform = platform_override or "linux"
+    with patch("platform.system", return_value=target_platform):
+        return RootItem(parent=None, root_raw_data=raw_data, name=name)
+
+
+@pytest.fixture
+def linux_root():
+    """RootItem configured for Linux."""
+    return make_root_item(linux="/mnt/projects", platform_override="linux")
+
+
+@pytest.fixture
+def windows_root():
+    """RootItem configured for Windows."""
+    return make_root_item(windows="C:/projects", platform_override="windows")
+
+
+@pytest.fixture
+def darwin_root():
+    """RootItem configured for macOS (Darwin)."""
+    return make_root_item(
+        darwin="/Volumes/projects", platform_override="darwin"
+    )
+
+
+@pytest.fixture
+def multi_platform_root():
+    """RootItem with all platforms set, current platform Linux."""
+    return make_root_item(
+        windows="C:/projects",
+        linux="/mnt/projects",
+        darwin="/Volumes/projects",
+        platform_override="linux",
+    )
+
+
+@pytest.fixture
+def cross_platform_root():
+    """RootItem with Linux and Windows paths, running on Linux."""
+    return make_root_item(
+        windows="C:/projects",
+        linux="/mnt/projects",
+        platform_override="linux",
+    )
+
+
+@pytest.mark.parametrize("platform,expected_value", [
+    ("linux", "/mnt/projects"),
+    ("windows", "C:/projects"),
+    ("darwin", "/Volumes/projects"),
+])
+def test_value_uses_current_platform(platform, expected_value):
+    item = make_root_item(
+        windows="C:/projects",
+        linux="/mnt/projects",
+        darwin="/Volumes/projects",
+        platform_override=platform,
+    )
+    assert item.value == expected_value
+
+
+@pytest.mark.parametrize("make_kwargs,expected_clean", [
+    (
+        {"linux": "/mnt/projects/", "platform_override": "linux"},
+        "/mnt/projects",
+    ),
+    (
+        {"windows": "C:\\projects\\work", "platform_override": "windows"},
+        "C:/projects/work",
+    ),
+])
+def test_clean_value(make_kwargs, expected_clean):
+    item = make_root_item(**make_kwargs)
+    assert item.clean_value == expected_clean
+
+
+def test_full_key_with_name():
+    item = make_root_item(name="publish", platform_override="linux")
+    assert item.full_key == "root[publish]"
+
+
+def test_value_expands_env_var():
+    with patch.dict(os.environ, {"MY_ROOT": "/env/root"}, clear=False):
+        with patch("platform.system", return_value="linux"):
+            item = RootItem(
+                parent=None,
+                root_raw_data={"linux": "$MY_ROOT/projects"},
+                name="work",
+            )
+    assert item.value == "/env/root/projects"
+
+
+def test_value_expands_user_home():
+    fake_home = "/home/testuser"
+    expand = lambda p: p.replace("~", fake_home)  # noqa: E731
+    with patch("os.path.expanduser", side_effect=expand):
+        with patch("platform.system", return_value="linux"):
+            item = RootItem(
+                parent=None,
+                root_raw_data={"linux": "~/projects"},
+                name="work",
+            )
+    assert item.value == "/home/testuser/projects"
+
+
+def test_available_platforms_populated(multi_platform_root):
+    expected = {"windows", "linux", "darwin"}
+    assert expected == multi_platform_root.available_platforms
+
+
+@pytest.mark.parametrize("make_kwargs,input_path,expected_result", [
+    (
+        {"linux": "/mnt/projects", "platform_override": "linux"},
+        "/mnt/projects/myproject/file.ma",
+        "{root[work]}/myproject/file.ma",
+    ),
+    (
+        {"windows": "C:/Projects", "platform_override": "windows"},
+        "C:/PROJECTS/myproject/file.ma",   # case-insensitive
+        "{root[work]}/myproject/file.ma",
+    ),
+    (
+        {"darwin": "/Volumes/projects", "platform_override": "darwin"},
+        "/Volumes/projects/myproject/file.ma",
+        "{root[work]}/myproject/file.ma",
+    ),
+    (
+        {"windows": "C:/projects", "platform_override": "windows"},
+        "C:\\projects\\myproject\\file.ma",  # backslashes normalised
+        "{root[work]}/myproject/file.ma",
+    ),
+    (
+        # trailing slash on stored root
+        {"linux": "/mnt/projects/", "platform_override": "linux"},
+        "/mnt/projects/myproject/file.ma",
+        "{root[work]}/myproject/file.ma",
+    ),
+    (
+        {"linux": "/mnt/projects", "platform_override": "linux"},
+        "/mnt/projects",                   # path == root, no subpath
+        "{root[work]}",
+    ),
+])
+def test_find_root_template_matches(make_kwargs, input_path, expected_result):
+    item = make_root_item(**make_kwargs)
+    success, result = item.find_root_template_from_path(input_path)
+    assert success is True
+    assert result == expected_result
+
+
+def test_find_root_template_cross_platform(cross_platform_root):
+    """Windows root entry is tried even when the current platform is Linux."""
+    success, result = cross_platform_root.find_root_template_from_path(
+        "C:/projects/myproject/file.ma"
+    )
+    assert success is True
+
+
+def test_find_root_template_no_match(linux_root):
+    path = "/completely/different/path/file.ma"
+    success, result = linux_root.find_root_template_from_path(path)
+    assert success is False
+    assert result == path
+
+
+def test_expanded_path_matches_unexpanded_root_with_envvar():
+    """Root stored as ``$MY_ROOT/projects``, path already expanded."""
+    fake_env = {"MY_ROOT": "/mnt"}
+    with patch.dict(os.environ, fake_env, clear=False):
+        with patch("platform.system", return_value="linux"):
+            item = RootItem(
+                parent=None,
+                root_raw_data={
+                    "linux": "$MY_ROOT/projects",
+                    "windows": "C:/projects",
+                },
+                name="work",
+            )
+        success, result = item.find_root_template_from_path(
+            "/mnt/projects/myproject/file.ma"
+        )
+    assert success is True
+    assert result == "{root[work]}/myproject/file.ma"
+
+
+def test_expanded_path_matches_unexpanded_root_with_tilde():
+    """Root stored as ``~/projects``, path already expanded."""
+    fake_home = "/home/user"
+    expand = lambda p: p.replace("~", fake_home)  # noqa: E731
+    with patch("os.path.expanduser", side_effect=expand):
+        with patch("platform.system", return_value="linux"):
+            item = RootItem(
+                parent=None,
+                root_raw_data={"linux": "~/projects"},
+                name="work",
+            )
+    with patch("os.path.expanduser", side_effect=expand):
+        success, result = item.find_root_template_from_path(
+            "/home/user/projects/shot/file.ma"
+        )
+    assert success is True
+    assert result == "{root[work]}/shot/file.ma"
+
+
+def test_unexpanded_path_matches_expanded_root():
+    """Root already expanded, path passed as ``~/projects/...``."""
+    fake_home = "/home/user"
+    expand = lambda p: p.replace("~", fake_home)  # noqa: E731
+    with patch("platform.system", return_value="linux"):
+        item = RootItem(
+            parent=None,
+            root_raw_data={"linux": "/home/user/projects"},
+            name="work",
+        )
+    with patch("os.path.expanduser", side_effect=expand):
+        success, result = item.find_root_template_from_path(
+            "~/projects/shot/file.ma"
+        )
+    assert success is True
+    assert result == "{root[work]}/shot/file.ma"
+
+
+def test_unexpanded_envvar_path_matches_expanded_root():
+    """Root already expanded, path contains ``$MY_ROOT``."""
+    fake_env = {"MY_ROOT": "/mnt"}
+    with patch("platform.system", return_value="linux"):
+        item = RootItem(
+            parent=None,
+            root_raw_data={"linux": "/mnt/projects"},
+            name="work",
+        )
+    with patch.dict(os.environ, fake_env, clear=False):
+        success, result = item.find_root_template_from_path(
+            "$MY_ROOT/projects/shot/file.ma"
+        )
+    assert success is True
+    assert result == "{root[work]}/shot/file.ma"
+
+
+def test_both_sides_need_expanding():
+    """Both root and path contain ``~``."""
+    fake_home = "/home/user"
+    expand = lambda p: p.replace("~", fake_home)  # noqa: E731
+    with patch("os.path.expanduser", side_effect=expand):
+        with patch("platform.system", return_value="linux"):
+            item = RootItem(
+                parent=None,
+                root_raw_data={"linux": "~/projects"},
+                name="work",
+            )
+    with patch("os.path.expanduser", side_effect=expand):
+        with patch.dict(os.environ, {"MY_ROOT": "/home/user"}, clear=False):
+            success, result = item.find_root_template_from_path(
+                "~/projects/shot/file.ma"
+            )
+    assert success is True
+
+
+def test_no_match_with_expansion_returns_false():
+    fake_env = {"MY_ROOT": "/mnt"}
+    with patch.dict(os.environ, fake_env, clear=False):
+        with patch("platform.system", return_value="linux"):
+            item = RootItem(
+                parent=None,
+                root_raw_data={"linux": "$MY_ROOT/projects"},
+                name="work",
+            )
+    path = "/completely/different/path/file.ma"
+    with patch.dict(os.environ, fake_env, clear=False):
+        success, result = item.find_root_template_from_path(path)
+    assert success is False
+    assert result == path
+
+
+# ---------------------------------------------------------------------------
+# RootItem.path_remapper
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("input_path,dst_platform,src_platform,expected", [
+    (
+        "/mnt/projects/myproject/file.ma", "windows", None,
+        "C:/projects/myproject/file.ma",
+    ),
+    (
+        "C:/projects/myproject/file.ma", "linux", "windows",
+        "/mnt/projects/myproject/file.ma",
+    ),
+    (
+        "/mnt/projects/myproject/file.ma", "linux", None,
+        "/mnt/projects/myproject/file.ma",
+    ),
+])
+def test_path_remapper_success(
+    cross_platform_root, input_path, dst_platform, src_platform, expected
+):
+    kwargs = {"dst_platform": dst_platform}
+    if src_platform is not None:
+        kwargs["src_platform"] = src_platform
+    result = cross_platform_root.path_remapper(input_path, **kwargs)
+    assert result == expected
+
+
+@pytest.mark.parametrize("input_path,remap_kwargs", [
+    (
+        "/mnt/projects/file.ma",
+        {"dst_platform": "foo"},   # unknown platform
+    ),
+    (
+        "/completely/different/path/file.ma",
+        {},                          # no matching root
+    ),
+])
+def test_path_remapper_returns_none(linux_root, input_path, remap_kwargs):
+    result = linux_root.path_remapper(input_path, **remap_kwargs)
+    assert result is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/client/ayon_core/pipeline/anatomy/test_root_item.py
+++ b/tests/client/ayon_core/pipeline/anatomy/test_root_item.py
@@ -7,9 +7,14 @@ from __future__ import annotations
 
 import os
 import pytest
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-from ayon_core.pipeline.anatomy.roots import AnatomyRoot
+from ayon_core.pipeline.anatomy import Anatomy
+from ayon_core.pipeline.anatomy.roots import AnatomyRoot, AnatomyRoots
+
+if TYPE_CHECKING:
+    from ayon_api.typing import ProjectDict
 
 
 def make_root_item(
@@ -34,10 +39,26 @@ def make_root_item(
         AnatomyRoot: Root Item.
 
     """
-    raw_data = {"windows": windows, "linux": linux, "darwin": darwin}
-    target_platform = platform_override or "linux"
-    with patch("platform.system", return_value=target_platform):
-        return AnatomyRoot(parent=None, root_raw_data=raw_data, name=name)
+    project_entity: ProjectDict = {
+        "name": "Test",
+        "code": "test",
+        "type": "project",
+        "config": {},
+        "taskTypes": {},
+        "attrib": {},
+    }
+
+    with patch((
+            "ayon_core.pipeline.anatomy.anatomy.Anatomy."
+            "_get_studio_roots_overrides"), return_value={}):
+        parent = AnatomyRoots(Anatomy(
+            project_name="Test",
+            project_entity=project_entity))
+        raw_data = {"windows": windows, "linux": linux, "darwin": darwin}
+        target_platform = platform_override or "linux"
+        with patch("platform.system", return_value=target_platform):
+            return AnatomyRoot(
+                parent=parent, root_raw_data=raw_data, name=name)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Changelog Description
Expand variables and user `~` in root paths.

Roots like `~/foo` or `$HOME/foo` or `{HOME}/foo` should all resolve correctly. Note that this feature needs to be used with care as dynamic roots can break a lot of things if not used properly.

## Additional info
This is alternative to #1882

## Testing notes:
1) Publishing to roots with `~` should work as expected
2) Loading should work too
