### PR TITLE
fix(ExtractReview): don't change staging dir when file names contain subfolders

### DIFF
--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -1279,9 +1279,6 @@ class ExtractReview(pyblish.api.InstancePlugin):
             self.log.debug("Creating dir: {}".format(dst_staging_dir))
             os.makedirs(dst_staging_dir)
 
-        # Store stagingDir to representation
-        new_repre["stagingDir"] = dst_staging_dir
-
         # Store paths to temp data
         temp_data.full_input_path = full_input_path
         temp_data.full_input_path_single_file = full_input_path_single_file


### PR DESCRIPTION
## Changelog Description
don't change the `staging_dir` when creating a review, in cases where the filenames contain subfolders

## Additional info

here is a log, printing `new_repre` before and after calling `input_output_paths`
```log
DEBUG: [PREPARE_TEMP_DATA 1] new_repre={'name': 'png', 'ext': 'png', 'files': 'ayon_ayon_imageMain/ayon_ayon_0001.png', 'stagingDir': '/tmp/ay_tmp_da40q560', 'tags': ['review', 'burnin', 'ftrackreview', 'kitsureview', 'webreview']}
...
DEBUG: [PREPARE_TEMP_DATA 2] new_repre={'name': 'png', 'ext': 'mp4', 'files': 'ayon_ayon_imageMain/ayon_ayon_0001_h264.mp4', 'stagingDir': '/tmp/ay_tmp_da40q560/ayon_ayon_imageMain', 'tags': ['review', 'burnin', 'ftrackreview', 'kitsureview', 'webreview']}
```

As you can see the `stagingDir` changes from `/tmp/ay_tmp_da40q560` to `mp/ay_tmp_da40q560/ayon_ayon_imageMain'` while the files keep the `ayon_ayon_imageMain/` prefix.

This causes issues later down the line. for example in `ExtractBurnin`

(note the double `.../ayon_ayon_imageMain/ayon_ayon_imageMain/...`)
```
DEBUG: script_data: {
    "input": "/tmp/ay_tmp_da40q560/ayon_ayon_imageMain/ayon_ayon_imageMain/ayon_ayon_0001_h264.mp4",
    "output": "/tmp/ay_tmp_da40q560/ayon_ayon_imageMain/ayon_ayon_imageMain/ayon_ayon_0001_h264burnin.mp4",
    "burnin_data": {
         ....
...

RuntimeError: Failed to run: ['/usr/bin/ffprobe', '-v', 'quiet', '-print_format', 'json', '-show_format', '-show_streams', '/tmp/ay_tmp_da40q560/ayon_ayon_imageMain/ayon_ayon_imageMain/ayon_ayon_0001_h264.mp4']
```

### Note:

if having subfolders in the `files` should be allowed may be another question for another PR
Either way, i think, it should not be `ExtractReviews` responsibility to validate/correct or modify the path.

### Note 2:

given that the `dst_staging_dir` is originally read from `new_repre["stagingDir"]` I think its safe to assume that it will be set, even after applying this PR

<img width="541" height="291" alt="image" src="https://github.com/user-attachments/assets/492a236b-1ce1-4812-9b6f-6532c96f8c4e" />


## Testing notes:
1. create a representation with subfolders in the `files` (`ayon-comfyui` [appears to be doing it](https://github.com/ynput/ayon-comfyui/blob/develop/client/ayon_comfyui/plugins/publish/collect_image.py#L45-L47))
2. publish
