### PR TITLE
Workfiles API: Be able to define context change order

### DIFF
--- a/client/ayon_core/host/interfaces/workfiles.py
+++ b/client/ayon_core/host/interfaces/workfiles.py
@@ -834,6 +834,9 @@ class IWorkfileHost(AbstractHost):
         all host integrations.
 
     """
+    change_context_after_workfile_open = False
+    change_context_after_workfile_save = False
+
     @abstractmethod
     def save_workfile(self, dst_path: Optional[str] = None) -> None:
         """Save the currently opened scene.
@@ -956,15 +959,25 @@ class IWorkfileHost(AbstractHost):
         # Set 'AYON_WORKDIR' environment variable
         os.environ["AYON_WORKDIR"] = workdir
 
-        self.set_current_context(
-            folder_entity,
-            task_entity,
-            reason=ContextChangeReason.workfile_save,
-            project_entity=save_workfile_context.project_entity,
-            anatomy=save_workfile_context.anatomy,
-        )
+        if not self.change_context_after_workfile_save:
+            self.set_current_context(
+                folder_entity,
+                task_entity,
+                reason=ContextChangeReason.workfile_save,
+                project_entity=save_workfile_context.project_entity,
+                anatomy=save_workfile_context.anatomy,
+            )
 
         self.save_workfile(filepath)
+
+        if self.change_context_after_workfile_save:
+            self.set_current_context(
+                folder_entity,
+                task_entity,
+                reason=ContextChangeReason.workfile_save,
+                project_entity=save_workfile_context.project_entity,
+                anatomy=save_workfile_context.anatomy,
+            )
 
         self._save_workfile_entity(
             save_workfile_context,
@@ -1019,15 +1032,25 @@ class IWorkfileHost(AbstractHost):
         self._before_workfile_open(open_workfile_context)
         self._emit_workfile_open_event(event_data, after_open=False)
 
-        self.set_current_context(
-            folder_entity,
-            task_entity,
-            reason=ContextChangeReason.workfile_open,
-            project_entity=open_workfile_context.project_entity,
-            anatomy=open_workfile_context.anatomy,
-        )
+        if not self.change_context_after_workfile_open:
+            self.set_current_context(
+                folder_entity,
+                task_entity,
+                reason=ContextChangeReason.workfile_open,
+                project_entity=open_workfile_context.project_entity,
+                anatomy=open_workfile_context.anatomy,
+            )
 
         self.open_workfile(filepath)
+
+        if self.change_context_after_workfile_open:
+            self.set_current_context(
+                folder_entity,
+                task_entity,
+                reason=ContextChangeReason.workfile_open,
+                project_entity=open_workfile_context.project_entity,
+                anatomy=open_workfile_context.anatomy,
+            )
 
         self._after_workfile_open(open_workfile_context)
         self._emit_workfile_open_event(event_data)

--- a/client/ayon_core/host/interfaces/workfiles.py
+++ b/client/ayon_core/host/interfaces/workfiles.py
@@ -834,7 +834,7 @@ class IWorkfileHost(AbstractHost):
         all host integrations.
 
     """
-    change_context_after_workfile_open = False
+    change_context_before_workfile_open = True
 
     @abstractmethod
     def save_workfile(self, dst_path: Optional[str] = None) -> None:
@@ -1021,7 +1021,7 @@ class IWorkfileHost(AbstractHost):
         self._before_workfile_open(open_workfile_context)
         self._emit_workfile_open_event(event_data, after_open=False)
 
-        if not self.change_context_after_workfile_open:
+        if self.change_context_before_workfile_open:
             self.set_current_context(
                 folder_entity,
                 task_entity,
@@ -1032,7 +1032,7 @@ class IWorkfileHost(AbstractHost):
 
         self.open_workfile(filepath)
 
-        if self.change_context_after_workfile_open:
+        if not self.change_context_before_workfile_open:
             self.set_current_context(
                 folder_entity,
                 task_entity,

--- a/client/ayon_core/host/interfaces/workfiles.py
+++ b/client/ayon_core/host/interfaces/workfiles.py
@@ -835,7 +835,6 @@ class IWorkfileHost(AbstractHost):
 
     """
     change_context_after_workfile_open = False
-    change_context_after_workfile_save = False
 
     @abstractmethod
     def save_workfile(self, dst_path: Optional[str] = None) -> None:
@@ -959,25 +958,15 @@ class IWorkfileHost(AbstractHost):
         # Set 'AYON_WORKDIR' environment variable
         os.environ["AYON_WORKDIR"] = workdir
 
-        if not self.change_context_after_workfile_save:
-            self.set_current_context(
-                folder_entity,
-                task_entity,
-                reason=ContextChangeReason.workfile_save,
-                project_entity=save_workfile_context.project_entity,
-                anatomy=save_workfile_context.anatomy,
-            )
+        self.set_current_context(
+            folder_entity,
+            task_entity,
+            reason=ContextChangeReason.workfile_save,
+            project_entity=save_workfile_context.project_entity,
+            anatomy=save_workfile_context.anatomy,
+        )
 
         self.save_workfile(filepath)
-
-        if self.change_context_after_workfile_save:
-            self.set_current_context(
-                folder_entity,
-                task_entity,
-                reason=ContextChangeReason.workfile_save,
-                project_entity=save_workfile_context.project_entity,
-                anatomy=save_workfile_context.anatomy,
-            )
 
         self._save_workfile_entity(
             save_workfile_context,

--- a/client/ayon_core/host/interfaces/workfiles.py
+++ b/client/ayon_core/host/interfaces/workfiles.py
@@ -835,8 +835,8 @@ class IWorkfileHost(AbstractHost):
 
     """
     # Can be changed to False if the host integration needs to change context
-    #   after workfile is opened, useful if the integration stores and retrieves 
-    #   context to metadata of the file
+    #   after workfile is opened, useful if the integration stores and
+    #   retrieves context to metadata of the file
     change_context_before_workfile_open = True
 
     @abstractmethod

--- a/client/ayon_core/host/interfaces/workfiles.py
+++ b/client/ayon_core/host/interfaces/workfiles.py
@@ -834,6 +834,10 @@ class IWorkfileHost(AbstractHost):
         all host integrations.
 
     """
+    # Can be changed to False if the host integration needs to change context
+    #   after workfile is opened
+    # - usefull in cases when the integration does store context to metadata
+    #   of the file
     change_context_before_workfile_open = True
 
     @abstractmethod

--- a/client/ayon_core/host/interfaces/workfiles.py
+++ b/client/ayon_core/host/interfaces/workfiles.py
@@ -835,9 +835,8 @@ class IWorkfileHost(AbstractHost):
 
     """
     # Can be changed to False if the host integration needs to change context
-    #   after workfile is opened
-    # - usefull in cases when the integration does store context to metadata
-    #   of the file
+    #   after workfile is opened, useful if the integration stores and retrieves 
+    #   context to metadata of the file
     change_context_before_workfile_open = True
 
     @abstractmethod


### PR DESCRIPTION
## Changelog Description
Host can define if the context change does happen before or after workfile open.

## Additional info
There are integrations that do need to have set context before the workfile is openedand then there are integrations that need to set the context after the workfile is opened. By adding `change_context_before_workfile_open` attribute the host can tell the order.

This was added for hosts where context is stored to workfile metadata and the context change before workfile is openedwould actually affect the context of currently opened file instead of the file that will be opened.

## Testing notes:
1. Validate changes.
2. Compromise if it is wrong.
