### PR TITLE
Delivery tool: replace representation checkboxes with a multi-select list

### DIFF
--- a/client/ayon_core/tools/delivery/delivery.py
+++ b/client/ayon_core/tools/delivery/delivery.py
@@ -33,7 +33,7 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
     ):
         super().__init__(parent=parent)
 
-        self.setWindowTitle("AYON - Deliver versions")
+        self.setWindowTitle(f"Deliver {len(version_ids)} versions")
         icon = QtGui.QIcon(resources.get_ayon_icon_filepath())
         self.setWindowIcon(icon)
 
@@ -170,7 +170,7 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         self.text_area = text_area
         self.btn_delivery = btn_delivery
 
-        self.files_selected, self.size_selected = \
+        self.selected_repres_count, self.files_selected, self.size_selected = \
             self._get_counts(self._get_selected_repres())
 
         self._update_selected_label()
@@ -331,8 +331,10 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         """Returns tuple of number of selected files and their size."""
         files_selected = 0
         size_selected = 0
+        selected_repres_count = 0
         for repre in self._representations:
             if repre["name"] in selected_repres:
+                selected_repres_count += 1
                 files = repre.get("files", [])
                 if not files:  # for repre without files, cannot divide by 0
                     files_selected += 1
@@ -342,11 +344,12 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
                         files_selected += 1
                         size_selected += repre_file["size"]
 
-        return files_selected, size_selected
+        return selected_repres_count, files_selected, size_selected
 
     def _prepare_label(self):
         """Provides text with no of selected files and their size."""
-        label = "{} files, size {}".format(
+        label = "{} ({} files, size {})".format(
+            self.selected_repres_count,
             self.files_selected,
             format_file_size(self.size_selected))
         return label
@@ -358,7 +361,7 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
     def _update_selected_label(self):
         """Updates label with list of number of selected files."""
         selected_repres = self._get_selected_repres()
-        self.files_selected, self.size_selected = \
+        self.selected_repres_count, self.files_selected, self.size_selected = \
             self._get_counts(selected_repres)
         self.selected_label.setText(self._prepare_label())
         # update delivery button state if any templates found

--- a/client/ayon_core/tools/delivery/delivery.py
+++ b/client/ayon_core/tools/delivery/delivery.py
@@ -81,17 +81,47 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
 
         root_line_edit = QtWidgets.QLineEdit()
 
-        repre_checkboxes_layout = QtWidgets.QFormLayout()
-        repre_checkboxes_layout.setContentsMargins(10, 5, 5, 10)
+        # Collapsible "Advanced options" section, hidden by default
+        advanced_toggle = QtWidgets.QToolButton()
+        advanced_toggle.setText("Advanced options")
+        advanced_toggle.setCheckable(True)
+        advanced_toggle.setChecked(False)
+        advanced_toggle.setToolButtonStyle(
+            QtCore.Qt.ToolButtonTextBesideIcon)
+        advanced_toggle.setArrowType(QtCore.Qt.RightArrow)
 
-        self._representation_checkboxes = {}
-        for repre in self._get_representation_names():
-            checkbox = QtWidgets.QCheckBox()
-            checkbox.setChecked(False)
-            self._representation_checkboxes[repre] = checkbox
+        advanced_widget = QtWidgets.QWidget(self)
+        advanced_layout = QtWidgets.QFormLayout(advanced_widget)
+        advanced_layout.setContentsMargins(10, 5, 5, 5)
+        advanced_layout.addRow("Renumber Frame", renumber_frame)
+        advanced_layout.addRow("Renumber start frame", first_frame_start)
+        advanced_layout.addRow("Root", root_line_edit)
+        advanced_widget.setVisible(False)
 
-            checkbox.stateChanged.connect(self._update_selected_label)
-            repre_checkboxes_layout.addRow(repre, checkbox)
+        def _on_advanced_toggled(checked):
+            advanced_widget.setVisible(checked)
+            advanced_toggle.setArrowType(
+                QtCore.Qt.DownArrow if checked else QtCore.Qt.RightArrow
+            )
+
+        advanced_toggle.toggled.connect(_on_advanced_toggled)
+
+        btn_select_all = QtWidgets.QPushButton("Select All")
+
+        repre_list = QtWidgets.QListWidget()
+        repre_list.setSelectionMode(
+            QtWidgets.QAbstractItemView.ExtendedSelection)
+        for repre in sorted(self._get_representation_names()):
+            repre_list.addItem(QtWidgets.QListWidgetItem(repre))
+
+        repre_list.itemSelectionChanged.connect(self._update_selected_label)
+        btn_select_all.clicked.connect(repre_list.selectAll)
+
+        repre_widget = QtWidgets.QWidget(self)
+        repre_layout = QtWidgets.QVBoxLayout(repre_widget)
+        repre_layout.setContentsMargins(10, 5, 5, 10)
+        repre_layout.addWidget(btn_select_all)
+        repre_layout.addWidget(repre_list)
 
         selected_label = QtWidgets.QLabel()
 
@@ -103,10 +133,9 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         input_layout.addRow("Delivery template", dropdown)
         input_layout.addRow("Directory template", template_dir_label)
         input_layout.addRow("File template", template_file_label)
-        input_layout.addRow("Renumber Frame", renumber_frame)
-        input_layout.addRow("Renumber start frame", first_frame_start)
-        input_layout.addRow("Root", root_line_edit)
-        input_layout.addRow("Representations", repre_checkboxes_layout)
+        input_layout.addRow("Representations", repre_widget)
+        input_layout.addRow(advanced_toggle)
+        input_layout.addRow(advanced_widget)
 
         btn_delivery = QtWidgets.QPushButton("Deliver")
         btn_delivery.setEnabled(False)
@@ -136,6 +165,7 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         self.first_frame_start = first_frame_start
         self.renumber_frame = renumber_frame
         self.root_line_edit = root_line_edit
+        self.repre_list = repre_list
         self.progress_bar = progress_bar
         self.text_area = text_area
         self.btn_delivery = btn_delivery
@@ -322,13 +352,8 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         return label
 
     def _get_selected_repres(self):
-        """Returns list of representation names filtered from checkboxes."""
-        selected_repres = []
-        for repre_name, checkbox in self._representation_checkboxes.items():
-            if checkbox.isChecked():
-                selected_repres.append(repre_name)
-
-        return selected_repres
+        """Returns list of representation names selected in the list."""
+        return [item.text() for item in self.repre_list.selectedItems()]
 
     def _update_selected_label(self):
         """Updates label with list of number of selected files."""


### PR DESCRIPTION
## Changelog Description
Delivery tool's representation selection now uses a `QListWidget` with multi-selection and a "Select All" button instead of a checkbox per representation. Advanced options (renumber frame, start frame, root) are moved into a collapsible "Advanced options" section, hidden by default, to simplify the default view.

## Additional info
Single file changed: `client/ayon_core/tools/delivery/delivery.py`. Representation names are now sorted for consistent ordering, and `_get_selected_repres` reads from `repre_list.selectedItems()` instead of iterating checkboxes.

## Testing notes:
1. Open the Delivery tool and confirm representations list appears sorted, with multi-select and "Select All" working.
2. Confirm delivery still triggers correctly for selected representations.
3. Expand/collapse "Advanced options" and verify renumber/root fields still function as before.

<img width="548" height="495" alt="image" src="https://github.com/user-attachments/assets/e6734764-1e39-49e0-993c-5893dbed48c2" />

<img width="556" height="501" alt="image" src="https://github.com/user-attachments/assets/75da7dab-7f62-4c4f-9468-a5c17321bef2" />


## Dependency
#1936 
