### PR TITLE
Support delivering versions from entity lists (playlists)

### DIFF
--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -283,9 +283,7 @@ def deliver(
             if not version_ids and not list_id:
                 raise ValueError("No version_ids or list_id in payload.")
             if list_id:
-                list_entity = ayon_api.get_entity_lists(
-                    project, list_ids=[list_id], fields=["items", "label"])
-                list_entity = list(list_entity)[0]
+                list_entity = ayon_api.get_entity_list_rest(project, list_id)
                 list_entity_label = list_entity["label"]
                 # get all version entities belonging to the list
                 version_ids = [

--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -284,6 +284,9 @@ def deliver(
                 raise ValueError("No version_ids or list_id in payload.")
             if list_id:
                 list_entity = ayon_api.get_entity_list_rest(project, list_id)
+                if not list_entity:
+                    raise ValueError(
+                        f"Entity list '{list_id}' was not found.")
                 list_entity_label = list_entity["label"]
                 # get all version entities belonging to the list
                 version_ids = [

--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -267,12 +267,6 @@ def deliver(
 
     log = Logger.get_logger("delivery")
 
-    if (event_id and version_ids) or (not event_id and not version_ids):
-        log.warning(
-            "Exactly one of '--event_id' or '--version_ids' must be provided."
-        )
-        return
-
     try:
         from ayon_core.tools.delivery.delivery import DeliveryOptionsDialog
         # must be here because no module qargparse
@@ -296,8 +290,10 @@ def deliver(
                 # get all version entities belonging to the list
                 version_ids = [
                     version["entityId"] for version in list_entity["items"]]
-        else:
+        elif version_ids:
             version_ids = version_ids.split(",")
+        else:
+            raise ValueError("Missing option '--version_ids' or '--event_id'")
 
         dialog = DeliveryOptionsDialog(
             project, version_ids, list_entity_label=list_entity_label, log=log

--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -279,13 +279,28 @@ def deliver(
         from ayon_core.tools.utils.lib import get_qt_app
 
         _app = get_qt_app()
+        list_entity_label = None
         if event_id:
             event = ayon_api.get_event(event_id)
-            version_ids = event["payload"]["version_ids"]
+
+            # either version_ids or list_id can be in payload
+            version_ids = event["payload"].get("version_ids")
+            list_id = event["payload"].get("list_id")
+            if not version_ids and not list_id:
+                raise ValueError("No version_ids or list_id in payload.")
+            if list_id:
+                list_entity = ayon_api.get_entity_lists(
+                    project, list_ids=[list_id], fields=["items", "label"])
+                list_entity = list(list_entity)[0]
+                list_entity_label = list_entity["label"]
+                # get all version entities belonging to the list
+                version_ids = [
+                    version["entityId"] for version in list_entity["items"]]
         else:
             version_ids = version_ids.split(",")
+
         dialog = DeliveryOptionsDialog(
-            project, version_ids, log=log
+            project, version_ids, list_entity_label=list_entity_label, log=log
         )
         dialog.exec_()
     except Exception:

--- a/client/ayon_core/plugins/loader/delivery.py
+++ b/client/ayon_core/plugins/loader/delivery.py
@@ -51,7 +51,7 @@ class DeliveryAction(LoaderSimpleActionPlugin):
         try:
             # TODO run the tool in subprocess
             dialog = DeliveryOptionsDialog(
-                selection.project_name, version_ids, self.log
+                selection.project_name, version_ids, log=self.log
             )
             dialog.exec_()
         except Exception:

--- a/client/ayon_core/tools/delivery/delivery.py
+++ b/client/ayon_core/tools/delivery/delivery.py
@@ -28,6 +28,7 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         self,
         project_name,
         version_ids,
+        list_entity_label=None,
         log=None,
         parent=None,
     ):
@@ -80,6 +81,7 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         first_frame_start.setRange(0, max_int - 1)
 
         root_line_edit = QtWidgets.QLineEdit()
+        list_label_line_edit = QtWidgets.QLineEdit()
 
         # Collapsible "Advanced options" section, hidden by default
         advanced_toggle = QtWidgets.QToolButton()
@@ -96,6 +98,10 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         advanced_layout.addRow("Renumber Frame", renumber_frame)
         advanced_layout.addRow("Renumber start frame", first_frame_start)
         advanced_layout.addRow("Root", root_line_edit)
+        advanced_layout.addRow("List label", list_label_line_edit)
+        # set default value if `list_entity_label` arg is provided
+        if list_entity_label:
+            list_label_line_edit.setText(list_entity_label)
         advanced_widget.setVisible(False)
 
         def _on_advanced_toggled(checked):
@@ -165,6 +171,7 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         self.first_frame_start = first_frame_start
         self.renumber_frame = renumber_frame
         self.root_line_edit = root_line_edit
+        self.list_label_line_edit = list_label_line_edit
         self.repre_list = repre_list
         self.progress_bar = progress_bar
         self.text_area = text_area
@@ -201,6 +208,7 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         datetime_data = get_datetime_data()
         template_name = self.dropdown.currentText()
         format_dict = get_format_dict(self.anatomy, self.root_line_edit.text())
+        list_label = self.list_label_line_edit.text()
         renumber_frame = self.renumber_frame.isChecked()
         frame_offset = self.first_frame_start.value()
         filtered_repres = []
@@ -221,6 +229,9 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
             )
 
             template_data = template_data_by_repre_id[repre["id"]]
+            if list_label:
+                template_data["list"] = {"label": list_label}
+
             new_report_items = check_destination_path(
                 repre["id"],
                 self.anatomy,

--- a/client/ayon_core/tools/delivery/delivery.py
+++ b/client/ayon_core/tools/delivery/delivery.py
@@ -1,4 +1,5 @@
 import platform
+import logging
 from collections import defaultdict
 
 import ayon_api
@@ -29,10 +30,14 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
         project_name,
         version_ids,
         list_entity_label=None,
+        *,
         log=None,
         parent=None,
     ):
         super().__init__(parent=parent)
+
+        if log is None:
+            log = logging.getLogger(__name__)
 
         self.setWindowTitle(f"Deliver {len(version_ids)} versions")
         icon = QtGui.QIcon(resources.get_ayon_icon_filepath())

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -146,6 +146,7 @@ class CoreAddon(BaseServerAddon):
 
             return await executor.get_launcher_response(args)
 
+        if executor.identifier == "core.delivery.list":
             if not executor.context.entity_ids:
                 return await executor.get_server_action_response(
                     message="No list selected.",

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -63,7 +63,7 @@ class CoreAddon(BaseServerAddon):
             )
             output.append(
                 SimpleActionManifest(
-                    identifier="core.delivery",
+                    identifier="core.delivery.version",
                     label="Delivery Versions (launcher action)",
                     icon={
                         "type": "material-symbols",
@@ -73,6 +73,23 @@ class CoreAddon(BaseServerAddon):
                     entity_type="version",
                     entity_subtypes=None,
                     allow_multiselection=True,
+                )
+            )
+            output.append(
+                SimpleActionManifest(
+                    identifier="core.delivery.list",
+                    label="Delivery Versions (launcher action)",
+                    icon={
+                        "type": "material-symbols",
+                        "name": "create_new_folder",
+                    },
+                    order=100,
+                    entity_type="list",
+                    entity_subtypes=[
+                        "version:review-session",
+                        "version:generic",
+                    ],
+                    allow_multiselection=False,
                 )
             )
 
@@ -108,7 +125,7 @@ class CoreAddon(BaseServerAddon):
 
             return await executor.get_launcher_action_response(args)
 
-        if executor.identifier == "core.delivery":
+        if executor.identifier == "core.delivery.version":
             selected_versions = await executor.context.get_entities()
             if not selected_versions:
                 return await executor.get_server_action_response(
@@ -120,6 +137,27 @@ class CoreAddon(BaseServerAddon):
                 topic="delivery.requested",
                 project=project_name,
                 payload={"version_ids": version_ids},
+                finished=True,
+            )
+            args = [
+                "deliver", "--project", project_name,
+                "--event_id", event_id,
+            ]
+
+            return await executor.get_launcher_response(args)
+
+        if executor.identifier == "core.delivery.list":
+            selected_list = executor.context.entity_ids[0]
+            print(f"selected_list: {selected_list}")
+            if not selected_list:
+                return await executor.get_server_action_response(
+                    message="No list available in selection.",
+                    success=False
+                )
+            event_id = await dispatch_event(
+                topic="delivery.requested",
+                project=project_name,
+                payload={"list_id": selected_list},
                 finished=True,
             )
             args = [

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -64,7 +64,7 @@ class CoreAddon(BaseServerAddon):
             output.append(
                 SimpleActionManifest(
                     identifier="core.delivery.version",
-                    label="Delivery Versions (launcher action)",
+                    label="Deliver versions (launcher action)",
                     icon={
                         "type": "material-symbols",
                         "name": "create_new_folder",
@@ -78,7 +78,7 @@ class CoreAddon(BaseServerAddon):
             output.append(
                 SimpleActionManifest(
                     identifier="core.delivery.list",
-                    label="Delivery Versions (launcher action)",
+                    label="Deliver versions (launcher action)",
                     icon={
                         "type": "material-symbols",
                         "name": "create_new_folder",
@@ -148,7 +148,6 @@ class CoreAddon(BaseServerAddon):
 
         if executor.identifier == "core.delivery.list":
             selected_list = executor.context.entity_ids[0]
-            print(f"selected_list: {selected_list}")
             if not selected_list:
                 return await executor.get_server_action_response(
                     message="No list available in selection.",

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -146,13 +146,13 @@ class CoreAddon(BaseServerAddon):
 
             return await executor.get_launcher_response(args)
 
-        if executor.identifier == "core.delivery.list":
-            selected_list = executor.context.entity_ids[0]
-            if not selected_list:
+            if not executor.context.entity_ids:
                 return await executor.get_server_action_response(
-                    message="No list available in selection.",
+                    message="No list selected.",
                     success=False
                 )
+
+            selected_list = executor.context.entity_ids[0]
             event_id = await dispatch_event(
                 topic="delivery.requested",
                 project=project_name,

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -167,7 +167,7 @@ class CoreAddon(BaseServerAddon):
             return await executor.get_launcher_response(args)
 
         logger.debug(f"Unknown action: {executor.identifier}")
-        # Works since AYON server 1.8.3
+
         if hasattr(executor, "get_simple_response"):
             return await executor.get_simple_response(
                 "Unknown action", success=False


### PR DESCRIPTION
## Changelog Description
Adds support for launching the Delivery tool directly from an entity list (e.g. a review session/playlist), in addition to individually selected versions. When triggered from a list, the tool resolves all versions contained in it and exposes the list label as a template token, allowing delivery path templates to include the list name. The previous single launcher action is also split into distinct version- and list-based actions on the server.

## Additional info
- CLI `deliver` command now reads either `version_ids` or `list_id` from the triggering event payload.
- `DeliveryOptionsDialog` accepts a new `list_entity_label` argument and exposes a "List label" advanced field, pre-filled when launched from a list, injected into template formatting as `list.label`.
- Server actions renamed/added: `core.delivery` → `core.delivery.version`; new `core.delivery.list` action for `list` entities with subtypes `version:review-session` and `version:generic`.

## Testing notes:
1. Create a review session/playlist containing several versions.
2. Trigger the "Delivery Versions" action from the list's context menu.
3. Confirm the Delivery dialog opens with all versions from the list and the "List label" field is pre-filled.
4. Use the `{list[label]}` in a delivery path template and confirm the resolved output path uses it. 
```
{root[work]}/{project[name]}/delivery/{list[label]}/{yyyy}-{mm}-{dd}/{folder[name]}/{representation}
```
5. Confirm triggering delivery from individually selected versions still works as before.

## Dependency
Close #1941
[YN-0915](https://support.ayon.app/projects/Active_Clients/overview?project=Active_Clients&type=folder&id=2767ebf07c6111f1bb2d1f14cfbf88d3)
