### PR TITLE
Chore: Use 'PublishError' over 'KnownPublishError'

### DIFF
--- a/client/ayon_core/pipeline/farm/pyblish_functions.py
+++ b/client/ayon_core/pipeline/farm/pyblish_functions.py
@@ -22,7 +22,7 @@ from ayon_core.pipeline import (
 )
 from ayon_core.pipeline.create import get_product_name
 from ayon_core.pipeline.farm.patterning import match_aov_pattern
-from ayon_core.pipeline.publish import KnownPublishError
+from ayon_core.pipeline.publish import PublishError
 from ayon_core.pipeline.publish.input_versions import serialize_input_versions
 
 if typing.TYPE_CHECKING:
@@ -685,9 +685,10 @@ def create_instances_for_aov(
         len(instance.data.get("attachTo", [])) > 0
         and len(instance.data.get("expectedFiles")[0].keys()) != 1
     ):
-        raise KnownPublishError(
-            "attaching multiple AOVs or renderable cameras to "
-            "product is not supported yet.")
+        raise PublishError(
+            "Attaching multiple AOVs or renderable cameras to"
+            " product is not supported yet."
+        )
 
     additional_data = {
         "renderProducts": instance.data["renderProducts"],

--- a/client/ayon_core/plugins/publish/collect_context_entities.py
+++ b/client/ayon_core/plugins/publish/collect_context_entities.py
@@ -16,7 +16,7 @@ Provides:
 import pyblish.api
 import ayon_api
 
-from ayon_core.pipeline import KnownPublishError, Anatomy
+from ayon_core.pipeline import PublishError, Anatomy
 
 
 class CollectContextEntities(pyblish.api.ContextPlugin):
@@ -37,9 +37,7 @@ class CollectContextEntities(pyblish.api.ContextPlugin):
         if not project_entity:
             project_entity = ayon_api.get_project(project_name)
             if not project_entity:
-                raise KnownPublishError(
-                    f"Project '{project_name}' was not found."
-                )
+                raise PublishError(f"Project '{project_name}' was not found.")
 
         context.data["projectEntity"] = project_entity
         context.data["anatomy"] = Anatomy(
@@ -109,7 +107,7 @@ class CollectContextEntities(pyblish.api.ContextPlugin):
             return None
         folder_entity = ayon_api.get_folder_by_path(project_name, folder_path)
         if not folder_entity:
-            raise KnownPublishError(
+            raise PublishError(
                 f"Folder '{folder_path}' was not found"
                 f" in project '{project_name}'."
             )
@@ -123,7 +121,7 @@ class CollectContextEntities(pyblish.api.ContextPlugin):
         )
         if not task_entity:
             task_path = "/".join([folder_entity["path"], task_name])
-            raise KnownPublishError(
+            raise PublishError(
                 f"Task '{task_path}' was not found"
                 f" in project '{project_name}'."
             )

--- a/client/ayon_core/plugins/publish/collect_scene_version.py
+++ b/client/ayon_core/plugins/publish/collect_scene_version.py
@@ -2,7 +2,7 @@ import os
 import pyblish.api
 
 from ayon_core.lib import get_version_from_path, is_in_tests
-from ayon_core.pipeline import KnownPublishError
+from ayon_core.pipeline import PublishError
 
 
 class CollectSceneVersion(pyblish.api.ContextPlugin):
@@ -47,8 +47,9 @@ class CollectSceneVersion(pyblish.api.ContextPlugin):
 
         version = get_version_from_path(filename)
         if version is None:
-            raise KnownPublishError("Unable to retrieve version number from "
-                                    "filename: {}".format(filename))
+            raise PublishError(
+                f"Unable to retrieve version number from filename: {filename}"
+            )
 
         context.data['version'] = int(version)
         self.log.debug(

--- a/client/ayon_core/plugins/publish/extract_otio_review.py
+++ b/client/ayon_core/plugins/publish/extract_otio_review.py
@@ -24,7 +24,7 @@ from ayon_core.lib import (
     run_subprocess,
 )
 from ayon_core.pipeline import (
-    KnownPublishError,
+    PublishError,
     publish,
 )
 
@@ -533,7 +533,7 @@ class ExtractOTIOReview(
             ])
 
         else:
-            raise KnownPublishError("Sequence, video or gap is required.")
+            raise PublishError("Dev bug: Sequence, video or gap is required.")
 
         if video or sequence:
             command.extend([

--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -31,7 +31,7 @@ from ayon_core.lib.transcoding import (
 )
 from ayon_core.pipeline import get_temp_dir
 from ayon_core.pipeline.publish import (
-    KnownPublishError,
+    PublishError,
     get_publish_instance_label,
 )
 from ayon_core.pipeline.publish.lib import (
@@ -489,8 +489,10 @@ class ExtractReview(pyblish.api.InstancePlugin):
                     files,
                 )[0]
                 if len(collections) != 1:
-                    raise KnownPublishError(
-                        "Multiple collections {} found.".format(collections))
+                    raise PublishError(
+                        "Found multiple collections, expected one."
+                        f" {collections}"
+                    )
 
                 collection = collections[0]
 
@@ -1140,9 +1142,9 @@ class ExtractReview(pyblish.api.InstancePlugin):
                 is done.
 
         Raises:
-            KnownPublishError: if more than one collection is obtained.
-        """
+            PublishError: if more than one collection is obtained.
 
+        """
         # Prepare which hole is filled with what frame
         #   - the frame is filled only with already existing frames
         prev_frame = next(iter(collection.indexes))
@@ -1161,8 +1163,9 @@ class ExtractReview(pyblish.api.InstancePlugin):
             hole_fpath = os.path.join(staging_dir, col_format % hole_frame)
             src_fpath = os.path.join(staging_dir, col_format % src_frame)
             if not os.path.isfile(src_fpath):
-                raise KnownPublishError(
-                    "Missing previously detected file: {}".format(src_fpath))
+                raise PublishError(
+                    f"Missing previously detected file: {src_fpath}"
+                )
 
             copyfile(src_fpath, hole_fpath)
             added_files[hole_frame] = hole_fpath

--- a/client/ayon_core/plugins/publish/extract_review_slate.py
+++ b/client/ayon_core/plugins/publish/extract_review_slate.py
@@ -15,7 +15,7 @@ from ayon_core.lib import (
     get_ffmpeg_format_args,
 )
 from ayon_core.pipeline import publish
-from ayon_core.pipeline.publish import KnownPublishError
+from ayon_core.pipeline.publish import PublishError
 
 
 class ExtractReviewSlate(publish.Extractor):
@@ -94,9 +94,9 @@ class ExtractReviewSlate(publish.Extractor):
 
             # Raise exception of any stream didn't define input resolution
             if input_width is None:
-                raise KnownPublishError(
-                    "FFprobe couldn't read resolution from input file: \"{}\""
-                    .format(input_path)
+                raise PublishError(
+                    "FFprobe couldn't read resolution from input file:"
+                    f" \"{input_path}\""
                 )
 
             (

--- a/client/ayon_core/plugins/publish/extract_scanline_exr.py
+++ b/client/ayon_core/plugins/publish/extract_scanline_exr.py
@@ -10,7 +10,7 @@ from ayon_core.lib import (
     get_oiio_tool_args,
     ToolNotFoundError,
 )
-from ayon_core.pipeline import KnownPublishError
+from ayon_core.pipeline import PublishError
 
 
 class ExtractScanlineExr(pyblish.api.InstancePlugin):
@@ -54,7 +54,7 @@ class ExtractScanlineExr(pyblish.api.InstancePlugin):
                 oiio_tool_args = get_oiio_tool_args("oiiotool")
             except ToolNotFoundError:
                 self.log.error("OIIO tool not found.")
-                raise KnownPublishError("OIIO tool not found")
+                raise PublishError("OIIO tool not found")
 
             for file in input_files:
 

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -39,7 +39,7 @@ from ayon_core.pipeline.entity_uri import (
 )
 from ayon_core.pipeline.load.utils import get_representation_path_by_names
 from ayon_core.pipeline.publish.lib import get_instance_expected_output_path
-from ayon_core.pipeline import publish, KnownPublishError
+from ayon_core.pipeline import publish, PublishError
 
 
 # This global toggle is here mostly for debugging purposes and should usually
@@ -711,7 +711,7 @@ class ValidateUSDDependencies(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         if Sdf is None:
-            raise KnownPublishError("USD library 'Sdf' is not available.")
+            raise PublishError("USD library 'Sdf' is not available.")
 
 
 class ExtractUSDLayerContribution(publish.Extractor):

--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -28,7 +28,7 @@ from ayon_core.lib.file_transaction import (
     DuplicateDestinationError
 )
 from ayon_core.pipeline.publish import (
-    KnownPublishError,
+    PublishError,
     get_publish_template_name,
 )
 from ayon_core.pipeline import is_product_base_type_supported
@@ -165,10 +165,10 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         try:
             self.register(instance, file_transactions, filtered_repres)
         except DuplicateDestinationError as exc:
-            # Raise DuplicateDestinationError as KnownPublishError
+            # Raise DuplicateDestinationError as PublishError
             # and rollback the transactions
             file_transactions.rollback()
-            raise KnownPublishError(exc).with_traceback(sys.exc_info()[2])
+            raise PublishError(str(exc)).with_traceback(sys.exc_info()[2])
 
         except Exception as exc:
             # clean destination
@@ -540,9 +540,9 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             is_sequence_representation (bool): Files are for sequence.
 
         Raises:
-            KnownPublishError: If validations don't pass.
-        """
+            PublishError: If validations don't pass.
 
+        """
         if not files:
             return
 
@@ -551,7 +551,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
 
         for fname in files:
             if os.path.isabs(fname):
-                raise KnownPublishError(
+                raise PublishError(
                     f"Representation file names contains full paths: {fname}"
                 )
 
@@ -560,7 +560,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
 
         src_collections, remainders = clique.assemble(files)
         if len(files) < 2 or len(src_collections) != 1 or remainders:
-            raise KnownPublishError((
+            raise PublishError((
                 "Files of representation does not contain proper"
                 " sequence files.\nCollected collections: {}"
                 "\nCollected remainders: {}"
@@ -580,16 +580,17 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
     ):
         # pre-flight validations
         if repre["ext"].startswith("."):
-            raise KnownPublishError((
-                "Extension must not start with a dot '.': {}"
-            ).format(repre["ext"]))
+            raise PublishError(
+                f"Extension must not start with a dot '.': {repre['ext']}"
+            )
 
-        if repre.get("transfers"):
-            raise KnownPublishError((
+        repre_transfers = repre["transfers"]
+        if repre_transfers:
+            raise PublishError(
                 "Representation is not allowed to have transfers"
                 "data before integration. They are computed in "
-                "the integrator. Got: {}"
-            ).format(repre["transfers"]))
+                f"the integrator. Got: {repre_transfers}"
+            )
 
         # create template data for Anatomy
         template_data = copy.deepcopy(instance.data["anatomyData"])
@@ -621,8 +622,8 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             stagingdir = instance_stagingdir
 
         if not stagingdir:
-            raise KnownPublishError(
-                "No staging directory set for representation: {}".format(repre)
+            raise PublishError(
+                f"No staging directory set for representation: {repre}."
             )
 
         # optionals
@@ -660,10 +661,10 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 instance.data.get("originalDirname") or stagingdir)
             _rootless = self.get_rootless_path(anatomy, original_directory)
             if _rootless == original_directory:
-                raise KnownPublishError((
-                        "Destination path '{}' ".format(original_directory) +
-                        "must be in project dir"
-                ))
+                raise PublishError(
+                    f"Destination path '{original_directory}'"
+                    f" must be in project directory."
+                )
             relative_path_start = _rootless.rfind('}') + 2
             without_root = _rootless[relative_path_start:]
             template_data["originalDirname"] = without_root
@@ -792,10 +793,10 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             dst_collection = clique.assemble(dst_filepaths)[0][0]
             dst_collection.padding = destination_padding
             if len(src_collection.indexes) != len(dst_collection.indexes):
-                raise KnownPublishError((
+                raise PublishError(
                     "This is a bug. Source sequence frames length"
                     " does not match integration frames length"
-                ))
+                )
 
             # Multiple file transfers
             transfers = []
@@ -1081,14 +1082,14 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
             file_path (str): Filepath.
 
         Raises:
-            KnownPublishError: When failed to find root for the path.
+            PublishError: When failed to find root for the path.
+
         """
         path = self.get_rootless_path(anatomy, file_path)
         if not path:
-            raise KnownPublishError((
-                "Destination path '{}' ".format(file_path) +
-                "must be in project dir"
-            ))
+            raise PublishError(
+                f"Destination path '{file_path}' must be in project dir"
+            )
 
     def _get_attributes_for_type(self, context, entity_type):
         return self._get_attributes_by_type(context)[entity_type]

--- a/client/ayon_core/plugins/publish/integrate_hero_version.py
+++ b/client/ayon_core/plugins/publish/integrate_hero_version.py
@@ -21,7 +21,7 @@ from ayon_core.lib.file_transaction import (
 from ayon_core.pipeline.publish import (
     get_publish_template_name,
     OptionalPyblishPluginMixin,
-    KnownPublishError,
+    PublishError,
 )
 
 
@@ -446,10 +446,10 @@ class IntegrateHeroVersion(
                 file_transactions.process()
 
             except DuplicateDestinationError as exc:
-                # Raise DuplicateDestinationError as KnownPublishError
+                # Raise DuplicateDestinationError as PublishError
                 # and rollback the transactions
                 file_transactions.rollback()
-                raise KnownPublishError(exc).with_traceback(sys.exc_info()[2])
+                raise PublishError(str(exc)).with_traceback(sys.exc_info()[2])
 
             except Exception as exc:
                 # Rollback the transactions

--- a/client/ayon_core/plugins/publish/integrate_hero_version_with_traits.py
+++ b/client/ayon_core/plugins/publish/integrate_hero_version_with_traits.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Optional
 from ayon_core.pipeline.publish import (
     get_publish_template_name,
     OptionalPyblishPluginMixin,
-    KnownPublishError,
+    PublishError,
 )
 
 if TYPE_CHECKING:
@@ -129,7 +129,7 @@ class IntegrateHeroVersionTraits(
                 "data. It has to go first through product integrator."
             )
             self.log.error(msg)
-            raise KnownPublishError(msg)
+            raise PublishError(msg)
 
         if src_version_entity["version"] == 0:
             self.log.warning("Version 0 cannot have hero version. Skipping.")
@@ -193,7 +193,7 @@ class IntegrateHeroVersionTraits(
                 "has to be published to create hero version."
             )
             self.log.error(msg)
-            raise KnownPublishError(msg)
+            raise PublishError(msg)
 
         # Separate old representations into `to replace` and `to delete`
         inactive_old_repres_by_name = {}
@@ -299,7 +299,7 @@ class IntegrateHeroVersionTraits(
             )
             file_transactions.rollback()
             self.log.error(msg)
-            raise KnownPublishError(msg) from e
+            raise PublishError(msg) from e
         except Exception as e:
             msg = (
                 "An error occurred during file transfer for hero version. "
@@ -307,7 +307,7 @@ class IntegrateHeroVersionTraits(
             )
             file_transactions.rollback()
             self.log.error(msg)
-            raise KnownPublishError(msg) from e
+            raise PublishError(msg) from e
         finally:
             file_transactions.finalize()
 


### PR DESCRIPTION
## Changelog Description
Replace usage of `KnownPublishError` with `PublishError`.

## Additional info
`KnowPublishError` is deprecated for some time, we should stop using it. Modified the error messages a little.

## Testing notes:
1. Validate the code changes.
2. If you don't like it, do a suggestion please.