### PR TITLE
Template hook: Keep template extension for workfile templates

### DIFF
--- a/client/ayon_core/hooks/pre_copy_template_workfile.py
+++ b/client/ayon_core/hooks/pre_copy_template_workfile.py
@@ -115,6 +115,11 @@ class CopyTemplateWorkfile(PreLaunchHook):
             f"Creating workfile from template: \"{template_path}\""
         )
 
+        # Keep extension of template file
+        _, ext = os.path.splitext(template_path)
+        last_workfile_extless, _ = os.path.splitext(last_workfile)
+        last_workfile = f"{last_workfile_extless}{ext}"
+
         # Copy template workfile to new destination
         shutil.copy2(
             os.path.normpath(template_path),
@@ -152,7 +157,6 @@ class CopyTemplateWorkfile(PreLaunchHook):
             host_name,
             settings=project_settings,
         )
-        ext = os.path.splitext(last_workfile)[1]
         _, version = get_last_workfile_with_version_from_paths(
             [last_workfile],
             file_template,


### PR DESCRIPTION
## Changelog Description
Keep extension of template filepath.

## Additional info
When a template file is using different extension from the first one, the addon it returning, launch hook that is copying the file did not respect that. So if `.mb` file was used as base it was copied as `.ma`. The same applies to `.psb` vs. `.psb` [here](https://github.com/ynput/ayon-photoshop/pull/94).

## Testing notes:
1. Extension from template is untouched when workfile template is used.
