### PR TITLE
Products filtering: Use product base type filtering

### DIFF
--- a/client/ayon_core/host/interfaces/workfiles.py
+++ b/client/ayon_core/host/interfaces/workfiles.py
@@ -186,10 +186,15 @@ class ListPublishedWorkfilesOptionalData(_WorkfileOptionalData):
     ]:
         product_entities = self.product_entities
         if product_entities is None:
+            # TODO remove when server >= 1.14.0 is required
+            filter_key = "product_base_types"
+            if ayon_api.get_server_version_tuple() < (1, 14, 0):
+                filter_key = "product_types"
+            filter_kwargs = {filter_key: {"workfile"}}
             product_entities = list(ayon_api.get_products(
                 project_name,
                 folder_ids={folder_id},
-                product_types={"workfile"},
+                **filter_kwargs,
                 fields={"id", "name"},
             ))
 

--- a/client/ayon_core/tools/workfiles/models/workfiles.py
+++ b/client/ayon_core/tools/workfiles/models/workfiles.py
@@ -567,11 +567,16 @@ class WorkfilesModel:
         if not cache.is_valid:
             project_name = self._project_name
             anatomy = self._controller.project_anatomy
-
+            # TODO remove when server >= 1.14.0 is required
+            # Backwards compatibility for product base types
+            filter_key = "product_base_types"
+            if ayon_api.get_server_version_tuple() < (1, 14, 0):
+                filter_key = "product_types"
+            filter_kwargs = {filter_key: {"workfile"}}
             product_entities = list(ayon_api.get_products(
                 project_name,
                 folder_ids={folder_id},
-                product_types={"workfile"},
+                **filter_kwargs,
                 fields={"id", "name"}
             ))
 


### PR DESCRIPTION
## Changelog Description
Use `product_base_type` over `product_type` filtering if server does support it.

## Additional info
Added fitlering kwargs for the cases with todo mentioning to remove it when server 1.14.0 or newer is required by ayon-core.

Similar changes were already added in template builde https://github.com/ynput/ayon-core/pull/1872 .

## Testing notes:
1. Validate code changes.
