### PR TITLE
bugfix: extract_color_transcode - validate for farm process

### DIFF
--- a/client/ayon_core/plugins/publish/extract_color_transcode.py
+++ b/client/ayon_core/plugins/publish/extract_color_transcode.py
@@ -70,6 +70,10 @@ class ExtractOIIOTranscode(publish.Extractor):
     options = None
 
     def process(self, instance):
+        if instance.data.get("farm"):
+            self.log.debug("Should be processed on farm, skipping.")
+            return
+
         if not self.profiles:
             self.log.debug("No profiles present for color transcode")
             return


### PR DESCRIPTION
## Changelog Description
This PR solves the issue that the plugin is not being validated for farm processing.

## Additional info
Linked issue [here](https://github.com/ynput/ayon-core/issues/1886)
Linked discussion [here](https://community.ynput.io/t/possible-missing-farm-check-in-extractcolorspacetranscode/3214/5)

Fix https://github.com/ynput/ayon-core/issues/1886

## Testing notes:
1. Publish a nuke write instance with render target set to "use existing frames - farm"
2. The extract_color_transcode plugin should not be processed.
