### PR TITLE
Integrate: Use safe getter for transfers

### DIFF
--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -584,7 +584,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
                 f"Extension must not start with a dot '.': {repre['ext']}"
             )
 
-        repre_transfers = repre["transfers"]
+        repre_transfers = repre.get("transfers")
         if repre_transfers:
             raise PublishError(
                 "Representation is not allowed to have transfers"


### PR DESCRIPTION
## Changelog Description
Use safe getter to get representation transfers.

## Additional info
Fix bug caused by https://github.com/ynput/ayon-core/pull/1913.

## Testing notes:
1. Integration does not crash.
