### PR TITLE
add library type to ContainersFilterResult

### DIFF
--- a/client/ayon_core/pipeline/load/utils.py
+++ b/client/ayon_core/pipeline/load/utils.py
@@ -1111,20 +1111,20 @@ def _is_valid_representation_id(repre_id: Any) -> bool:
     return True
 
 
-def get_library_projects() -> Generator[ProjectDict, None, None]:
+def _get_library_projects() -> Generator[ProjectDict, None, None]:
     """Get library projects."""
     return ayon_api.get_projects(library=True, fields={"id", "name"})
 
 
 @functools.cache
-def get_library_project_names() -> list[str]:
+def _get_library_project_names() -> list[str]:
     """Get library project names."""
-    return [project["name"] for project in get_library_projects()]
+    return [project["name"] for project in _get_library_projects()]
 
 
-def is_library_project(project_name: str) -> bool:
+def _is_library_project(project_name: str) -> bool:
     """Check if project is library project."""
-    return project_name in get_library_project_names()
+    return project_name in _get_library_project_names()
 
 
 def filter_containers(containers, project_name):
@@ -1234,7 +1234,7 @@ def filter_containers(containers, project_name):
     for container in containers:
 
         project_name = container.get("project_name")
-        if project_name and is_library_project(project_name):
+        if project_name and _is_library_project(project_name):
             library_containers.append(container)
             continue
 

--- a/client/ayon_core/pipeline/load/utils.py
+++ b/client/ayon_core/pipeline/load/utils.py
@@ -1111,12 +1111,12 @@ def _is_valid_representation_id(repre_id: Any) -> bool:
     return True
 
 
-@functools.cache
 def get_library_projects() -> Generator[ProjectDict, None, None]:
     """Get library projects."""
     return ayon_api.get_projects(library=True, fields={"id", "name"})
 
 
+@functools.cache
 def get_library_project_names() -> list[str]:
     """Get library project names."""
     return [project["name"] for project in get_library_projects()]

--- a/client/ayon_core/pipeline/load/utils.py
+++ b/client/ayon_core/pipeline/load/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import os
 import uuid
 import warnings
@@ -9,7 +10,7 @@ import collections
 import numbers
 import copy
 from functools import wraps
-from typing import Optional, Union, Any, overload
+from typing import Optional, Union, Any, overload, TYPE_CHECKING
 
 import ayon_api
 
@@ -21,11 +22,18 @@ from ayon_core.lib import (
 from ayon_core.lib.path_templates import TemplateResult
 from ayon_core.pipeline import Anatomy
 
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from ayon_api.typing import ProjectDict
+
+
 log = logging.getLogger(__name__)
 
 ContainersFilterResult = collections.namedtuple(
     "ContainersFilterResult",
-    ["latest", "outdated", "not_found", "invalid"]
+    ["latest", "outdated", "not_found", "invalid", "library"]
 )
 
 
@@ -1103,25 +1111,43 @@ def _is_valid_representation_id(repre_id: Any) -> bool:
     return True
 
 
-def filter_containers(containers, project_name):
-    """Filter containers and split them into 4 categories.
+@functools.cache
+def get_library_projects() -> Generator[ProjectDict, None, None]:
+    """Get library projects."""
+    return ayon_api.get_projects(library=True, fields={"id", "name"})
 
-    Categories are 'latest', 'outdated', 'invalid' and 'not_found'.
-    The 'lastest' containers are from last version, 'outdated' are not,
-    'invalid' are invalid containers (invalid content) and 'not_found' has
-    some missing entity in database.
+
+def get_library_project_names() -> list[str]:
+    """Get library project names."""
+    return [project["name"] for project in get_library_projects()]
+
+
+def is_library_project(project_name: str) -> bool:
+    """Check if project is library project."""
+    return project_name in get_library_project_names()
+
+
+def filter_containers(containers, project_name):
+    """Filter containers and split them into 5 categories.
+
+    Categories:
+    - 'latest': containers from latest version.
+    - 'outdated': containers from outdated versions.
+    - 'invalid': containers with invalid content.
+    - 'not_found': containers with missing entity in database.
+    - 'library': containers from library projects.
 
     Todos:
         Respect 'project_name' on containers if is available.
 
     Args:
         containers (Iterable[dict]): List of containers referenced into scene.
-        project_name (str): Name of project in which context shoud look for
+        project_name (str): Name of project in which context should look for
             versions.
 
     Returns:
         ContainersFilterResult: Named tuple with 'latest', 'outdated',
-            'invalid' and 'not_found' containers.
+            'invalid', 'not_found' and 'library' containers.
 
     """
     # Make sure containers is list that won't change
@@ -1131,11 +1157,13 @@ def filter_containers(containers, project_name):
     uptodate_containers = []
     not_found_containers = []
     invalid_containers = []
+    library_containers = []
     output = ContainersFilterResult(
         uptodate_containers,
         outdated_containers,
         not_found_containers,
-        invalid_containers
+        invalid_containers,
+        library_containers,
     )
     # Query representation docs to get it's version ids
     repre_ids = {
@@ -1204,6 +1232,12 @@ def filter_containers(containers, project_name):
     # Based on all collected data figure out which containers are outdated
     #   - log out if there are missing representation or version documents
     for container in containers:
+
+        project_name = container.get("project_name")
+        if project_name and is_library_project(project_name):
+            library_containers.append(container)
+            continue
+
         container_name = container["objectName"]
         repre_id = container["representation"]
         if not _is_valid_representation_id(repre_id):


### PR DESCRIPTION
## Changelog Description
add `library` as another possible category in `ContainersFilterResult`

## Additional info
`filter_containers` only knows about products from the given project_name.
this causes products imported from a library to be flagged as `not_found`.

Some hosts use the category to mark the loader nodes different. For example `nuke` uses them to apply different colors in the node graph. This PR would allow us to apply a different color to nodes reading from the library, rather than them being colored as `not_found` 


## Testing notes:
1. load a bunch of different products (a latest version, a non latest and one product from a library)
2. run this script (or similar):
```py
from ayon_core.pipeline import registered_host, get_current_project_name
from ayon_core.pipeline.load import filter_containers
from ayon_core.pipeline.load import utils

host = registered_host()
project_name = get_current_project_name()
containers = host.get_containers()

filtered_containers = filter_containers(containers, project_name)
for category, containers in filtered_containers._asdict().items():
    print(category)
    for container in containers:
        print("\t{project_name}, {name}, {version}".format(**container))
```

## Open Questions:

> should we distinguish between `library_latest` and `library_outdated`?

for the sake of simplicity I decided not to

> should we distinguish between `library` and `from_other_project` (products from another project where the source project is not a library)? 

I think the `not_found` category covers this well enough for now. I can't think of a use case where users would pull in assets from another project that is not a library

