### PR TITLE
Publish report: Label auto fill fixes

### DIFF
--- a/client/ayon_core/pipeline/publish/report.py
+++ b/client/ayon_core/pipeline/publish/report.py
@@ -622,7 +622,7 @@ class PublishReport:
 
         data = json.loads(content)
         if not data.get("label"):
-            data["label"] = os.path.basename(filepath)
+            data["label"] = os.path.splitext(os.path.basename(filepath))[0]
 
         updater = _PublishReportDataUpdate(data, filepath)
         updater.process()

--- a/client/ayon_core/tools/publisher/publish_report_viewer/window.py
+++ b/client/ayon_core/tools/publisher/publish_report_viewer/window.py
@@ -89,10 +89,6 @@ class PublishReportItem:
                 report_path = os.path.join(get_reports_dir(), report.id)
                 report.store_to_file(report_path)
 
-            label = report.label
-            if not label:
-                new_label = os.path.splitext(os.path.basename(filepath))[0]
-
         except Exception as exc:
             traceback.print_exception(*sys.exc_info())
             print(f"Failed to load report from file: {filepath}. {exc}")


### PR DESCRIPTION
## Changelog Description
Don't include extension from file in the label and don't duplicate the code in UI.

## Additional info
Extension was kept in report label which is not necessary and window did the same code in it's logic.

## Testing notes:
1. Drop report to publish report viewer.
2. The label of the report should be withou file extension.
