### PR TITLE
Publish: Base of publish api

### DIFF
--- a/client/ayon_core/pipeline/publish/__init__.py
+++ b/client/ayon_core/pipeline/publish/__init__.py
@@ -65,7 +65,7 @@ from .lib import (
     get_default_reviewable_layers,
 )
 from .report import PublishReport
-
+from .logic import PublishLogic, PublishActionResult
 from .abstract_expected_files import ExpectedFiles
 from .abstract_collect_render import (
     RenderInstance,
@@ -120,6 +120,9 @@ __all__ = (
     "main_cli_publish",
 
     "PublishReport",
+
+    "PublishLogic",
+    "PublishActionResult",
 
     "ExpectedFiles",
 

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -1171,6 +1171,7 @@ def main_cli_publish(
         install_ayon_plugins,
         get_global_context,
     )
+    from ayon_core.pipeline.publish import PublishLogic
 
     # Register target and host
     if not isinstance(path, str):
@@ -1239,15 +1240,17 @@ def main_cli_publish(
     discover_result = publish_plugins_discover()
     print(discover_result.get_report(only_errors=False))
 
-    filtered_crashed_paths = filter_crashed_publish_paths(
-        context["project_name"],
-        set(discover_result.crashed_file_paths),
-        project_settings=project_settings,
+    logic = PublishLogic()
+    logic.reset(
+        project_name=context["project_name"],
+        publish_discover_result=discover_result,
     )
-    if filtered_crashed_paths:
+    report = logic.get_publish_report()
+
+    if report.blocking_crashed_paths:
         joined_paths = "\n".join([
             f"- {path}"
-            for path in filtered_crashed_paths
+            for path in report.blocking_crashed_paths
         ])
         log.error(
             "Plugin discovery strict mode is enabled."
@@ -1256,15 +1259,9 @@ def main_cli_publish(
         )
         sys.exit(1)
 
-    publish_plugins = discover_result.plugins
-
-    # Error exit as soon as any error occurs.
-    error_format = "Failed {plugin.__name__}: {error} -- {error.traceback}"
-
-    for result in pyblish.util.publish_iter(plugins=publish_plugins):
-        if result["error"]:
-            log.error(error_format.format(**result))
-            sys.exit(1)
+    logic.start_publish(wait=True)
+    if logic.has_crashed() or logic.has_validation_errors():
+        sys.exit(1)
 
     log.info("Publish finished.")
 

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -1243,23 +1243,31 @@ def main_cli_publish(
     logic.reset(
         project_name=context["project_name"],
         publish_discover_result=discover_result,
+        targets=targets,
     )
-    report = logic.get_publish_report()
+    if logic.has_failed():
+        report = logic.get_publish_report()
+        if report.blocking_crashed_paths:
+            joined_paths = "\n".join([
+                f"- {path}"
+                for path in report.blocking_crashed_paths
+            ])
+            log.error(
+                "Plugin discovery strict mode is enabled."
+                " Crashed plugin paths that prevent from publishing:"
+                f"\n{joined_paths}"
+            )
+            sys.exit(1)
 
-    if report.blocking_crashed_paths:
-        joined_paths = "\n".join([
-            f"- {path}"
-            for path in report.blocking_crashed_paths
-        ])
+        fail_reason = logic.get_fail_reason()
         log.error(
-            "Plugin discovery strict mode is enabled."
-            " Crashed plugin paths that prevent from publishing:"
-            f"\n{joined_paths}"
+            "Failed before publishing started."
+            f" Probably because of unhandled reason '{fail_reason}'."
         )
         sys.exit(1)
 
     logic.start_publish(wait=True)
-    if logic.has_crashed() or logic.has_validation_errors():
+    if logic.has_failed():
         sys.exit(1)
 
     log.info("Publish finished.")

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -11,7 +11,7 @@ import copy
 import warnings
 import hashlib
 import xml.etree.ElementTree
-from typing import TYPE_CHECKING, Optional, Union, List, Any
+from typing import TYPE_CHECKING, Any, Generator
 import logging
 
 from ayon_api import (
@@ -45,6 +45,10 @@ if TYPE_CHECKING:
         AnatomyStringTemplate,
         TemplateItem as AnatomyTemplateItem,
     )
+    from ayon_core.pipeline.create import CreateContext
+
+    from .report import PublishReport
+    from .typing import PluginType
 
 TRAIT_INSTANCE_KEY: str = "representations_with_traits"
 
@@ -53,7 +57,7 @@ log = logging.getLogger(__name__)
 
 def get_template_name_profiles(
     project_name: str,
-    project_settings: Optional[dict[str, Any]] = None,
+    project_settings: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Receive profiles for publish template keys.
 
@@ -87,7 +91,7 @@ def get_template_name_profiles(
 
 def get_hero_template_name_profiles(
     project_name: str,
-    project_settings: Optional[dict[str, Any]] = None,
+    project_settings: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Receive profiles for hero publish template keys.
 
@@ -95,7 +99,7 @@ def get_hero_template_name_profiles(
 
     Args:
         project_name (str): Name of project where to look for templates.
-        project_settings (Dict[str, Any]): Prepared project settings.
+        project_settings (dict[str, Any] | None): Prepared project settings.
 
     Returns:
         list[dict[str, Any]]: Publish template profiles.
@@ -175,12 +179,12 @@ def get_publish_template_name(
     project_name: str,
     host_name: str,
     product_base_type: str,
-    task_name: Union[str, None],
-    task_type: Union[str, None],
+    task_name: str | None,
+    task_type: str | None,
     *,
-    project_settings: Optional[dict] = None,
+    project_settings: dict[str, Any] | None = None,
     hero: bool = False,
-    logger: Optional[logging.Logger] = None,
+    logger: logging.Logger | None = None,
 ) -> str:
     """Get template name which should be used for passed context.
 
@@ -197,10 +201,10 @@ def get_publish_template_name(
             found template.
         task_name (str): Task name on which is instance working.
         task_type (str): Task type on which is instance working.
-        project_settings (Dict[str, Any]): Prepared project settings.
+        project_settings (dict[str, Any] | None): Prepared project settings.
         hero (bool): Template is for hero version publishing.
-        logger (logging.Logger): Custom logger used for 'filter_profiles'
-            function.
+        logger (logging.Logger | None): Custom logger used for
+            'filter_profiles' function.
 
     Returns:
         str: Template name which should be used for integration.
@@ -276,8 +280,8 @@ def load_help_content_from_filepath(
 
 
 def load_help_content_from_plugin(
-    plugin: pyblish.api.Plugin,
-    help_filename: Optional[str] = None,
+    plugin: PluginType | pyblish.api.Plugin,
+    help_filename: str | None = None,
 ) -> dict[str, dict[str, HelpContent]]:
     cls = plugin
     if not inspect.isclass(plugin):
@@ -296,7 +300,7 @@ def filter_crashed_publish_paths(
     project_name: str,
     crashed_paths: set[str],
     *,
-    project_settings: Optional[dict[str, Any]] = None,
+    project_settings: dict[str, Any] | None = None,
 ) -> set[str]:
     """Filter crashed paths happened during plugins discovery.
 
@@ -309,7 +313,7 @@ def filter_crashed_publish_paths(
         project_name (str): Project name in which context plugins discovery
             happened.
         crashed_paths (set[str]): Crashed paths from plugins discovery report.
-        project_settings (Optional[dict[str, Any]]): Project settings.
+        project_settings (dict[str, Any] | None): Project settings.
 
     Returns:
         set[str]: Filtered crashed paths.
@@ -354,17 +358,18 @@ def filter_crashed_publish_paths(
 
 
 def publish_plugins_discover(
-        paths: Optional[list[str]] = None) -> DiscoverResult:
+    paths: list[str] | None = None,
+) -> DiscoverResult:
     """Find and return available pyblish plug-ins.
 
     Overridden function from `pyblish` module to be able to collect
         crashed files and reason of their crash.
 
     Arguments:
-        paths (list, optional): Paths to discover plug-ins from.
+        paths (list[str] | None): Paths to discover plug-ins from.
             If no paths are provided, all paths are searched.
-    """
 
+    """
     # The only difference with `pyblish.api.discover`
     result = DiscoverResult(pyblish.api.Plugin)
 
@@ -457,7 +462,12 @@ def publish_plugins_discover(
     return result
 
 
-def get_plugin_settings(plugin, project_settings, log, category=None):
+def get_plugin_settings(
+    plugin: PluginType,
+    project_settings: dict[str, Any],
+    log: logging.Logger,
+    category: str | None = None,
+) -> dict[str, Any]:
     """Get plugin settings based on host name and plugin name.
 
     Note:
@@ -465,16 +475,16 @@ def get_plugin_settings(plugin, project_settings, log, category=None):
             into 'category'.
 
     Args:
-        plugin (pyblish.Plugin): Plugin where settings are applied.
+        plugin (PluginType): Plugin where settings are applied.
         project_settings (dict[str, Any]): Project settings.
         log (logging.Logger): Logger to log messages.
-        category (Optional[str]): Settings category key where to look
+        category (str | None): Settings category key where to look
             for plugin settings.
 
     Returns:
         dict[str, Any]: Plugin settings {'attribute': 'value'}.
-    """
 
+    """
     # Plugin can define settings category by class attribute
     # - it's impossible to set `settings_category` via settings because
     #     obviously settings are not applied before it.
@@ -550,7 +560,11 @@ def get_plugin_settings(plugin, project_settings, log, category=None):
     return {}
 
 
-def apply_plugin_settings_automatically(plugin, settings, logger=None):
+def apply_plugin_settings_automatically(
+    plugin: PluginType,
+    settings: dict[str, Any],
+    logger: logging.Logger | None = None,
+) -> None:
     """Automatically apply plugin settings to a plugin object.
 
     Note:
@@ -558,20 +572,21 @@ def apply_plugin_settings_automatically(plugin, settings, logger=None):
             'apply_settings' class method.
 
     Args:
-        plugin (type[pyblish.api.Plugin]): Class of a plugin.
+        plugin (PluginType): Class of a plugin.
         settings (dict[str, Any]): Plugin specific settings.
-        logger (Optional[logging.Logger]): Logger to log debug messages about
+        logger (logging.Logger | None): Logger to log debug messages about
             applied settings values.
-    """
 
+    """
     for option, value in settings.items():
         if logger:
-            logger.debug("Plugin %s - Attr: %s -> %s",
-                         plugin.__name__, option, value)
+            logger.debug(
+                "Plugin %s - Attr: %s -> %s", plugin.__name__, option, value
+            )
         setattr(plugin, option, value)
 
 
-def filter_pyblish_plugins(plugins):
+def filter_pyblish_plugins(plugins: list[PluginType]) -> None:
     """Pyblish plugin filter which applies AYON settings.
 
     Apply settings on discovered plugins. On plugin with implemented
@@ -580,10 +595,10 @@ def filter_pyblish_plugins(plugins):
     host name to look for
 
     Args:
-        plugins (List[pyblish.plugin.Plugin]): Discovered plugins on which
+        plugins (List[PluginType]): Discovered plugins on which
             are applied settings.
-    """
 
+    """
     log = Logger.get_logger("filter_pyblish_plugins")
 
     # TODO: Don't use host from 'pyblish.api' but from defined host by us.
@@ -631,19 +646,22 @@ def filter_pyblish_plugins(plugins):
             plugins.remove(plugin)
 
 
-def get_errored_instances_from_context(context, plugin=None):
+def get_errored_instances_from_context(
+    context: pyblish.api.Context,
+    plugin: PluginType | None = None,
+) -> list[pyblish.lib.Instance]:
     """Collect failed instances from pyblish context.
 
     Args:
         context (pyblish.api.Context): Publish context where we're looking
             for failed instances.
-        plugin (pyblish.api.Plugin): If provided then only consider errors
+        plugin (PluginType | None): If provided then only consider errors
             related to that plug-in.
 
     Returns:
-        List[pyblish.lib.Instance]: Instances which failed during processing.
-    """
+        list[pyblish.lib.Instance]: Instances which failed during processing.
 
+    """
     instances = list()
     for result in context.data["results"]:
         if result["instance"] is None:
@@ -659,7 +677,9 @@ def get_errored_instances_from_context(context, plugin=None):
     return instances
 
 
-def get_errored_plugins_from_context(context):
+def get_errored_plugins_from_context(
+    context: pyblish.api.Context
+) -> list[PluginType]:
     """Collect failed plugins from pyblish context.
 
     Args:
@@ -667,9 +687,9 @@ def get_errored_plugins_from_context(context):
             for failed plugins.
 
     Returns:
-        List[pyblish.api.Plugin]: Plugins which failed during processing.
-    """
+        list[PluginType]: Plugins which failed during processing.
 
+    """
     plugins = list()
     results = context.data.get("results", [])
     for result in results:
@@ -680,7 +700,10 @@ def get_errored_plugins_from_context(context):
     return plugins
 
 
-def filter_instances_for_context_plugin(plugin, context):
+def filter_instances_for_context_plugin(
+    plugin: PluginType,
+    context: pyblish.api.Context,
+) -> Generator[pyblish.lib.Instance, None, None]:
     """Filter instances on context by context plugin filters.
 
     This is for cases when context plugin need similar filtering like instance
@@ -688,13 +711,14 @@ def filter_instances_for_context_plugin(plugin, context):
     if there is at least one instance with a family.
 
     Args:
-        plugin (pyblish.api.Plugin): Plugin with filters.
+        plugin (PluginType): Plugin with filters.
         context (pyblish.api.Context): Pyblish context with instances.
 
     Returns:
-        Iterator[pyblish.lib.Instance]: Iteration of valid instances.
-    """
+        Generator[pyblish.lib.Instance, None, None]: Iteration of valid
+            instances.
 
+    """
     instances = []
     plugin_families = set()
     all_families = False
@@ -721,7 +745,10 @@ def filter_instances_for_context_plugin(plugin, context):
             yield instance
 
 
-def context_plugin_should_run(plugin, context):
+def context_plugin_should_run(
+    plugin: PluginType,
+    context: pyblish.api.Context,
+) -> bool:
     """Return whether the ContextPlugin should run on the given context.
 
     This is a helper function to work around a bug pyblish-base#250
@@ -743,7 +770,11 @@ def context_plugin_should_run(plugin, context):
     return False
 
 
-def get_publish_repre_path(instance, repre, only_published=False):
+def get_publish_repre_path(
+    instance: pyblish.api.Instance,
+    repre: dict[str, Any],
+    only_published: bool = False,
+) -> str | None:
     """Get representation path that can be used for integration.
 
     When 'only_published' is set to true the validation of path is not
@@ -752,7 +783,7 @@ def get_publish_repre_path(instance, repre, only_published=False):
     for reference where the file was published.
 
     Args:
-        instance (pyblish.Instance): Processed instance object. Used
+        instance (pyblish.api.Instance): Processed instance object. Used
             for source of staging dir if representation does not have
             filled it.
         repre (dict): Representation on instance which could be and
@@ -763,8 +794,8 @@ def get_publish_repre_path(instance, repre, only_published=False):
     Returns:
         str: Path to representation file.
         None: Path is not filled or does not exists.
-    """
 
+    """
     published_path = repre.get("published_path")
     if published_path:
         published_path = os.path.normpath(published_path)
@@ -795,7 +826,9 @@ def get_publish_repre_path(instance, repre, only_published=False):
     return None
 
 
-def get_instance_staging_dir(instance):
+def get_instance_staging_dir(
+    instance: pyblish.api.Instance
+) -> str:
     """Unified way how staging dir is stored and created on instances.
 
     First check if 'stagingDir' is already set in instance data.
@@ -854,7 +887,9 @@ def get_instance_staging_dir(instance):
     return staging_dir_path
 
 
-def get_published_workfile_instance(context):
+def get_published_workfile_instance(
+    context: pyblish.api.Context
+) -> pyblish.api.Instance | None:
     """Find workfile instance in context"""
     for i in context:
         # test if there is instance of workfile waiting
@@ -872,7 +907,10 @@ def get_published_workfile_instance(context):
         return i
 
 
-def replace_with_published_scene_path(instance, replace_in_path=True):
+def replace_with_published_scene_path(
+    instance: pyblish.api.Instance,
+    replace_in_path: bool = True,
+) -> str | None:
     """Switch work scene path for published scene.
     If rendering/exporting from published scenes is enabled, this will
     replace paths from working scene to published scene.
@@ -882,13 +920,16 @@ def replace_with_published_scene_path(instance, replace_in_path=True):
         replace_in_path (bool): if True, it will try to find
             old scene name in path of expected files and replace it
             with name of published scene.
+
     Returns:
         str: Published scene path.
-        None: if no published scene is found.
+        None: No published scene is found.
+
     Note:
         Published scene path is actually determined from project Anatomy
         as at the time this plugin is running scene can still not be
         published.
+
     """
     log = Logger.get_logger("published_workfile")
     workfile_instance = get_published_workfile_instance(instance.context)
@@ -979,7 +1020,10 @@ def replace_with_published_scene_path(instance, replace_in_path=True):
     return file_path
 
 
-def add_repre_files_for_cleanup(instance, repre):
+def add_repre_files_for_cleanup(
+    instance: pyblish.api.Instance,
+    repre: dict[str, Any],
+) -> None:
     """ Explicitly mark repre files to be deleted.
 
     Should be used on intermediate files (eg. review, thumbnails) to be
@@ -1007,7 +1051,7 @@ def add_repre_files_for_cleanup(instance, repre):
         instance.context.data["cleanupFullPaths"].append(expected_file)
 
 
-def get_publish_instance_label(instance):
+def get_publish_instance_label(instance: pyblish.api.Instance) -> str:
     """Try to get label from pyblish instance.
 
     First are used values in instance data under 'label' and 'name' keys. Then
@@ -1030,7 +1074,9 @@ def get_publish_instance_label(instance):
     )
 
 
-def get_publish_instance_families(instance):
+def get_publish_instance_families(
+    instance: pyblish.api.Instance
+) -> list[str]:
     """Get all families of the instance.
 
     Look for families under 'productType' and 'families' keys in instance data.
@@ -1038,7 +1084,7 @@ def get_publish_instance_families(instance):
     in random order.
 
     Args:
-        pyblish.api.Instance: Instance to get families from.
+        instance (pyblish.api.Instance): Instance to get families from.
 
     Returns:
         list[str]: List of families.
@@ -1055,11 +1101,11 @@ def get_publish_instance_families(instance):
 
 
 def get_instance_expected_output_path(
-        instance: pyblish.api.Instance,
-        representation_name: str,
-        ext: Union[str, None],
-        version: Optional[str] = None
-):
+    instance: pyblish.api.Instance,
+    representation_name: str,
+    ext: str | None,
+    version: str | None = None,
+) -> str:
     """Return expected publish filepath for representation in instance
 
     This does not validate whether the instance has any representation by the
@@ -1068,9 +1114,9 @@ def get_instance_expected_output_path(
     Arguments:
         instance (pyblish.api.Instance): Publish instance
         representation_name (str): Representation name
-        ext (Union[str, None]): Extension for the file.
+        ext (str | None): Extension for the file.
             When None, the `ext` will be set to the representation name.
-        version (Optional[int]): If provided, force it to format to this
+        version (int | None): If provided, force it to format to this
             particular version.
 
     Returns:
@@ -1307,7 +1353,8 @@ def run_publish(
 
 
 def has_trait_representations(
-        instance: pyblish.api.Instance) -> bool:
+    instance: pyblish.api.Instance
+) -> bool:
     """Check if instance has trait representation.
 
     Args:
@@ -1322,8 +1369,8 @@ def has_trait_representations(
 
 
 def add_trait_representations(
-        instance: pyblish.api.Instance,
-        representations: list[Representation]
+    instance: pyblish.api.Instance,
+    representations: list[Representation],
 ) -> None:
     """Add trait representations to instance.
 
@@ -1339,8 +1386,8 @@ def add_trait_representations(
 
 
 def set_trait_representations(
-        instance: pyblish.api.Instance,
-        representations: list[Representation]
+    instance: pyblish.api.Instance,
+    representations: list[Representation]
 ) -> None:
     """Set trait representations to instance.
 
@@ -1355,7 +1402,8 @@ def set_trait_representations(
 
 
 def get_trait_representations(
-        instance: pyblish.api.Instance) -> list[Representation]:
+    instance: pyblish.api.Instance
+) -> list[Representation]:
     """Get trait representations from instance.
 
     Args:
@@ -1372,11 +1420,11 @@ def get_trait_representations(
 def fill_sequence_gaps_with_previous_version(
     collection: str,
     staging_dir: str,
-    instance: pyblish.plugin.Instance,
+    instance: pyblish.api.Instance,
     current_repre_name: str,
     start_frame: int,
     end_frame: int
-) -> tuple[Optional[dict[str, Any]], Optional[dict[int, str]]]:
+) -> tuple[dict[str, Any] | None, dict[int, str] | None]:
     """Tries to replace missing frames from ones from last version"""
     used_version_entity, repre_file_paths = _get_last_version_files(
         instance, current_repre_name
@@ -1420,9 +1468,9 @@ def fill_sequence_gaps_with_previous_version(
 
 
 def _get_last_version_files(
-    instance: pyblish.plugin.Instance,
+    instance: pyblish.api.Instance,
     current_repre_name: str,
-) -> tuple[Optional[dict[str, Any]], Optional[list[str]]]:
+) -> tuple[dict[str, Any] | None, list[str] | None]:
     product_name = instance.data["productName"]
     project_name = instance.data["projectEntity"]["name"]
     folder_entity = instance.data["folderEntity"]
@@ -1506,9 +1554,9 @@ def get_instance_publish_template(instance: pyblish.api.Instance) -> str:
 
 
 def get_publish_template_object(
-        instance: pyblish.api.Instance,
-        category_name: str = "publish",
-        template_name: Optional[str] = None,
+    instance: pyblish.api.Instance,
+    category_name: str = "publish",
+    template_name: str | None = None,
 ) -> "AnatomyTemplateItem":
     """Return anatomy template object to use for integration.
 
@@ -1518,7 +1566,7 @@ def get_publish_template_object(
         instance (pyblish.api.Instance): Instance to process.
         category_name (str): Category name of the template to use.
             Defaults to "publish".
-        template_name (str, optional): Template name to use.
+        template_name (str | None): Template name to use.
             If not provided, it will get the template name from
             the provided instance.
 
@@ -1559,7 +1607,8 @@ def get_instance_families(instance: pyblish.api.Instance) -> list[str]:
 
 
 def get_version_data_from_instance(
-        instance: pyblish.api.Instance) -> dict:
+    instance: pyblish.api.Instance
+) -> dict:
     """Get version data from the Instance.
 
     Args:
@@ -1666,7 +1715,8 @@ class IntegrationTemplateItem:
     def __init__(self,
         anatomy: "Anatomy",
         template_data: dict[str, Any],
-        template_object: "AnatomyTemplateItem"):
+        template_object: "AnatomyTemplateItem",
+    ) -> None:
         """Initialize TemplateItem.
 
         Args:
@@ -1688,5 +1738,6 @@ def get_default_reviewable_layers(project_settings: dict) -> list[str]:
 
     Returns:
         list[str]: List of default reviewable layers.
+
     """
     return project_settings["core"]["reviewable_layers"]["review_layers"]

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -1329,10 +1329,6 @@ def run_publish(
         publish_discover_result=publish_discover_result,
         project_settings=project_settings,
     )
-    report = logic.get_publish_report()
-    if report.blocking_crashed_paths:
-        return report
-
     logic.publish()
 
     return logic.get_publish_report()

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -1149,17 +1149,17 @@ def get_instance_expected_output_path(
 
 def main_cli_publish(
     path: str,
-    targets: Optional[List[str]] = None,
-    addons_manager: Optional[AddonsManager] = None,
-):
+    targets: list[str] | None = None,
+    addons_manager: AddonsManager | None = None,
+) -> None:
     """Start headless publishing.
 
     Publish use json from passed path argument.
 
     Args:
         path (str): Path to JSON.
-        targets (Optional[List[str]]): List of pyblish targets.
-        addons_manager (Optional[AddonsManager]): Addons manager instance.
+        targets (list[str] | None): List of pyblish targets.
+        addons_manager (AddonsManager | None): Addons manager instance.
 
     Raises:
         RuntimeError: When there is no path to process or when executed with
@@ -1224,15 +1224,11 @@ def main_cli_publish(
 
     pyblish.api.register_host("shell")
 
-    if targets:
-        for target in targets:
-            print(f"setting target: {target}")
-            pyblish.api.register_target(target)
-    else:
-        pyblish.api.register_target("farm")
+    if not targets:
+        targets = ["farm"]
 
     os.environ["AYON_PUBLISH_DATA"] = path
-    os.environ["HEADLESS_PUBLISH"] = 'true'  # to use in app lib
+    os.environ["HEADLESS_PUBLISH"] = "true"  # to use in app lib
 
     log.info("Running publish ...")
 

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -1302,7 +1302,7 @@ def main_cli_publish(
 
 
 def run_publish(
-    project_name: str,
+    project_name: str | None = None,
     *,
     context: pyblish.api.Context | None = None,
     plugins: list[PluginType] | None = None,
@@ -1314,8 +1314,8 @@ def run_publish(
     """Start publishing.
 
     Args:
-        project_name (str): Name of the project in which publishing
-            should run.
+        project_name (str | None): Name of the project in which publishing
+            should run. 'get_current_project_name' is used when not provided.
         context (pyblish.api.Context | None): Pyblish context.
         plugins (list[PluginType] | None): List of pyblish plugins.
         targets (list[str] | None): List of pyblish targets.
@@ -1325,7 +1325,14 @@ def run_publish(
         project_settings (dict[str, Any] | None): Settings for the project.
 
     """
+    from ayon_core.pipeline import get_current_project_name
     from ayon_core.pipeline.publish import PublishLogic
+
+    if project_name is None:
+        project_name = get_current_project_name()
+
+    if project_name is None:
+        raise ValueError("Missing project name.")
 
     logic = PublishLogic(reset=False)
     logic.reset(

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -1267,7 +1267,7 @@ def main_cli_publish(
     discover_result = publish_plugins_discover()
     print(discover_result.get_report(only_errors=False))
 
-    logic = PublishLogic()
+    logic = PublishLogic(reset=False)
     logic.reset(
         project_name=context["project_name"],
         publish_discover_result=discover_result,
@@ -1319,7 +1319,7 @@ def run_publish(
     """
     from ayon_core.pipeline.publish import PublishLogic
 
-    logic = PublishLogic()
+    logic = PublishLogic(reset=False)
     logic.reset(
         project_name,
         context=context,

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -1314,7 +1314,15 @@ def run_publish(
     """Start publishing.
 
     Args:
+        project_name (str): Name of the project in which publishing
+            should run.
+        context (pyblish.api.Context | None): Pyblish context.
+        plugins (list[PluginType] | None): List of pyblish plugins.
         targets (list[str] | None): List of pyblish targets.
+        create_context (CreateContext | None): Prepared CreateContext object.
+        publish_discover_result (DiscoverResult | None): Result of
+            publish discovery.
+        project_settings (dict[str, Any] | None): Settings for the project.
 
     """
     from ayon_core.pipeline.publish import PublishLogic

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -1294,7 +1294,7 @@ def main_cli_publish(
         )
         sys.exit(1)
 
-    logic.start_publish(wait=True)
+    logic.publish()
     if logic.has_failed():
         sys.exit(1)
 
@@ -1333,7 +1333,7 @@ def run_publish(
     if report.blocking_crashed_paths:
         return report
 
-    logic.start_publish(wait=True)
+    logic.publish()
 
     return logic.get_publish_report()
 

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -1269,6 +1269,43 @@ def main_cli_publish(
     log.info("Publish finished.")
 
 
+def run_publish(
+    project_name: str,
+    *,
+    context: pyblish.api.Context | None = None,
+    plugins: list[PluginType] | None = None,
+    targets: list[str] | None = None,
+    create_context: CreateContext | None = None,
+    publish_discover_result: DiscoverResult | None = None,
+    project_settings: dict[str, Any] | None = None,
+) -> PublishReport:
+    """Start publishing.
+
+    Args:
+        targets (list[str] | None): List of pyblish targets.
+
+    """
+    from ayon_core.pipeline.publish import PublishLogic
+
+    logic = PublishLogic()
+    logic.reset(
+        project_name,
+        context=context,
+        plugins=plugins,
+        targets=targets,
+        create_context=create_context,
+        publish_discover_result=publish_discover_result,
+        project_settings=project_settings,
+    )
+    report = logic.get_publish_report()
+    if report.blocking_crashed_paths:
+        return report
+
+    logic.start_publish(wait=True)
+
+    return logic.get_publish_report()
+
+
 def has_trait_representations(
         instance: pyblish.api.Instance) -> bool:
     """Check if instance has trait representation.

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -20,7 +20,6 @@ from ayon_api import (
     get_last_version_by_product_name
 )
 import clique
-import pyblish.util
 import pyblish.plugin
 import pyblish.api
 

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -27,13 +27,11 @@ from .report import (
 )
 if typing.TYPE_CHECKING:
     from ayon_core.pipeline.create import CreateContext
+    from .typing import PluginType, ActionType
 
 # Define constant for plugin orders offset
 PLUGIN_ORDER_OFFSET = 0.5
 VALIDATION_ORDER: float = pyblish.api.ValidatorOrder + PLUGIN_ORDER_OFFSET
-# The pyblish logic is working with classes, not with objects
-PluginType = Type[pyblish.api.Plugin]
-ActionType = Type[pyblish.api.Action]
 
 
 class MessageHandler(logging.Handler):

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -360,6 +360,7 @@ class PublishLogic:
 
         self._publish_plugins: list[PluginType] = []
         self._publish_plugins_by_id: dict[str, PluginType] = {}
+        self._publish_plugins_by_name: dict[str, PluginType] = {}
 
         # pyblish.api.Context
         self._publish_context: pyblish.api.Context = pyblish.api.Context()
@@ -430,6 +431,11 @@ class PublishLogic:
         self, plugin_id: str
     ) -> PluginType | None:
         return self._publish_plugins_by_id.get(plugin_id)
+
+    def get_publish_plugin_by_name(
+        self, plugin_name: str
+    ) -> PluginType | None:
+        return self._publish_plugins_by_name.get(plugin_name)
 
     def set_log_to_console(self, value: bool) -> None:
         """Set whether to log to console."""
@@ -668,7 +674,10 @@ class PublishLogic:
         action: ActionType | str,
     ) -> PublishActionResult:
         if isinstance(plugin, str):
-            plugin = self._publish_plugins_by_id[plugin]
+            _plugin = self._publish_plugins_by_id.get(plugin)
+            if _plugin is None:
+                _plugin = self._publish_plugins_by_name[plugin]
+            plugin = _plugin
 
         if isinstance(action, str):
             action_id = action
@@ -787,6 +796,10 @@ class PublishLogic:
         self._publish_plugins = plugins_by_targets
         self._publish_plugins_by_id = {
             self.get_publish_plugin_id(plugin): plugin
+            for plugin in plugins_by_targets
+        }
+        self._publish_plugins_by_name = {
+            plugin.__name__: plugin
             for plugin in plugins_by_targets
         }
         strict_validation_error_handling = (

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -156,7 +156,7 @@ class PublishErrorInfo:
 def collect_families_from_instances(
     instances: list[pyblish.api.Instance],
     only_active: bool = False,
-) -> list[str]:
+) -> set[str]:
     """Collect all families for passed publish instances.
 
     Args:
@@ -165,7 +165,7 @@ def collect_families_from_instances(
         only_active (bool): Return families only for active instances.
 
     Returns:
-        list[str]: Families available on instances.
+        set[str]: Families available on instances.
 
     """
     all_families = set()
@@ -181,7 +181,7 @@ def collect_families_from_instances(
         for family in families:
             all_families.add(family)
 
-    return list(all_families)
+    return all_families
 
 
 class PublishFailReason(Enum):
@@ -189,7 +189,7 @@ class PublishFailReason(Enum):
 
     Attributes:
         No - Publishing did not fail.
-        BlockingPaths - Strict valodation of crashed publish plugin paths
+        BlockingPaths - Strict validation of crashed publish plugin paths
             during discovery.
         ValidationErrors - Publishing failed because of validation errors.
         Error - An error happened during publishing.

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -205,7 +205,7 @@ class PublishFailReason(Enum):
 class PublishState:
     """Keep state of PublishLogic at one place."""
     # Publishing should stop at validation stage
-    up_validation: bool = False
+    stop_after_validation: bool = False
     # 'PublishValidationError' won't stop the publishing until the end of
     #   the validation order if set to 'False'. Other exceptions will stop
     #   the publishing.
@@ -257,7 +257,7 @@ class PublishState:
 
         # Stop if validation is over and validation errors happened
         #   or publishing should stop at validation
-        if self.validated and self.up_validation:
+        if self.validated and self.stop_after_validation:
             return True
         return False
 
@@ -497,7 +497,7 @@ class PublishLogic:
         # Everything is ok so try to get new processing item
         return next(self._main_thread_iter)
 
-    def get_publish_up_validation(self) -> bool:
+    def get_stop_after_validation(self) -> bool:
         """Check if publishing will stop after validation.
 
         Returns:
@@ -505,16 +505,16 @@ class PublishLogic:
                 False otherwise.
 
         """
-        return self._publish_state.up_validation
+        return self._publish_state.stop_after_validation
 
-    def set_publish_up_validation(self, value: bool) -> None:
+    def set_stop_after_validation(self, value: bool) -> None:
         """Publishing will stop after validation.
 
         Args:
             value (bool): If True, publishing will stop after validation.
 
         """
-        self._publish_state.up_validation = value
+        self._publish_state.stop_after_validation = value
 
     def set_strict_validation_error_handling(self, value: bool) -> None:
         """Set strict validation error handling.
@@ -846,7 +846,7 @@ class PublishLogic:
             ):
                 self._publish_state.validated = True
                 if (
-                    self._publish_state.up_validation
+                    self._publish_state.stop_after_validation
                     or self.has_validation_errors()
                 ):
                     yield PublishIterInfo(self, PublishIterAction.Stop)

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -288,8 +288,10 @@ class PublishIterInfo:
     plugin: PluginType
     instance: pyblish.api.Instance | None
     item_label: str
+    executed: bool = False
 
     def __call__(self) -> None:
+        self.executed = True
         self.logic._process_plugin(self.plugin, self.instance)
 
 
@@ -475,7 +477,13 @@ class PublishLogic:
             info()
 
     def publish_iter(self) -> Generator[PublishIterInfo, None, None]:
-        """Publish iteration generator."""
+        """Publish iteration generator.
+
+        Yields:
+            PublishIterInfo: Information about next processing function in
+                publishing. Can be called to process the next function.
+
+        """
         self._publish_state.is_running = True
         self._publish_state.started = True
         for item in self._publish_iterator:
@@ -815,6 +823,10 @@ class PublishLogic:
             None: If publishing should stop, yields None to indicate
                 that publishing should stop.
 
+        Raises:
+            ValueError: If a previous item did not execute and the next one
+                was requested.
+
         """
         for idx, plugin in enumerate(self._publish_plugins):
             if self._publish_state.should_stop():
@@ -870,12 +882,17 @@ class PublishLogic:
                         instance.data.get("label")
                         or instance.data["name"]
                     )
-                    yield PublishIterInfo(
+                    info = PublishIterInfo(
                         self,
                         plugin,
                         instance,
                         item_label,
                     )
+                    yield info
+
+                    if not info.executed:
+                        raise ValueError("Previous item did not execute")
+
             else:
                 families = collect_families_from_instances(
                     self._pyblish_context, only_active=True
@@ -892,12 +909,15 @@ class PublishLogic:
                     or self._pyblish_context.data.get("name")
                     or "Context"
                 )
-                yield PublishIterInfo(
+                item = PublishIterInfo(
                     self,
                     plugin,
                     None,
                     item_label,
                 )
+                yield item
+                if not item.executed:
+                    raise ValueError("Previous item did not execute")
 
             self._publish_report.set_plugin_passed(plugin_id)
 

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -234,8 +234,8 @@ class PublishState:
     def can_continue(self) -> bool:
         """Check if publishing can continue.
 
-        Does not respect 'is_running' value as this should tell if it can be
-            continued even though is currently paused.
+        Does not respect 'is_running' and 'stop_after_validation' values
+            as this should tell if publishing can be continued.
 
         Returns:
             bool: Can publishing continue.
@@ -254,6 +254,7 @@ class PublishState:
         return False
 
     def should_stop(self) -> bool:
+        """Check if publishing should stop."""
         if not self.can_continue():
             return True
 
@@ -265,7 +266,7 @@ class PublishState:
 
 
 @dataclass
-class PublishIterInfo:
+class PublishIterTask:
     """Information about next processing function in publishing.
 
     Holds reference to PublishLogic that defined the next processing function.
@@ -297,7 +298,7 @@ class PublishIterInfo:
 
 
 if typing.TYPE_CHECKING:
-    PublishIterGen = Generator[PublishIterInfo | None, None, None]
+    PublishIterGen = Generator[PublishIterTask | None, None, None]
 
 
 @dataclass
@@ -344,13 +345,13 @@ class _PublishIterator:
     def __iter__(self):
         return self
 
-    def __next__(self) -> PublishIterInfo:
+    def __next__(self) -> PublishIterTask:
         if self._iter is None:
             raise StopIteration
 
-        for item in self._iter:
-            if item is not None:
-                return item
+        for task in self._iter:
+            if task is not None:
+                return task
             raise StopIteration
         raise StopIteration
 
@@ -532,18 +533,18 @@ class PublishLogic:
         for info in self.publish_iter():
             info()
 
-    def publish_iter(self) -> Generator[PublishIterInfo, None, None]:
+    def publish_iter(self) -> Generator[PublishIterTask, None, None]:
         """Publish iteration generator.
 
         Yields:
-            PublishIterInfo: Information about next processing function in
+            PublishIterTask: Information about next processing function in
                 publishing. Can be called to process the next function.
 
         """
         self._publish_state.is_running = True
         self._publish_state.started = True
-        for item in self._publish_iterator:
-            yield item
+        for task in self._publish_iterator:
+            yield task
 
     def get_stop_after_validation(self) -> bool:
         """Check if publishing will stop after validation.
@@ -893,7 +894,7 @@ class PublishLogic:
     def _inner_publish_iter(self) -> PublishIterGen:
         """Main logic center of publishing.
 
-        Iterator returns `PublishIterInfo` objects with callbacks that should
+        Iterator returns `PublishIterTask` objects with callbacks that should
         be processed in main thread (threaded in future?). Cares about
         changing states of currently processed publish plugin and instance.
         Also change state of processed orders like validation order
@@ -902,7 +903,7 @@ class PublishLogic:
         Also stops publishing, if should stop on validation.
 
         Yields:
-            PublishIterInfo: Information about next processing function in
+            PublishIterTask: Information about next processing function in
                 publishing.
             None: If publishing should stop, yields None to indicate
                 that publishing should stop.
@@ -966,16 +967,16 @@ class PublishLogic:
                         instance.data.get("label")
                         or instance.data["name"]
                     )
-                    info = PublishIterInfo(
+                    task = PublishIterTask(
                         self,
                         plugin,
                         instance,
                         item_label,
                     )
-                    yield info
+                    yield task
 
-                    if not info.executed:
-                        raise ValueError("Previous item did not execute")
+                    if not task.executed:
+                        raise ValueError("Previous task did not execute")
 
             else:
                 families = collect_families_from_instances(
@@ -993,15 +994,15 @@ class PublishLogic:
                     or self._pyblish_context.data.get("name")
                     or "Context"
                 )
-                item = PublishIterInfo(
+                task = PublishIterTask(
                     self,
                     plugin,
                     None,
                     item_label,
                 )
-                yield item
-                if not item.executed:
-                    raise ValueError("Previous item did not execute")
+                yield task
+                if not task.executed:
+                    raise ValueError("Previous task did not execute")
 
             self._publish_report.set_plugin_passed(plugin_id)
 

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -363,7 +363,7 @@ class PublishLogic:
         self._publish_plugins_by_name: dict[str, PluginType] = {}
 
         # pyblish.api.Context
-        self._publish_context: pyblish.api.Context = pyblish.api.Context()
+        self._pyblish_context: pyblish.api.Context = pyblish.api.Context()
         # Pyblish report
         self._publish_report: PublishReportMaker = PublishReportMaker()
 
@@ -426,6 +426,11 @@ class PublishLogic:
 
         """
         return plugin.id
+
+    def get_pyblish_context(self) -> pyblish.api.Context:
+        return self._pyblish_context
+
+    pyblish_context: pyblish.api.Context = property(get_pyblish_context)
 
     def get_publish_plugin_by_id(
         self, plugin_id: str
@@ -593,7 +598,7 @@ class PublishLogic:
 
     def get_publish_report(self) -> PublishReport:
         """Extract report for current state of publishing."""
-        self._publish_report.update_publish_instances(self._publish_context)
+        self._publish_report.update_publish_instances(self._pyblish_context)
         return self._publish_report.get_report()
 
     def get_publish_report_data(self) -> dict[str, Any]:
@@ -650,7 +655,7 @@ class PublishLogic:
         # Ignore change of comment when publishing started
         if self._publish_state.started:
             return
-        self._publish_context.data["comment"] = comment
+        self._pyblish_context.data["comment"] = comment
         self._publish_state.comment_is_set = True
 
     @staticmethod
@@ -693,7 +698,7 @@ class PublishLogic:
                 )
 
         result = pyblish.plugin.process(
-            plugin, self._publish_context, None, action.id
+            plugin, self._pyblish_context, None, action.id
         )
         self._publish_report.add_action_result(action, result)
 
@@ -792,7 +797,7 @@ class PublishLogic:
                     self.get_publish_plugin_id(plugin)
                 )
 
-        self._publish_context = publish_context
+        self._pyblish_context = publish_context
         self._publish_plugins = plugins_by_targets
         self._publish_plugins_by_id = {
             self.get_publish_plugin_id(plugin): plugin
@@ -858,7 +863,7 @@ class PublishLogic:
 
             # Add plugin to publish report
             self._publish_report.add_plugin_iter(
-                plugin_id, self._publish_context
+                plugin_id, self._pyblish_context
             )
 
             # Check if plugin should be skipped because is not enabled
@@ -870,7 +875,7 @@ class PublishLogic:
             # Plugin is instance plugin
             if plugin.__instanceEnabled__:
                 instances = pyblish.logic.instances_by_plugin(
-                    self._publish_context, plugin
+                    self._pyblish_context, plugin
                 )
                 if not instances:
                     self._publish_report.set_plugin_skipped(plugin_id)
@@ -893,7 +898,7 @@ class PublishLogic:
                     )
             else:
                 families = collect_families_from_instances(
-                    self._publish_context, only_active=True
+                    self._pyblish_context, only_active=True
                 )
                 plugins = pyblish.logic.plugins_by_families(
                     [plugin], families
@@ -903,8 +908,8 @@ class PublishLogic:
                     continue
 
                 item_label = (
-                    self._publish_context.data.get("label")
-                    or self._publish_context.data.get("name")
+                    self._pyblish_context.data.get("label")
+                    or self._pyblish_context.data.get("name")
                     or "Context"
                 )
                 yield PublishIterInfo(
@@ -952,7 +957,7 @@ class PublishLogic:
         plugin_id = self.get_publish_plugin_id(plugin)
         with self._log_manager(plugin) as log_handler:
             result = pyblish.plugin.process(
-                plugin, self._publish_context, instance
+                plugin, self._pyblish_context, instance
             )
             if log_handler is not None:
                 records = log_handler.get_records()

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -6,7 +6,7 @@ from enum import auto, Enum
 import inspect
 import logging
 import typing
-from typing import Any, Iterable, Generator, Type
+from typing import Any, Iterable, Generator
 
 import pyblish.api
 import pyblish.logic

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -212,9 +212,9 @@ class PublishState:
     strict_validation_error_handling: bool = True
     comment_is_set: bool = False
 
-    # Publishing sarted
+    # Publishing started -> can prevent some actions
     started: bool = False
-    # Publishing is in progress
+    # Publishing is in progress -> can be used to stop/pause publishing
     is_running: bool = False
     # Publishing is over validation order
     validated: bool = False
@@ -233,7 +233,8 @@ class PublishState:
     def can_continue(self) -> bool:
         """Check if publishing can continue.
 
-        This does not check if publishing should stop at validation stage.
+        Does not respect 'is_running' value as this should tell if it can be
+            continued even though is currently paused.
 
         Returns:
             bool: Can publishing continue.
@@ -262,11 +263,6 @@ class PublishState:
         return False
 
 
-class PublishIterAction(Enum):
-    Stop = auto()
-    Continue = auto()
-
-
 @dataclass
 class PublishIterInfo:
     """Information about next processing function in publishing.
@@ -277,34 +273,28 @@ class PublishIterInfo:
         currently processed plugin and instance, also has to trigger the
         process in between UI updates, but in main thread.
 
-    Attributes 'plugin', 'instance' and 'item_label' are set only if 'action'
-        is set to 'PublishIterAction.Continue'.
+    Attributes 'plugin', 'instance' and 'item_label'.
 
     Attributes:
         logic (PublishLogic): PublishLogic that defined the next processing
             function.
-        action (PublishIterAction): Action to be performed.
-        plugin (PluginType | None): Currently processed plugin.
+        plugin (PluginType): Currently processed plugin.
         instance (pyblish.api.Instance | None): Currently processed instance.
-        item_label (str | None): Label of currently processed item. Can be
+        item_label (str): Label of currently processed item. Can be
             plugin or instance label.
 
     """
     logic: "PublishLogic"
-    action: PublishIterAction
-    plugin: PluginType | None = None
-    instance: pyblish.api.Instance | None = None
-    item_label: str | None = None
+    plugin: PluginType
+    instance: pyblish.api.Instance | None
+    item_label: str
 
-    def __call__(self):
-        if self.action == PublishIterAction.Stop:
-            self.logic.stop_publish()
-            return
-
-        if self.plugin is None:
-            raise ValueError("Plugin is None but action is Continue")
-
+    def __call__(self) -> None:
         self.logic._process_plugin(self.plugin, self.instance)
+
+
+if typing.TYPE_CHECKING:
+    PublishIterGen = Generator[PublishIterInfo | None, None, None]
 
 
 @dataclass
@@ -340,6 +330,33 @@ class PublishActionResult:
 #     return any(host in plugin.hosts for host in hosts)
 
 
+class _PublishIterator:
+    """Iterator for PublishLogic.
+
+    Allows to "pause" iteration and continue later.
+    """
+    def __init__(self) -> None:
+        self._iter: PublishIterGen | None = None
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> PublishIterInfo:
+        if self._iter is None:
+            raise StopIteration
+
+        for item in self._iter:
+            if item is not None:
+                return item
+            raise StopIteration
+        raise StopIteration
+
+    def update_iter(
+        self, publish_iter: PublishIterGen
+    ) -> None:
+        self._iter = publish_iter
+
+
 class PublishLogic:
     """Wrapper for publising logic.
 
@@ -364,9 +381,7 @@ class PublishLogic:
         self._publish_report: PublishReportMaker = PublishReportMaker()
 
         # Plugin iterator
-        self._main_thread_iter: Generator[PublishIterInfo, None, None] = (
-            self._default_iterator()
-        )
+        self._publish_iterator: _PublishIterator = _PublishIterator()
 
     def reset(
         self,
@@ -455,47 +470,16 @@ class PublishLogic:
         """
         yield from self._publish_plugins
 
-    def start_publish(self, wait: bool = True) -> None:
-        """Run publishing.
+    def publish(self) -> None:
+        for info in self.publish_iter():
+            info()
 
-        Make sure all changes are saved before method is called (Call
-        'save_changes' and check output).
-        """
-        if self._publish_state.is_running:
-            return
-
-        if self._publish_state.should_stop():
-            return
-
+    def publish_iter(self) -> Generator[PublishIterInfo, None, None]:
+        """Publish iteration generator."""
         self._publish_state.is_running = True
         self._publish_state.started = True
-
-        if wait:
-            while self.is_running():
-                func = self.get_next_process_func()
-                func()
-
-    def get_next_process_func(self) -> PublishIterInfo:
-        """Get the next processing function to execute with some metadata.
-
-        Returns:
-            PublishIterInfo: Information about the next processing function.
-                Can be used as function.
-
-        Raises:
-            ValueError: If publishing is not running.
-
-        """
-        # Raise error if this function is called when publishing
-        #   is not running
-        if not self._publish_state.is_running:
-            raise ValueError("Publish is not running")
-
-        if self._publish_state.should_stop():
-            return PublishIterInfo(self, PublishIterAction.Stop)
-
-        # Everything is ok so try to get new processing item
-        return next(self._main_thread_iter)
+        for item in self._publish_iterator:
+            yield item
 
     def get_stop_after_validation(self) -> bool:
         """Check if publishing will stop after validation.
@@ -812,22 +796,9 @@ class PublishLogic:
         if blocking_crashed_paths:
             self._publish_state.fail_reason = PublishFailReason.BlockingPaths
 
-        self._main_thread_iter = self._publish_iterator()
+        self._publish_iterator.update_iter(self._inner_publish_iter())
 
-    def _default_iterator(self) -> Generator[PublishIterInfo, None, None]:
-        """Iterator used on initialization.
-
-        Should be replaced by real iterator when 'reset' is called.
-
-        Returns:
-            collections.abc.Generator[PublishIterInfo]: Generator with partial
-                functions that should be called in main thread.
-
-        """
-        while True:
-            yield PublishIterInfo(self, PublishIterAction.Stop)
-
-    def _publish_iterator(self) -> Generator[PublishIterInfo, None, None]:
+    def _inner_publish_iter(self) -> PublishIterGen:
         """Main logic center of publishing.
 
         Iterator returns `PublishIterInfo` objects with callbacks that should
@@ -837,9 +808,21 @@ class PublishLogic:
         has passed etc.
 
         Also stops publishing, if should stop on validation.
-        """
 
+        Yields:
+            PublishIterInfo: Information about next processing function in
+                publishing.
+            None: If publishing should stop, yields None to indicate
+                that publishing should stop.
+
+        """
         for idx, plugin in enumerate(self._publish_plugins):
+            if self._publish_state.should_stop():
+                self.stop_publish()
+
+            while not self.is_running():
+                yield None
+
             plugin_id = self.get_publish_plugin_id(plugin)
             self._publish_state.progress = idx
 
@@ -853,7 +836,8 @@ class PublishLogic:
                     self._publish_state.stop_after_validation
                     or self.has_validation_errors()
                 ):
-                    yield PublishIterInfo(self, PublishIterAction.Stop)
+                    self.stop_publish()
+                    yield None
 
             # Add plugin to publish report
             self._publish_report.add_plugin_iter(
@@ -876,6 +860,9 @@ class PublishLogic:
                     continue
 
                 for instance in instances:
+                    while not self.is_running():
+                        yield None
+
                     if instance.data.get("publish") is False:
                         continue
 
@@ -885,7 +872,6 @@ class PublishLogic:
                     )
                     yield PublishIterInfo(
                         self,
-                        PublishIterAction.Continue,
                         plugin,
                         instance,
                         item_label,
@@ -908,7 +894,6 @@ class PublishLogic:
                 )
                 yield PublishIterInfo(
                     self,
-                    PublishIterAction.Continue,
                     plugin,
                     None,
                     item_label,
@@ -920,7 +905,9 @@ class PublishLogic:
         self._publish_state.finished = True
         self._publish_state.progress = self._publish_state.max_progress
 
-        yield PublishIterInfo(self, PublishIterAction.Stop)
+        self.stop_publish()
+        while True:
+            yield None
 
     @contextmanager
     def _log_manager(self, plugin: PluginType):

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -242,18 +242,14 @@ class PublishState:
         if self.finished:
             return False
 
+        if self.fail_reason == PublishFailReason.No:
+            return True
+
         if self.fail_reason == PublishFailReason.ValidationErrors:
             if self.strict_validation_error_handling or self.validated:
                 return False
             return True
-
-        if self.fail_reason in (
-            PublishFailReason.Error,
-            PublishFailReason.BlockingPaths
-        ):
-            return False
-
-        return True
+        return False
 
     def should_stop(self) -> bool:
         if not self.can_continue():

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -650,7 +650,9 @@ class PublishLogic:
     def set_comment(self, comment: str) -> None:
         # Ignore change of comment when publishing started
         if self._publish_state.started:
-            return
+            raise ValueError(
+                "Cannot change comment when publishing started."
+            )
         self._pyblish_context.data["comment"] = comment
         self._publish_state.comment_is_set = True
 

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -1,20 +1,17 @@
 from __future__ import annotations
 
-import collections
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import auto, Enum
 import inspect
 import logging
 import typing
-from typing import Any, Iterable, Generator
-import uuid
+from typing import Any, Iterable, Generator, Type
 
 import pyblish.api
 import pyblish.logic
 import pyblish.plugin
 
-from ayon_core.lib import env_value_to_bool
 from ayon_core.settings import get_project_settings
 from ayon_core.pipeline.plugin_discover import DiscoverResult
 
@@ -22,7 +19,6 @@ from .lib import filter_crashed_publish_paths, publish_plugins_discover
 from .publish_plugins import (
     PublishError,
     PublishValidationError,
-    KnownPublishError,
     OptionalPyblishPluginMixin,
 )
 from .report import (
@@ -34,10 +30,33 @@ if typing.TYPE_CHECKING:
 
 # Define constant for plugin orders offset
 PLUGIN_ORDER_OFFSET = 0.5
-VALIDATION_ORDER: int = pyblish.api.ValidatorOrder + PLUGIN_ORDER_OFFSET
+VALIDATION_ORDER: float = pyblish.api.ValidatorOrder + PLUGIN_ORDER_OFFSET
+# The pyblish logic is working with classes, not with objects
+PluginType = Type[pyblish.api.Plugin]
+ActionType = Type[pyblish.api.Action]
 
 
 class MessageHandler(logging.Handler):
+    """Helper to collect log records during publishing.
+
+    This is used to collect log records during publishing and store them in
+        a list. The list can be cleared and retrieved as needed.
+
+    This is needed to create the log message at the moment of their emit. The
+        fill data may change during publishing and stored records might not
+        reflect data at the moment of their emit.
+
+    ```python
+    data = {"key": 1}
+    log.info("Data: %s", data)
+    data["key"] = 2
+    log.info("Data: %s", data)
+    ```
+    Without the handle would this code snippet product 2 records:
+    - 'Data: {"key": 1}' -> But this should be 'Data: {"key": 2}'
+    - 'Data: {"key": 1}'
+
+    """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._records = []
@@ -56,224 +75,8 @@ class MessageHandler(logging.Handler):
         return self._records
 
 
+@dataclass
 class PublishErrorInfo:
-    def __init__(
-        self,
-        message: str,
-        is_unknown_error: bool,
-        description: str | None = None,
-        title: str | None = None,
-        detail: str | None = None,
-    ):
-        self.message: str = message
-        self.is_unknown_error = is_unknown_error
-        self.description: str = description or message
-        self.title: str = title or "Unknown error"
-        self.detail: str | None = detail
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, PublishErrorInfo):
-            return False
-        return (
-            self.description == other.description
-            and self.is_unknown_error == other.is_unknown_error
-            and self.title == other.title
-            and self.detail == other.detail
-        )
-
-    def __ne__(self, other: Any) -> bool:
-        return not self.__eq__(other)
-
-    @classmethod
-    def from_exception(cls, exc) -> "PublishErrorInfo":
-        if isinstance(exc, PublishError):
-            return cls(
-                exc.message,
-                False,
-                exc.description,
-                title=exc.title,
-                detail=exc.detail,
-            )
-        if isinstance(exc, KnownPublishError):
-            msg = str(exc)
-        else:
-            msg = (
-                "Something went wrong. Send report"
-                " to your supervisor or Ynput team."
-            )
-        return cls(msg, True)
-
-
-class PublishPluginActionItem:
-    """Representation of publish plugin action.
-
-    Data driven object which is used as proxy for controller and UI.
-
-    Args:
-        action_id (str): Action id.
-        plugin_id (str): Plugin id.
-        active (bool): Action is active.
-        on_filter (Literal["all", "notProcessed", "processed", "failed",
-            "warning", "failedOrWarning", "succeeded"]): Actions have 'on'
-            attribute which define  when can be action triggered
-            (e.g. 'all', 'failed', ...).
-        label (str): Action's label.
-        icon (str | None) Action's icon.
-    """
-
-    def __init__(
-        self,
-        action_id: str,
-        plugin_id: str,
-        active: bool,
-        on_filter: str,
-        label: str,
-        icon: str | None,
-    ):
-        self.action_id: str = action_id
-        self.plugin_id: str = plugin_id
-        self.active: bool = active
-        self.on_filter: str = on_filter
-        self.label: str = label
-        self.icon: str | None = icon
-
-    def to_data(self) -> dict[str, str | bool | None]:
-        """Serialize object to dictionary.
-
-        Returns:
-            dict[str, str | bool | None]: Serialized object.
-
-        """
-        return {
-            "action_id": self.action_id,
-            "plugin_id": self.plugin_id,
-            "active": self.active,
-            "on_filter": self.on_filter,
-            "label": self.label,
-            "icon": self.icon
-        }
-
-    @classmethod
-    def from_data(
-        cls, data: dict[str, str | bool | None]
-    ) -> "PublishPluginActionItem":
-        """Create object from data.
-
-        Args:
-            data (dict[str, str | bool | None]): Data used to recreate
-                object.
-
-        Returns:
-            PublishPluginActionItem: Object created using data.
-        """
-
-        return cls(**data)
-
-
-class PublishPluginsProxy:
-    """Wrapper around publish plugin.
-
-    Prepare mapping for publish plugins and actions. Also can create
-    serializable data for plugin actions for UI purposes.
-
-    This object is created in process where publishing is actually running.
-
-    Notes:
-        Actions have id but single action can be used on multiple plugins so
-            to run an action is needed combination of plugin and action.
-
-    Args:
-        plugins [list[pyblish.api.Plugin]]: Discovered plugins that will be
-            processed.
-    """
-
-    def __init__(self, plugins: list[pyblish.api.Plugin]):
-        plugins_by_id: dict[str, pyblish.api.Plugin] = {}
-        actions_by_plugin_id: dict[str, dict[str, pyblish.api.Action]] = {}
-        action_ids_by_plugin_id: dict[str, list[str]] = {}
-        for plugin in plugins:
-            plugin_id = plugin.id
-            plugins_by_id[plugin_id] = plugin
-
-            action_ids = []
-            actions_by_id = {}
-            action_ids_by_plugin_id[plugin_id] = action_ids
-            actions_by_plugin_id[plugin_id] = actions_by_id
-
-            actions = getattr(plugin, "actions", None) or []
-            for action in actions:
-                action_id = action.id
-                action_ids.append(action_id)
-                actions_by_id[action_id] = action
-
-        self._plugins_by_id: dict[str, pyblish.api.Plugin] = plugins_by_id
-        self._actions_by_plugin_id: dict[
-            str, dict[str, pyblish.api.Action]
-        ] = actions_by_plugin_id
-        self._action_ids_by_plugin_id: dict[str, list[str]] = (
-            action_ids_by_plugin_id
-        )
-
-    def get_action(
-        self, plugin_id: str, action_id: str
-    ) -> pyblish.api.Action:
-        return self._actions_by_plugin_id[plugin_id][action_id]
-
-    def get_plugin(self, plugin_id: str) -> pyblish.api.Plugin:
-        return self._plugins_by_id[plugin_id]
-
-    @staticmethod
-    def get_plugin_id(plugin: pyblish.api.Plugin) -> str:
-        """Get id of plugin based on plugin object.
-
-        It's used for validation errors report.
-
-        Args:
-            plugin (pyblish.api.Plugin): Publish plugin for which id should be
-                returned.
-
-        Returns:
-            str: Plugin id.
-        """
-
-        return plugin.id
-
-    def get_plugin_action_items(
-        self, plugin_id: str
-    ) -> list[PublishPluginActionItem]:
-        """Get plugin action items for plugin by its id.
-
-        Args:
-            plugin_id (str): Publish plugin id.
-
-        Returns:
-            list[PublishPluginActionItem]: Items with information about publish
-                plugin actions.
-        """
-
-        return [
-            self._create_action_item(
-                self.get_action(plugin_id, action_id), plugin_id
-            )
-            for action_id in self._action_ids_by_plugin_id[plugin_id]
-        ]
-
-    def _create_action_item(
-        self, action: pyblish.api.Action, plugin_id: str
-    ) -> PublishPluginActionItem:
-        label = action.label or action.__name__
-        icon = getattr(action, "icon", None)
-        return PublishPluginActionItem(
-            action.id,
-            plugin_id,
-            action.active,
-            action.on,
-            label,
-            icon
-        )
-
-
-class PublishErrorItem:
     """Data driven publish error item.
 
     Prepared data container with information about publish error and it's
@@ -282,285 +85,74 @@ class PublishErrorItem:
     Can be converted to raw data and recreated should be used for controller
     and UI connection.
 
-    Args:
+    Attributes:
+        exception (Exception): The exception that caused the publish error.
         instance_id (str | None): Pyblish instance id to which is
             publish error connected.
         instance_label (str | None): Prepared instance label.
         plugin_id (str): Pyblish plugin id which triggered the publish
-            error. Id is generated using 'PublishPluginsProxy'.
+            error.
         is_context_plugin (bool): Error happened on context.
-        title (str): Error title.
-        description (str): Error description.
+        is_validation_error (bool): Error is a validation error.
+        title (str | None): Error title.
+        description (str | None): Error description.
         detail (str): Error detail.
 
     """
-    def __init__(
-        self,
-        instance_id: str | None,
-        instance_label: str | None,
-        plugin_id: str,
-        is_context_plugin: bool,
-        is_validation_error: bool,
-        title: str | None,
-        description: str | None,
-        detail: str
-    ):
-        self.instance_id: str | None = instance_id
-        self.instance_label: str | None = instance_label
-        self.plugin_id: str = plugin_id
-        self.is_context_plugin: bool = is_context_plugin
-        self.is_validation_error: bool = is_validation_error
-        self.title: str | None = title
-        self.description: str | None = description
-        self.detail: str = detail
+    exception: Exception
+    instance_id: str | None
+    instance_label: str | None
+    plugin_id: str
+    is_context_plugin: bool
+    is_validation_error: bool
+    title: str | None
+    description: str | None
+    detail: str | None
 
     @classmethod
     def from_result(
         cls,
-        plugin_id: str,
-        error: PublishError,
-        instance: pyblish.api.Instance | None
-    ):
-        """Create new object based on resukt from controller.
+        plugin: PluginType,
+        instance: pyblish.api.Instance | None,
+        exception: Exception,
+    ) -> "PublishErrorInfo":
+        """Hold information about publishing error.
 
         Returns:
-            PublishErrorItem: New object with filled data.
-        """
+            PublishErrorInfo: New object with filled data.
 
-        instance_label = None
-        instance_id = None
+        """
+        plugin_id = PublishLogic.get_publish_plugin_id(plugin)
+        instance_label = instance_id = title = description = detail = None
         if instance is not None:
             instance_label = (
                 instance.data.get("label") or instance.data.get("name")
             )
             instance_id = instance.id
 
-        return cls(
-            instance_id,
-            instance_label,
-            plugin_id,
-            instance is None,
-            isinstance(error, PublishValidationError),
-            error.title,
-            error.description,
-            error.detail,
-        )
+        if isinstance(exception, PublishError):
+            title = exception.title
+            description = exception.description
+            detail = exception.detail
 
-    def to_data(self) -> dict[str, str | bool | None]:
-        """Serialize object to dictionary.
-
-        Returns:
-            dict[str, str | bool | None]: Serialized object data.
-
-        """
-        return {
-            "instance_id": self.instance_id,
-            "instance_label": self.instance_label,
-            "plugin_id": self.plugin_id,
-            "is_context_plugin": self.is_context_plugin,
-            "is_validation_error": self.is_validation_error,
-            "title": self.title,
-            "description": self.description,
-            "detail": self.detail,
-        }
-
-    @classmethod
-    def from_data(cls, data):
-        return cls(**data)
-
-
-class PublishErrorsReport:
-    """Publish errors report that can be parsed to raw data.
-
-    Args:
-        error_items (list[PublishErrorItem]): List of publish errors.
-        plugin_action_items (dict[str, list[PublishPluginActionItem]]): Action
-            items by plugin id.
-
-    """
-    def __init__(
-        self,
-        error_items: list[PublishErrorItem],
-        plugin_action_items: dict[str, list[PublishPluginActionItem]],
-    ):
-        self._error_items = error_items
-        self._plugin_action_items = plugin_action_items
-
-    def __iter__(self) -> Iterable[PublishErrorItem]:
-        for item in self._error_items:
-            yield item
-
-    def group_items_by_title(self) -> list[dict[str, Any]]:
-        """Group errors by plugin and their titles.
-
-        Items are grouped by plugin and title -> same title from different
-        plugin is different item. Items are ordered by plugin order.
-
-        Returns:
-            list[dict[str, Any]]: List where each item title, instance
-                information related to title and possible plugin actions.
-        """
-
-        ordered_plugin_ids = []
-        error_items_by_plugin_id = collections.defaultdict(list)
-        for error_item in self._error_items:
-            plugin_id = error_item.plugin_id
-            if plugin_id not in ordered_plugin_ids:
-                ordered_plugin_ids.append(plugin_id)
-            error_items_by_plugin_id[plugin_id].append(error_item)
-
-        grouped_error_items = []
-        for plugin_id in ordered_plugin_ids:
-            plugin_action_items = self._plugin_action_items[plugin_id]
-            error_items = error_items_by_plugin_id[plugin_id]
-
-            titles = []
-            error_items_by_title = collections.defaultdict(list)
-            for error_item in error_items:
-                title = error_item.title
-                if title not in titles:
-                    titles.append(error_item.title)
-                error_items_by_title[title].append(error_item)
-
-            for title in titles:
-                grouped_error_items.append({
-                    "id": uuid.uuid4().hex,
-                    "plugin_id": plugin_id,
-                    "plugin_action_items": list(plugin_action_items),
-                    "error_items": error_items_by_title[title],
-                    "title": title
-                })
-        return grouped_error_items
-
-    def to_data(self):
-        """Serialize object to dictionary.
-
-        Returns:
-            dict[str, Any]: Serialized data.
-        """
-
-        error_items = [
-            item.to_data()
-            for item in self._error_items
-        ]
-
-        plugin_action_items = {
-            plugin_id: [
-                action_item.to_data()
-                for action_item in action_items
-            ]
-            for plugin_id, action_items in self._plugin_action_items.items()
-        }
-
-        return {
-            "error_items": error_items,
-            "plugin_action_items": plugin_action_items
-        }
-
-    @classmethod
-    def from_data(
-        cls, data: dict[str, Any]
-    ) -> "PublishErrorsReport":
-        """Recreate object from data.
-
-        Args:
-            data (dict[str, Any]): Data to recreate object. Can be created
-                using 'to_data' method.
-
-        Returns:
-            PublishErrorsReport: New object based on data.
-        """
-
-        error_items = [
-            PublishErrorItem.from_data(error_item)
-            for error_item in data["error_items"]
-        ]
-        plugin_action_items = {}
-        for action_item in data["plugin_action_items"]:
-            item = PublishPluginActionItem.from_data(action_item)
-            action_items = plugin_action_items.setdefault(item.plugin_id, [])
-            action_items.append(item)
-
-        return cls(error_items, plugin_action_items)
-
-
-class PublishErrors:
-    """Object to keep track about publish errors by plugin."""
-
-    def __init__(self):
-        self._plugins_proxy: PublishPluginsProxy | None = None
-        self._error_items: list[PublishErrorItem] = []
-        self._plugin_action_items: dict[
-            str, list[PublishPluginActionItem]
-        ] = {}
-
-    def __bool__(self):
-        return self.has_errors
-
-    @property
-    def has_errors(self) -> bool:
-        """At least one error was added."""
-
-        return bool(self._error_items)
-
-    def reset(self, plugins_proxy: PublishPluginsProxy):
-        """Reset object to default state.
-
-        Args:
-            plugins_proxy (PublishPluginsProxy): Proxy which store plugins,
-                actions by ids and create mapping of action ids by plugin ids.
-        """
-
-        self._plugins_proxy = plugins_proxy
-        self._error_items = []
-        self._plugin_action_items = {}
-
-    def create_report(self) -> PublishErrorsReport:
-        """Create report based on currently existing errors.
-
-        Returns:
-            PublishErrorsReport: Publish error report with all
-                error information and publish plugin action items.
-        """
-
-        return PublishErrorsReport(
-            self._error_items, self._plugin_action_items
-        )
-
-    def add_error(
-        self,
-        plugin: pyblish.api.Plugin,
-        error: PublishError,
-        instance: pyblish.api.Instance | None
-    ):
-        """Add error from pyblish result.
-
-        Args:
-            plugin (pyblish.api.Plugin): Plugin which triggered error.
-            error (PublishError): Publish error.
-            instance (pyblish.api.Instance | None): Instance on which was
-                error raised or None if was raised on context.
-        """
-
-        # Make sure the cached report is cleared
-        plugin_id = self._plugins_proxy.get_plugin_id(plugin)
-        if not error.title:
+        if not title:
             if hasattr(plugin, "label") and plugin.label:
                 plugin_label = plugin.label
             else:
                 plugin_label = plugin.__name__
-            error.title = plugin_label
+            title = plugin_label
 
-        self._error_items.append(
-            PublishErrorItem.from_result(plugin_id, error, instance)
+        return cls(
+            exception,
+            instance_id,
+            instance_label,
+            plugin_id,
+            instance is None,
+            isinstance(exception, PublishValidationError),
+            title,
+            description,
+            detail,
         )
-        if plugin_id in self._plugin_action_items:
-            return
-
-        plugin_actions = self._plugins_proxy.get_plugin_action_items(
-            plugin_id
-        )
-        self._plugin_action_items[plugin_id] = plugin_actions
 
 
 def collect_families_from_instances(
@@ -594,49 +186,84 @@ def collect_families_from_instances(
     return list(all_families)
 
 
+class PublishFailReason(Enum):
+    """Reason why publishing failed.
+
+    Attributes:
+        No - Publishing did not fail.
+        BlockingPaths - Strict valodation of crashed publish plugin paths
+            during discovery.
+        ValidationErrors - Publishing failed because of validation errors.
+        Error - An error happened during publishing.
+
+    """
+    No = auto()
+    Error = auto()
+    ValidationErrors = auto()
+    BlockingPaths = auto()
+
+
 @dataclass
 class PublishState:
+    """Keep state of PublishLogic at one place."""
     # Publishing should stop at validation stage
     up_validation: bool = False
+    # 'PublishValidationError' won't stop the publishing until the end of
+    #   the validation order if set to 'False'. Other exceptions will stop
+    #   the publishing.
+    strict_validation_error_handling: bool = True
     comment_is_set: bool = False
 
+    # Publishing sarted
+    started: bool = False
     # Publishing is in progress
     is_running: bool = False
     # Publishing is over validation order
     validated: bool = False
-    has_validation_errors: bool = False
-    crashed: bool = False
-    started: bool = False
+    # Finished successfully
     finished: bool = False
-    max_progress: int = 0
-    progress: int = 0
 
-    # Any other exception that happened during publishing
+    progress: int = 0
+    max_progress: int = 0
+
+    fail_reason: PublishFailReason = PublishFailReason.No
     error_info: PublishErrorInfo | None = None
+    validation_errors: list[PublishErrorInfo] = field(
+        default_factory=list
+    )
 
     def can_continue(self) -> bool:
         """Check if publishing can continue.
+
+        This does not check if publishing should stop at validation stage.
 
         Returns:
             bool: Can publishing continue.
 
         """
-        return (
-            not self.crashed
-            and not self.has_validation_errors
-            and not self.finished
-        )
+        if self.finished:
+            return False
+
+        if self.fail_reason == PublishFailReason.ValidationErrors:
+            if self.strict_validation_error_handling or self.validated:
+                return False
+            return True
+
+        if self.fail_reason in (
+            PublishFailReason.Error,
+            PublishFailReason.BlockingPaths
+        ):
+            return False
+
+        return True
 
     def should_stop(self) -> bool:
-        if self.crashed:
+        if not self.can_continue():
             return True
 
         # Stop if validation is over and validation errors happened
         #   or publishing should stop at validation
-        if (
-            self.validated
-            and (self.has_validation_errors or self.up_validation)
-        ):
+        if self.validated and self.up_validation:
             return True
         return False
 
@@ -648,9 +275,30 @@ class PublishIterAction(Enum):
 
 @dataclass
 class PublishIterInfo:
+    """Information about next processing function in publishing.
+
+    Holds reference to PublishLogic that defined the next processing function.
+
+    This wrapper is needed for UI purposes as the UI has to have access to
+        currently processed plugin and instance, also has to trigger the
+        process in between UI updates, but in main thread.
+
+    Attributes 'plugin', 'instance' and 'item_label' are set only if 'action'
+        is set to 'PublishIterAction.Continue'.
+
+    Attributes:
+        logic (PublishLogic): PublishLogic that defined the next processing
+            function.
+        action (PublishIterAction): Action to be performed.
+        plugin (PluginType | None): Currently processed plugin.
+        instance (pyblish.api.Instance | None): Currently processed instance.
+        item_label (str | None): Label of currently processed item. Can be
+            plugin or instance label.
+
+    """
     logic: "PublishLogic"
     action: PublishIterAction
-    plugin: pyblish.api.Plugin | None = None
+    plugin: PluginType | None = None
     instance: pyblish.api.Instance | None = None
     item_label: str | None = None
 
@@ -667,49 +315,58 @@ class PublishIterInfo:
 
 @dataclass
 class PublishActionResult:
+    """Result of triggered action.
+
+    Attributes:
+        success (bool): Whether action was successful.
+        action (ActionType): Triggered action.
+        exception (Exception | None): Exception that happened if success is
+            'False'.
+
+    """
     success: bool
-    action: pyblish.api.Action
+    action: ActionType
     exception: Exception | None = None
 
 
-def _plugin_is_hosts_compatible(
-    plugin: pyblish.api.Plugin,
-    hosts: list[str] | set[str],
-) -> bool:
-    """Determine whether plugin is compatible with the hosts.
-
-    Arguments:
-        plugin (Plugin): Plug-in to assess.
-        hosts (list[str] | set[str]): List or set of hosts to check against.
-
-    """
-    if "*" in plugin.hosts:
-        return True
-
-    return any(host in plugin.hosts for host in hosts)
+# def _plugin_is_hosts_compatible(
+#     plugin: PluginType,
+#     hosts: list[str] | set[str],
+# ) -> bool:
+#     """Determine whether plugin is compatible with the hosts.
+#
+#     Arguments:
+#         plugin (Plugin): Plug-in to assess.
+#         hosts (list[str] | set[str]): List or set of hosts to check against.
+#
+#     """
+#     if "*" in plugin.hosts:
+#         return True
+#
+#     return any(host in plugin.hosts for host in hosts)
 
 
 class PublishLogic:
+    """Wrapper for publising logic.
+
+    This class is used to manage publishing logic. Can be used to run
+        publishing and then create publish report.
+
+    """
     def __init__(self) -> None:
         self._log_handler: MessageHandler = MessageHandler()
 
-        self._log_to_console: bool = env_value_to_bool(
-            "AYON_PUBLISHER_PRINT_LOGS", default=False
-        )
+        self._log_to_console: bool = True
 
         self._publish_state = PublishState()
 
-        self._publish_plugins: list[pyblish.api.Plugin] = []
-        self._publish_plugins_proxy: PublishPluginsProxy = (
-            PublishPluginsProxy([])
-        )
+        self._publish_plugins: list[PluginType] = []
+        self._publish_plugins_by_id: dict[str, PluginType] = {}
 
         # pyblish.api.Context
         self._publish_context: pyblish.api.Context = pyblish.api.Context()
         # Pyblish report
         self._publish_report: PublishReportMaker = PublishReportMaker()
-        # Store exceptions of publish error
-        self._publish_errors: PublishErrors = PublishErrors()
 
         # Plugin iterator
         self._main_thread_iter: Generator[PublishIterInfo] = (
@@ -720,8 +377,9 @@ class PublishLogic:
         self,
         project_name: str,
         context: pyblish.api.Context | None = None,
-        plugins: list[pyblish.api.Plugin] | None = None,
+        plugins: list[PluginType] | None = None,
         targets: list[str] | None = None,
+        create_context: CreateContext | None = None,
         publish_discover_result: DiscoverResult | None = None,
         project_settings: dict[str, Any] | None = None,
     ) -> None:
@@ -733,6 +391,7 @@ class PublishLogic:
             project_name,
             publish_context=context,
             publish_targets=targets,
+            create_context=create_context,
             publish_discover_result=publish_discover_result,
             project_settings=project_settings,
         )
@@ -753,13 +412,45 @@ class PublishLogic:
             create_context=create_context,
         )
 
-    def publish_up_validation(self) -> bool:
-        return self._publish_state.up_validation
+    @staticmethod
+    def get_publish_plugin_id(plugin: PluginType) -> str:
+        """Get id of plugin based on plugin object.
 
-    def set_publish_up_validation(self, value: bool):
-        self._publish_state.up_validation = value
+        It's used for validation errors report.
 
-    def start_publish(self, wait: bool = True):
+        Args:
+            plugin (PluginType): Publish plugin for which id should
+                be returned.
+
+        Returns:
+            str: Plugin id.
+
+        """
+        return plugin.id
+
+    def get_publish_plugin_by_id(
+        self, plugin_id: str
+    ) -> PluginType | None:
+        return self._publish_plugins_by_id.get(plugin_id)
+
+    def set_log_to_console(self, value: bool) -> None:
+        """Set whether to log to console."""
+        self._log_to_console = value
+
+    def iter_publish_plugins(self) -> Iterable[PluginType]:
+        """Iterate over publish plugins.
+
+        Give developers access to publish plugins that are used in current
+            publishing process. Can be used to change their attributes, e.g.
+            to disable them.
+
+        Returns:
+            Iterable[PluginType]: Iterable with publish plugins.
+
+        """
+        yield from self._publish_plugins
+
+    def start_publish(self, wait: bool = True) -> None:
         """Run publishing.
 
         Make sure all changes are saved before method is called (Call
@@ -780,6 +471,16 @@ class PublishLogic:
                 func()
 
     def get_next_process_func(self) -> PublishIterInfo:
+        """Get the next processing function to execute with some metadata.
+
+        Returns:
+            PublishIterInfo: Information about the next processing function.
+                Can be used as function.
+
+        Raises:
+            ValueError: If publishing is not running.
+
+        """
         # Raise error if this function is called when publishing
         #   is not running
         if not self._publish_state.is_running:
@@ -791,54 +492,155 @@ class PublishLogic:
         # Everything is ok so try to get new processing item
         return next(self._main_thread_iter)
 
+    def get_publish_up_validation(self) -> bool:
+        """Check if publishing will stop after validation.
+
+        Returns:
+            bool: True if publishing will stop after validation,
+                False otherwise.
+
+        """
+        return self._publish_state.up_validation
+
+    def set_publish_up_validation(self, value: bool) -> None:
+        """Publishing will stop after validation.
+
+        Args:
+            value (bool): If True, publishing will stop after validation.
+
+        """
+        self._publish_state.up_validation = value
+
+    def set_strict_validation_error_handling(self, value: bool) -> None:
+        """Set strict validation error handling.
+
+        Args:
+            value (bool): If True, publishing will stop after validation.
+
+        """
+        self._publish_state.strict_validation_error_handling = value
+
     def stop_publish(self) -> None:
-        if self._publish_state.is_running:
-            self._publish_state.is_running = False
+        """Mark publishing to stop on next iteration.
+
+        This is useful for UI purposes.
+        """
+        self._publish_state.is_running = False
 
     def is_running(self) -> bool:
+        """Check if publishing is currently running."""
         return self._publish_state.is_running
 
-    def has_crashed(self) -> bool:
-        return self._publish_state.crashed
-
     def has_started(self) -> bool:
+        """Check if publishing has started."""
         return self._publish_state.started
 
     def has_finished(self) -> bool:
+        """Check if publishing successfully finished."""
         return self._publish_state.finished
 
     def has_validated(self) -> bool:
+        """Validation order passed."""
         return self._publish_state.validated
 
-    def has_validation_errors(self) -> bool:
-        return self._publish_state.has_validation_errors
-
     def publish_can_continue(self) -> bool:
+        """Publishing can continue."""
         return self._publish_state.can_continue()
 
     def get_progress(self) -> int:
+        """Get current progress of publishing.
+
+        Returns:
+            int: Current progress of publishing. Value is between 0 and
+                max progress. 0 means no plugin was processed yet.
+
+        """
         return self._publish_state.progress
 
     def get_max_progress(self) -> int:
+        """Get max progress of publishing."""
         return self._publish_state.max_progress
 
+    def has_validation_errors(self) -> bool:
+        """Check if publishing has validation errors."""
+        return bool(self._publish_state.validation_errors)
+
+    def has_failed(self) -> bool:
+        """Check if publishing has failed.
+
+        It is possible that publishing even didn't start, or still can
+            continue even if publishing has crashed. Don't use this method
+            to check if publishing should be running.
+
+        Returns:
+            bool: True if publishing has crashed, False otherwise.
+
+        """
+        return self._publish_state.fail_reason != PublishFailReason.No
+
+    def get_fail_reason(self) -> PublishFailReason:
+        """Get the reason for publishing failure.
+
+        Returns:
+            PublishFailReason: The reason for publishing failure.
+
+        """
+        return self._publish_state.fail_reason
+
     def get_publish_report(self) -> PublishReport:
+        """Extract report for current state of publishing."""
         self._publish_report.update_publish_instances(self._publish_context)
         return self._publish_report.get_report()
 
     def get_publish_report_data(self) -> dict[str, Any]:
+        """Get publish report data for current state of publishing.
+
+        This method should be used if report data are being stored to a file.
+            It does mark current plugin as 'passed' for UI.
+
+        Returns:
+            dict[str, Any]: Publish report data.
+
+        """
         report: PublishReport = self.get_publish_report()
         return report.to_data(self._publish_report.current_plugin_id)
 
-    def get_publish_errors_report(self) -> PublishErrorsReport:
-        return self._publish_errors.create_report()
+    def store_publish_report(self, filepath: str) -> None:
+        """Store publish report to a file."""
+        report: PublishReport = self.get_publish_report()
+        report.store_to_file(
+            filepath,
+            self._publish_report.current_plugin_id
+        )
 
     def get_error_info(self) -> PublishErrorInfo | None:
+        """Get information about publish error.
+
+        Use to get error if fail reason is 'Error'.
+
+        Returns:
+            PublishErrorInfo | None: Information about publish error or None
+                if no error happened.
+
+        """
         return self._publish_state.error_info
 
-    def store_publish_report(self, filepath: str) -> None:
-        report: PublishReport = self.get_publish_report()
-        report.store_to_file(filepath)
+    def get_validation_errors_info(self) -> list[PublishErrorInfo]:
+        """Get information about validation errors.
+
+        Use to get errors if fail reason is 'ValidationErrors'.
+
+        Returns:
+            list[PublishErrorInfo]: Validation errors info.
+
+        """
+        return self._publish_state.validation_errors
+
+    def iter_all_error_info(self) -> Iterable[PublishErrorInfo]:
+        """Iterate over all error information."""
+        if self._publish_state.error_info is not None:
+            yield self._publish_state.error_info
+        yield from self._publish_state.validation_errors
 
     def set_comment(self, comment: str) -> None:
         # Ignore change of comment when publishing started
@@ -847,11 +649,41 @@ class PublishLogic:
         self._publish_context.data["comment"] = comment
         self._publish_state.comment_is_set = True
 
+    @staticmethod
+    def get_publish_plugin_actions(
+        plugin: PluginType
+    ) -> list[ActionType]:
+        actions = getattr(plugin, "actions", None)
+        if isinstance(actions, list):
+            return actions
+        return []
+
+    def get_publish_plugin_actions_by_id(
+        self, plugin_id: str
+    ) -> list[ActionType]:
+        plugin = self._publish_plugins_by_id[plugin_id]
+        return self.get_publish_plugin_actions(plugin)
+
     def run_action(
-        self, plugin_id: str, action_id: str
+        self,
+        plugin: PluginType | str,
+        action: ActionType | str,
     ) -> PublishActionResult:
-        plugin = self._publish_plugins_proxy.get_plugin(plugin_id)
-        action = self._publish_plugins_proxy.get_action(plugin_id, action_id)
+        if isinstance(plugin, str):
+            plugin = self._publish_plugins_by_id[plugin]
+
+        if isinstance(action, str):
+            action_id = action
+            action = None
+            for plugin_action in self.get_publish_plugin_actions(plugin):
+                if plugin_action.id == action_id:
+                    action = plugin_action
+                    break
+
+            if action is None:
+                raise ValueError(
+                    f"Action '{action_id}' not found in plugin '{plugin}'"
+                )
 
         result = pyblish.plugin.process(
             plugin, self._publish_context, None, action.id
@@ -878,13 +710,6 @@ class PublishLogic:
         create_context: CreateContext | None = None,
         project_settings: dict[str, Any] | None = None,
     ) -> None:
-        # Allow to change behavior during process lifetime
-        self._log_to_console = env_value_to_bool(
-            "AYON_PUBLISHER_PRINT_LOGS", default=False
-        )
-
-        self._publish_state = PublishState()
-
         # Publish context preparation
         if publish_context is None:
             publish_context = pyblish.api.Context()
@@ -956,20 +781,30 @@ class PublishLogic:
 
         for plugin in discovered_publish_plugins:
             if plugin not in plugins_by_targets:
-                self._publish_report.set_plugin_skipped(plugin.id)
+                self._publish_report.set_plugin_skipped(
+                    self.get_publish_plugin_id(plugin)
+                )
 
         self._publish_context = publish_context
         self._publish_plugins = plugins_by_targets
-        self._publish_plugins_proxy = PublishPluginsProxy(
-            plugins_by_targets
+        self._publish_plugins_by_id = {
+            self.get_publish_plugin_id(plugin): plugin
+            for plugin in plugins_by_targets
+        }
+        strict_validation_error_handling = (
+            self._publish_state.strict_validation_error_handling
         )
-        self._publish_errors.reset(self._publish_plugins_proxy)
-
+        self._publish_state = PublishState()
+        self._publish_state.strict_validation_error_handling = (
+            strict_validation_error_handling
+        )
         self._publish_state.max_progress = len(plugins_by_targets)
+        if blocking_crashed_paths:
+            self._publish_state.fail_reason = PublishFailReason.BlockingPaths
 
         self._main_thread_iter = self._publish_iterator()
 
-    def _default_iterator(self):
+    def _default_iterator(self) -> Generator[PublishIterInfo, None, None]:
         """Iterator used on initialization.
 
         Should be replaced by real iterator when 'reset' is called.
@@ -995,9 +830,10 @@ class PublishLogic:
         """
 
         for idx, plugin in enumerate(self._publish_plugins):
+            plugin_id = self.get_publish_plugin_id(plugin)
             self._publish_state.progress = idx
 
-            # Check if plugin is over validation order
+            # Check if plugin is over validation order and stop if needed
             if (
                 not self._publish_state.validated
                 and plugin.order >= VALIDATION_ORDER
@@ -1005,19 +841,19 @@ class PublishLogic:
                 self._publish_state.validated = True
                 if (
                     self._publish_state.up_validation
-                    or self._publish_state.has_validation_errors
+                    or self.has_validation_errors()
                 ):
                     yield PublishIterInfo(self, PublishIterAction.Stop)
 
             # Add plugin to publish report
             self._publish_report.add_plugin_iter(
-                plugin.id, self._publish_context
+                plugin_id, self._publish_context
             )
 
             # Check if plugin should be skipped because is not enabled
             #   or active.
             if self._should_skip_plugin(plugin):
-                self._publish_report.set_plugin_skipped(plugin.id)
+                self._publish_report.set_plugin_skipped(plugin_id)
                 continue
 
             # Plugin is instance plugin
@@ -1026,7 +862,7 @@ class PublishLogic:
                     self._publish_context, plugin
                 )
                 if not instances:
-                    self._publish_report.set_plugin_skipped(plugin.id)
+                    self._publish_report.set_plugin_skipped(plugin_id)
                     continue
 
                 for instance in instances:
@@ -1052,7 +888,7 @@ class PublishLogic:
                     [plugin], families
                 )
                 if not plugins:
-                    self._publish_report.set_plugin_skipped(plugin.id)
+                    self._publish_report.set_plugin_skipped(plugin_id)
                     continue
 
                 item_label = (
@@ -1068,7 +904,7 @@ class PublishLogic:
                     item_label,
                 )
 
-            self._publish_report.set_plugin_passed(plugin.id)
+            self._publish_report.set_plugin_passed(plugin_id)
 
         # Cleanup of publishing process
         self._publish_state.finished = True
@@ -1077,7 +913,7 @@ class PublishLogic:
         yield PublishIterInfo(self, PublishIterAction.Stop)
 
     @contextmanager
-    def _log_manager(self, plugin: pyblish.api.Plugin):
+    def _log_manager(self, plugin: PluginType):
         root = logging.getLogger()
         if not self._log_to_console:
             plugin.log.propagate = False
@@ -1099,9 +935,10 @@ class PublishLogic:
 
     def _process_plugin(
         self,
-        plugin: pyblish.api.Plugin,
-        instance: pyblish.api.Instance
+        plugin: PluginType,
+        instance: pyblish.api.Instance | None
     ) -> None:
+        plugin_id = self.get_publish_plugin_id(plugin)
         with self._log_manager(plugin) as log_handler:
             result = pyblish.plugin.process(
                 plugin, self._publish_context, instance
@@ -1122,39 +959,36 @@ class PublishLogic:
 
         exception = result.get("error")
         if exception:
+            error_info = PublishErrorInfo.from_result(
+                plugin, instance, exception
+            )
+            is_validation_error = False
             if (
                 isinstance(exception, PublishValidationError)
                 and not self._publish_state.validated
             ):
-                result["is_validation_error"] = True
-                self._add_validation_error(result)
+                is_validation_error = True
+                self._publish_state.validation_errors.append(error_info)
+                self._publish_state.fail_reason = (
+                    PublishFailReason.ValidationErrors
+                )
 
             else:
-                if isinstance(exception, PublishError):
-                    if not exception.title:
-                        exception.title = plugin.label or plugin.__name__
-                    self._add_publish_error_to_report(result)
+                if (
+                    isinstance(exception, PublishError)
+                    and not exception.title
+                ):
+                    exception.title = plugin.label or plugin.__name__
 
-                error_info = PublishErrorInfo.from_exception(exception)
                 self._publish_state.error_info = error_info
-                self._publish_state.crashed = True
+                self._publish_state.fail_reason = PublishFailReason.Error
 
-                result["is_validation_error"] = False
+            # Store additional metadata to result for report maker
+            result["is_validation_error"] = is_validation_error
 
-        self._publish_report.add_result(plugin.id, result)
+        self._publish_report.add_result(plugin_id, result)
 
-    def _add_validation_error(self, result: dict[str, Any]):
-        self._publish_state.has_validation_errors = True
-        self._add_publish_error_to_report(result)
-
-    def _add_publish_error_to_report(self, result: dict[str, Any]):
-        self._publish_errors.add_error(
-            result["plugin"],
-            result["error"],
-            result["instance"]
-        )
-
-    def _should_skip_plugin(self, plugin: pyblish.api.Plugin) -> bool:
+    def _should_skip_plugin(self, plugin: PluginType) -> bool:
         """Decide if publish plugin should be skipped.
 
         The pyblish base does define 'active' on plugin which is used to mark
@@ -1171,7 +1005,7 @@ class PublishLogic:
             it is skipped no matter what.
 
         Args:
-            plugin (pyblish.api.Plugin): Plugin which should be checked
+            plugin (PluginType): Plugin which should be checked
                 if it should be skipped.
 
         Returns:
@@ -1184,9 +1018,10 @@ class PublishLogic:
         if plugin.active:
             return False
 
-        if not plugin.optional:
-            return True
-
-        if OptionalPyblishPluginMixin in inspect.getmro(plugin):
+        # Custom handling of AYON's optional plugins
+        if (
+            plugin.optional
+            and OptionalPyblishPluginMixin in inspect.getmro(plugin)
+        ):
             return False
         return True

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -667,12 +667,6 @@ class PublishLogic:
             return actions
         return []
 
-    def get_publish_plugin_actions_by_id(
-        self, plugin_id: str
-    ) -> list[ActionType]:
-        plugin = self._publish_plugins_by_id[plugin_id]
-        return self.get_publish_plugin_actions(plugin)
-
     def run_action(
         self,
         plugin: PluginType | str,

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -356,7 +356,7 @@ class PublishLogic:
 
         self._log_to_console: bool = True
 
-        self._publish_state = PublishState()
+        self._publish_state: PublishState = PublishState()
 
         self._publish_plugins: list[PluginType] = []
         self._publish_plugins_by_id: dict[str, PluginType] = {}
@@ -368,7 +368,7 @@ class PublishLogic:
         self._publish_report: PublishReportMaker = PublishReportMaker()
 
         # Plugin iterator
-        self._main_thread_iter: Generator[PublishIterInfo] = (
+        self._main_thread_iter: Generator[PublishIterInfo, None, None] = (
             self._default_iterator()
         )
 
@@ -400,7 +400,7 @@ class PublishLogic:
         create_context: CreateContext,
         context: pyblish.api.Context | None = None,
         targets: list[str] | None = None,
-    ):
+    ) -> None:
         self._reset(
             create_context.project_name,
             publish_context=context,

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -1014,8 +1014,9 @@ class PublishLogic:
                 plugin.id, self._publish_context
             )
 
-            # WARNING This is hack fix for optional plugins
-            if not self._is_publish_plugin_active(plugin):
+            # Check if plugin should be skipped because is not enabled
+            #   or active.
+            if self._should_skip_plugin(plugin):
                 self._publish_report.set_plugin_skipped(plugin.id)
                 continue
 
@@ -1153,34 +1154,39 @@ class PublishLogic:
             result["instance"]
         )
 
-    def _is_publish_plugin_active(self, plugin: pyblish.api.Plugin) -> bool:
-        """Decide if publish plugin is active.
+    def _should_skip_plugin(self, plugin: pyblish.api.Plugin) -> bool:
+        """Decide if publish plugin should be skipped.
 
-        This is hack because 'active' is mis-used in mixin
-        'OptionalPyblishPluginMixin' where 'active' is used for default value
-        of optional plugins. Because of that is 'active' state of plugin
-        which inherit from 'OptionalPyblishPluginMixin' ignored. That affects
-        headless publishing inside host, potentially remote publishing.
+        The pyblish base does define 'active' on plugin which is used to mark
+            plugin as active or not. But if plugin is also 'optional' it is
+            possible to change the 'active' value.
 
-        We have to change that to match pyblish base, but we can do that
-        only when all hosts use Publisher because the change requires
-        change of settings schemas.
+        AYON does use 'optional' to mark plugin as optional. But the
+            optional logic does not change 'active', instead it is handled by
+            'process' logic. So AYON's 'OptionalPyblishPluginMixin' will
+            always be 'active'.
+
+        With that AYON plugins have to somehow mark plugin as disabled, that
+            is why 'enabled' can be set on plugins. If plugin is disabled
+            it is skipped no matter what.
 
         Args:
-            plugin (pyblish.api.Plugin): Plugin which should be checked if is
-                active.
+            plugin (pyblish.api.Plugin): Plugin which should be checked
+                if it should be skipped.
 
         Returns:
-            bool: Is plugin active.
+            bool: Skip the plugin.
 
         """
+        if getattr(plugin, "enabled", True) is False:
+            return True
 
         if plugin.active:
-            return True
-
-        if not plugin.optional:
             return False
 
-        if OptionalPyblishPluginMixin in inspect.getmro(plugin):
+        if not plugin.optional:
             return True
-        return False
+
+        if OptionalPyblishPluginMixin in inspect.getmro(plugin):
+            return False
+        return True

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -762,9 +762,11 @@ class PublishLogic:
         crashed_file_paths = publish_discover_result.crashed_file_paths
 
         if publish_targets is None:
-            publish_targets = set(pyblish.logic.registered_targets())
-            publish_targets.add("default")
-            publish_targets = list(publish_targets)
+            publish_targets = pyblish.logic.registered_targets()
+
+        publish_targets = list(publish_targets)
+        if "default" not in publish_targets:
+            publish_targets.append("default")
 
         plugins_by_targets = pyblish.logic.plugins_by_targets(
             discovered_publish_plugins, publish_targets

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -27,6 +27,7 @@ from .report import (
 )
 if typing.TYPE_CHECKING:
     from ayon_core.pipeline.create import CreateContext
+
     from .typing import PluginType, ActionType
 
 # Define constant for plugin orders offset
@@ -365,8 +366,13 @@ class PublishLogic:
     This class is used to manage publishing logic. Can be used to run
         publishing and then create publish report.
 
+    Args:
+        reset (bool): Reset publish logic with current context
+            on initialization. If False, an explicit reset has to be called
+            before publishing.
+
     """
-    def __init__(self) -> None:
+    def __init__(self, *, reset=True) -> None:
         self._log_handler: MessageHandler = MessageHandler()
 
         self._log_to_console: bool = True
@@ -384,6 +390,29 @@ class PublishLogic:
 
         # Plugin iterator
         self._publish_iterator: _PublishIterator = _PublishIterator()
+
+        if reset:
+            self.reset_with_current_context()
+
+    def reset_with_current_context(self) -> None:
+        """Reset publish logic with current context."""
+        from ayon_core.pipeline.create import CreateContext
+        from ayon_core.pipeline.context_tools import (
+            registered_host,
+            get_current_project_name,
+        )
+
+        host = registered_host()
+        create_context = None
+        if host is not None:
+            create_context = CreateContext(host)
+
+        if create_context is not None:
+            self.reset_from_create_context(create_context)
+            return
+
+        project_name = get_current_project_name()
+        self.reset(project_name)
 
     def reset(
         self,

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -600,6 +600,9 @@ class PublishLogic:
     def has_finished(self) -> bool:
         """Publishing has successfully finished.
 
+        It is not possible that 'has_finished' is True and 'has_failed'
+            is True at the same time.
+
         Returns:
             bool: True if publishing has successfully finished,
                 False otherwise.

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -424,6 +424,22 @@ class PublishLogic:
         publish_discover_result: DiscoverResult | None = None,
         project_settings: dict[str, Any] | None = None,
     ) -> None:
+        """Reset publish logic with given parameters.
+
+        Args:
+            project_name (str): Name of the project.
+            context (pyblish.api.Context | None): Pyblish context to use.
+                If None, a new context will be created.
+            plugins (list[PluginType] | None): List of publish plugins to use.
+                If None, plugins will be discovered.
+            targets (list[str] | None): List of publish targets to use.
+                If None, all registered targets will be used.
+            create_context (CreateContext | None): Create context to use.
+                If None, a new create context will be created if possible.
+            publish_discover_result (DiscoverResult | None): Discover result
+                for publish plugins. If None, plugins will be discovered.
+
+        """
         if plugins is not None and publish_discover_result is None:
             publish_discover_result = DiscoverResult(pyblish.api.Plugin)
             publish_discover_result.plugins = plugins
@@ -443,6 +459,16 @@ class PublishLogic:
         context: pyblish.api.Context | None = None,
         targets: list[str] | None = None,
     ) -> None:
+        """Reset publish logic with given create context.
+
+        Args:
+            create_context (CreateContext): Create context to use.
+            context (pyblish.api.Context | None): Pyblish context to use.
+                If None, a new context will be created.
+            targets (list[str] | None): List of publish targets to use.
+                If None, all registered targets will be used.
+
+        """
         self._reset(
             create_context.project_name,
             publish_context=context,
@@ -470,6 +496,7 @@ class PublishLogic:
         return plugin.id
 
     def get_pyblish_context(self) -> pyblish.api.Context:
+        """Get pyblish context used for publishing."""
         return self._pyblish_context
 
     pyblish_context: pyblish.api.Context = property(get_pyblish_context)
@@ -554,23 +581,48 @@ class PublishLogic:
         self._publish_state.is_running = False
 
     def is_running(self) -> bool:
-        """Check if publishing is currently running."""
+        """Check if publishing is currently meant to be running.
+
+        It is possible that publishing is currently in process of stopping,
+            but this method will return False.
+
+        Returns:
+            bool: True if publishing is currently meant to be running,
+                False otherwise.
+
+        """
         return self._publish_state.is_running
 
     def has_started(self) -> bool:
-        """Check if publishing has started."""
+        """Publishing has started."""
         return self._publish_state.started
 
     def has_finished(self) -> bool:
-        """Check if publishing successfully finished."""
+        """Publishing has successfully finished.
+
+        Returns:
+            bool: True if publishing has successfully finished,
+                False otherwise.
+
+        """
         return self._publish_state.finished
 
     def has_validated(self) -> bool:
-        """Validation order passed."""
+        """Validation order passed.
+
+        Returns:
+            bool: True if validation order passed, False otherwise.
+
+        """
         return self._publish_state.validated
 
     def publish_can_continue(self) -> bool:
-        """Publishing can continue."""
+        """Publishing can continue.
+
+        Returns:
+            bool: True if publishing still can continue, False otherwise.
+
+        """
         return self._publish_state.can_continue()
 
     def get_progress(self) -> int:
@@ -614,15 +666,15 @@ class PublishLogic:
         return self._publish_state.fail_reason
 
     def get_publish_report(self) -> PublishReport:
-        """Extract report for current state of publishing."""
+        """Get report for the current state of publishing."""
         self._publish_report.update_publish_instances(self._pyblish_context)
         return self._publish_report.get_report()
 
     def get_publish_report_data(self) -> dict[str, Any]:
-        """Get publish report data for current state of publishing.
+        """Extract publish report data for the current state of publishing.
 
         This method should be used if report data are being stored to a file.
-            It does mark current plugin as 'passed' for UI.
+            It does mark the current plugin as 'passed' for UI report viewer.
 
         Returns:
             dict[str, Any]: Publish report data.

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -1,0 +1,1186 @@
+from __future__ import annotations
+
+import collections
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import auto, Enum
+import inspect
+import logging
+import typing
+from typing import Any, Iterable, Generator
+import uuid
+
+import pyblish.api
+import pyblish.logic
+import pyblish.plugin
+
+from ayon_core.lib import env_value_to_bool
+from ayon_core.settings import get_project_settings
+from ayon_core.pipeline.plugin_discover import DiscoverResult
+
+from .lib import filter_crashed_publish_paths, publish_plugins_discover
+from .publish_plugins import (
+    PublishError,
+    PublishValidationError,
+    KnownPublishError,
+    OptionalPyblishPluginMixin,
+)
+from .report import (
+    PublishReportMaker,
+    PublishReport,
+)
+if typing.TYPE_CHECKING:
+    from ayon_core.pipeline.create import CreateContext
+
+# Define constant for plugin orders offset
+PLUGIN_ORDER_OFFSET = 0.5
+VALIDATION_ORDER: int = pyblish.api.ValidatorOrder + PLUGIN_ORDER_OFFSET
+
+
+class MessageHandler(logging.Handler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._records = []
+
+    def clear_records(self):
+        self._records = []
+
+    def emit(self, record):
+        try:
+            record.msg = record.getMessage()
+        except Exception:
+            record.msg = str(record.msg)
+        self._records.append(record)
+
+    def get_records(self):
+        return self._records
+
+
+class PublishErrorInfo:
+    def __init__(
+        self,
+        message: str,
+        is_unknown_error: bool,
+        description: str | None = None,
+        title: str | None = None,
+        detail: str | None = None,
+    ):
+        self.message: str = message
+        self.is_unknown_error = is_unknown_error
+        self.description: str = description or message
+        self.title: str = title or "Unknown error"
+        self.detail: str | None = detail
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, PublishErrorInfo):
+            return False
+        return (
+            self.description == other.description
+            and self.is_unknown_error == other.is_unknown_error
+            and self.title == other.title
+            and self.detail == other.detail
+        )
+
+    def __ne__(self, other: Any) -> bool:
+        return not self.__eq__(other)
+
+    @classmethod
+    def from_exception(cls, exc) -> "PublishErrorInfo":
+        if isinstance(exc, PublishError):
+            return cls(
+                exc.message,
+                False,
+                exc.description,
+                title=exc.title,
+                detail=exc.detail,
+            )
+        if isinstance(exc, KnownPublishError):
+            msg = str(exc)
+        else:
+            msg = (
+                "Something went wrong. Send report"
+                " to your supervisor or Ynput team."
+            )
+        return cls(msg, True)
+
+
+class PublishPluginActionItem:
+    """Representation of publish plugin action.
+
+    Data driven object which is used as proxy for controller and UI.
+
+    Args:
+        action_id (str): Action id.
+        plugin_id (str): Plugin id.
+        active (bool): Action is active.
+        on_filter (Literal["all", "notProcessed", "processed", "failed",
+            "warning", "failedOrWarning", "succeeded"]): Actions have 'on'
+            attribute which define  when can be action triggered
+            (e.g. 'all', 'failed', ...).
+        label (str): Action's label.
+        icon (str | None) Action's icon.
+    """
+
+    def __init__(
+        self,
+        action_id: str,
+        plugin_id: str,
+        active: bool,
+        on_filter: str,
+        label: str,
+        icon: str | None,
+    ):
+        self.action_id: str = action_id
+        self.plugin_id: str = plugin_id
+        self.active: bool = active
+        self.on_filter: str = on_filter
+        self.label: str = label
+        self.icon: str | None = icon
+
+    def to_data(self) -> dict[str, str | bool | None]:
+        """Serialize object to dictionary.
+
+        Returns:
+            dict[str, str | bool | None]: Serialized object.
+
+        """
+        return {
+            "action_id": self.action_id,
+            "plugin_id": self.plugin_id,
+            "active": self.active,
+            "on_filter": self.on_filter,
+            "label": self.label,
+            "icon": self.icon
+        }
+
+    @classmethod
+    def from_data(
+        cls, data: dict[str, str | bool | None]
+    ) -> "PublishPluginActionItem":
+        """Create object from data.
+
+        Args:
+            data (dict[str, str | bool | None]): Data used to recreate
+                object.
+
+        Returns:
+            PublishPluginActionItem: Object created using data.
+        """
+
+        return cls(**data)
+
+
+class PublishPluginsProxy:
+    """Wrapper around publish plugin.
+
+    Prepare mapping for publish plugins and actions. Also can create
+    serializable data for plugin actions for UI purposes.
+
+    This object is created in process where publishing is actually running.
+
+    Notes:
+        Actions have id but single action can be used on multiple plugins so
+            to run an action is needed combination of plugin and action.
+
+    Args:
+        plugins [list[pyblish.api.Plugin]]: Discovered plugins that will be
+            processed.
+    """
+
+    def __init__(self, plugins: list[pyblish.api.Plugin]):
+        plugins_by_id: dict[str, pyblish.api.Plugin] = {}
+        actions_by_plugin_id: dict[str, dict[str, pyblish.api.Action]] = {}
+        action_ids_by_plugin_id: dict[str, list[str]] = {}
+        for plugin in plugins:
+            plugin_id = plugin.id
+            plugins_by_id[plugin_id] = plugin
+
+            action_ids = []
+            actions_by_id = {}
+            action_ids_by_plugin_id[plugin_id] = action_ids
+            actions_by_plugin_id[plugin_id] = actions_by_id
+
+            actions = getattr(plugin, "actions", None) or []
+            for action in actions:
+                action_id = action.id
+                action_ids.append(action_id)
+                actions_by_id[action_id] = action
+
+        self._plugins_by_id: dict[str, pyblish.api.Plugin] = plugins_by_id
+        self._actions_by_plugin_id: dict[
+            str, dict[str, pyblish.api.Action]
+        ] = actions_by_plugin_id
+        self._action_ids_by_plugin_id: dict[str, list[str]] = (
+            action_ids_by_plugin_id
+        )
+
+    def get_action(
+        self, plugin_id: str, action_id: str
+    ) -> pyblish.api.Action:
+        return self._actions_by_plugin_id[plugin_id][action_id]
+
+    def get_plugin(self, plugin_id: str) -> pyblish.api.Plugin:
+        return self._plugins_by_id[plugin_id]
+
+    @staticmethod
+    def get_plugin_id(plugin: pyblish.api.Plugin) -> str:
+        """Get id of plugin based on plugin object.
+
+        It's used for validation errors report.
+
+        Args:
+            plugin (pyblish.api.Plugin): Publish plugin for which id should be
+                returned.
+
+        Returns:
+            str: Plugin id.
+        """
+
+        return plugin.id
+
+    def get_plugin_action_items(
+        self, plugin_id: str
+    ) -> list[PublishPluginActionItem]:
+        """Get plugin action items for plugin by its id.
+
+        Args:
+            plugin_id (str): Publish plugin id.
+
+        Returns:
+            list[PublishPluginActionItem]: Items with information about publish
+                plugin actions.
+        """
+
+        return [
+            self._create_action_item(
+                self.get_action(plugin_id, action_id), plugin_id
+            )
+            for action_id in self._action_ids_by_plugin_id[plugin_id]
+        ]
+
+    def _create_action_item(
+        self, action: pyblish.api.Action, plugin_id: str
+    ) -> PublishPluginActionItem:
+        label = action.label or action.__name__
+        icon = getattr(action, "icon", None)
+        return PublishPluginActionItem(
+            action.id,
+            plugin_id,
+            action.active,
+            action.on,
+            label,
+            icon
+        )
+
+
+class PublishErrorItem:
+    """Data driven publish error item.
+
+    Prepared data container with information about publish error and it's
+    source plugin.
+
+    Can be converted to raw data and recreated should be used for controller
+    and UI connection.
+
+    Args:
+        instance_id (str | None): Pyblish instance id to which is
+            publish error connected.
+        instance_label (str | None): Prepared instance label.
+        plugin_id (str): Pyblish plugin id which triggered the publish
+            error. Id is generated using 'PublishPluginsProxy'.
+        is_context_plugin (bool): Error happened on context.
+        title (str): Error title.
+        description (str): Error description.
+        detail (str): Error detail.
+
+    """
+    def __init__(
+        self,
+        instance_id: str | None,
+        instance_label: str | None,
+        plugin_id: str,
+        is_context_plugin: bool,
+        is_validation_error: bool,
+        title: str | None,
+        description: str | None,
+        detail: str
+    ):
+        self.instance_id: str | None = instance_id
+        self.instance_label: str | None = instance_label
+        self.plugin_id: str = plugin_id
+        self.is_context_plugin: bool = is_context_plugin
+        self.is_validation_error: bool = is_validation_error
+        self.title: str | None = title
+        self.description: str | None = description
+        self.detail: str = detail
+
+    @classmethod
+    def from_result(
+        cls,
+        plugin_id: str,
+        error: PublishError,
+        instance: pyblish.api.Instance | None
+    ):
+        """Create new object based on resukt from controller.
+
+        Returns:
+            PublishErrorItem: New object with filled data.
+        """
+
+        instance_label = None
+        instance_id = None
+        if instance is not None:
+            instance_label = (
+                instance.data.get("label") or instance.data.get("name")
+            )
+            instance_id = instance.id
+
+        return cls(
+            instance_id,
+            instance_label,
+            plugin_id,
+            instance is None,
+            isinstance(error, PublishValidationError),
+            error.title,
+            error.description,
+            error.detail,
+        )
+
+    def to_data(self) -> dict[str, str | bool | None]:
+        """Serialize object to dictionary.
+
+        Returns:
+            dict[str, str | bool | None]: Serialized object data.
+
+        """
+        return {
+            "instance_id": self.instance_id,
+            "instance_label": self.instance_label,
+            "plugin_id": self.plugin_id,
+            "is_context_plugin": self.is_context_plugin,
+            "is_validation_error": self.is_validation_error,
+            "title": self.title,
+            "description": self.description,
+            "detail": self.detail,
+        }
+
+    @classmethod
+    def from_data(cls, data):
+        return cls(**data)
+
+
+class PublishErrorsReport:
+    """Publish errors report that can be parsed to raw data.
+
+    Args:
+        error_items (list[PublishErrorItem]): List of publish errors.
+        plugin_action_items (dict[str, list[PublishPluginActionItem]]): Action
+            items by plugin id.
+
+    """
+    def __init__(
+        self,
+        error_items: list[PublishErrorItem],
+        plugin_action_items: dict[str, list[PublishPluginActionItem]],
+    ):
+        self._error_items = error_items
+        self._plugin_action_items = plugin_action_items
+
+    def __iter__(self) -> Iterable[PublishErrorItem]:
+        for item in self._error_items:
+            yield item
+
+    def group_items_by_title(self) -> list[dict[str, Any]]:
+        """Group errors by plugin and their titles.
+
+        Items are grouped by plugin and title -> same title from different
+        plugin is different item. Items are ordered by plugin order.
+
+        Returns:
+            list[dict[str, Any]]: List where each item title, instance
+                information related to title and possible plugin actions.
+        """
+
+        ordered_plugin_ids = []
+        error_items_by_plugin_id = collections.defaultdict(list)
+        for error_item in self._error_items:
+            plugin_id = error_item.plugin_id
+            if plugin_id not in ordered_plugin_ids:
+                ordered_plugin_ids.append(plugin_id)
+            error_items_by_plugin_id[plugin_id].append(error_item)
+
+        grouped_error_items = []
+        for plugin_id in ordered_plugin_ids:
+            plugin_action_items = self._plugin_action_items[plugin_id]
+            error_items = error_items_by_plugin_id[plugin_id]
+
+            titles = []
+            error_items_by_title = collections.defaultdict(list)
+            for error_item in error_items:
+                title = error_item.title
+                if title not in titles:
+                    titles.append(error_item.title)
+                error_items_by_title[title].append(error_item)
+
+            for title in titles:
+                grouped_error_items.append({
+                    "id": uuid.uuid4().hex,
+                    "plugin_id": plugin_id,
+                    "plugin_action_items": list(plugin_action_items),
+                    "error_items": error_items_by_title[title],
+                    "title": title
+                })
+        return grouped_error_items
+
+    def to_data(self):
+        """Serialize object to dictionary.
+
+        Returns:
+            dict[str, Any]: Serialized data.
+        """
+
+        error_items = [
+            item.to_data()
+            for item in self._error_items
+        ]
+
+        plugin_action_items = {
+            plugin_id: [
+                action_item.to_data()
+                for action_item in action_items
+            ]
+            for plugin_id, action_items in self._plugin_action_items.items()
+        }
+
+        return {
+            "error_items": error_items,
+            "plugin_action_items": plugin_action_items
+        }
+
+    @classmethod
+    def from_data(
+        cls, data: dict[str, Any]
+    ) -> "PublishErrorsReport":
+        """Recreate object from data.
+
+        Args:
+            data (dict[str, Any]): Data to recreate object. Can be created
+                using 'to_data' method.
+
+        Returns:
+            PublishErrorsReport: New object based on data.
+        """
+
+        error_items = [
+            PublishErrorItem.from_data(error_item)
+            for error_item in data["error_items"]
+        ]
+        plugin_action_items = {}
+        for action_item in data["plugin_action_items"]:
+            item = PublishPluginActionItem.from_data(action_item)
+            action_items = plugin_action_items.setdefault(item.plugin_id, [])
+            action_items.append(item)
+
+        return cls(error_items, plugin_action_items)
+
+
+class PublishErrors:
+    """Object to keep track about publish errors by plugin."""
+
+    def __init__(self):
+        self._plugins_proxy: PublishPluginsProxy | None = None
+        self._error_items: list[PublishErrorItem] = []
+        self._plugin_action_items: dict[
+            str, list[PublishPluginActionItem]
+        ] = {}
+
+    def __bool__(self):
+        return self.has_errors
+
+    @property
+    def has_errors(self) -> bool:
+        """At least one error was added."""
+
+        return bool(self._error_items)
+
+    def reset(self, plugins_proxy: PublishPluginsProxy):
+        """Reset object to default state.
+
+        Args:
+            plugins_proxy (PublishPluginsProxy): Proxy which store plugins,
+                actions by ids and create mapping of action ids by plugin ids.
+        """
+
+        self._plugins_proxy = plugins_proxy
+        self._error_items = []
+        self._plugin_action_items = {}
+
+    def create_report(self) -> PublishErrorsReport:
+        """Create report based on currently existing errors.
+
+        Returns:
+            PublishErrorsReport: Publish error report with all
+                error information and publish plugin action items.
+        """
+
+        return PublishErrorsReport(
+            self._error_items, self._plugin_action_items
+        )
+
+    def add_error(
+        self,
+        plugin: pyblish.api.Plugin,
+        error: PublishError,
+        instance: pyblish.api.Instance | None
+    ):
+        """Add error from pyblish result.
+
+        Args:
+            plugin (pyblish.api.Plugin): Plugin which triggered error.
+            error (PublishError): Publish error.
+            instance (pyblish.api.Instance | None): Instance on which was
+                error raised or None if was raised on context.
+        """
+
+        # Make sure the cached report is cleared
+        plugin_id = self._plugins_proxy.get_plugin_id(plugin)
+        if not error.title:
+            if hasattr(plugin, "label") and plugin.label:
+                plugin_label = plugin.label
+            else:
+                plugin_label = plugin.__name__
+            error.title = plugin_label
+
+        self._error_items.append(
+            PublishErrorItem.from_result(plugin_id, error, instance)
+        )
+        if plugin_id in self._plugin_action_items:
+            return
+
+        plugin_actions = self._plugins_proxy.get_plugin_action_items(
+            plugin_id
+        )
+        self._plugin_action_items[plugin_id] = plugin_actions
+
+
+def collect_families_from_instances(
+    instances: list[pyblish.api.Instance],
+    only_active: bool = False,
+) -> list[str]:
+    """Collect all families for passed publish instances.
+
+    Args:
+        instances (list[pyblish.api.Instance]): List of publish instances from
+            which are families collected.
+        only_active (bool): Return families only for active instances.
+
+    Returns:
+        list[str]: Families available on instances.
+
+    """
+    all_families = set()
+    for instance in instances:
+        if only_active:
+            if instance.data.get("publish") is False:
+                continue
+        family = instance.data.get("family")
+        if family:
+            all_families.add(family)
+
+        families = instance.data.get("families") or tuple()
+        for family in families:
+            all_families.add(family)
+
+    return list(all_families)
+
+
+@dataclass
+class PublishState:
+    # Publishing should stop at validation stage
+    up_validation: bool = False
+    comment_is_set: bool = False
+
+    # Publishing is in progress
+    is_running: bool = False
+    # Publishing is over validation order
+    validated: bool = False
+    has_validation_errors: bool = False
+    crashed: bool = False
+    started: bool = False
+    finished: bool = False
+    max_progress: int = 0
+    progress: int = 0
+
+    # Any other exception that happened during publishing
+    error_info: PublishErrorInfo | None = None
+
+    def can_continue(self) -> bool:
+        """Check if publishing can continue.
+
+        Returns:
+            bool: Can publishing continue.
+
+        """
+        return (
+            not self.crashed
+            and not self.has_validation_errors
+            and not self.finished
+        )
+
+    def should_stop(self) -> bool:
+        if self.crashed:
+            return True
+
+        # Stop if validation is over and validation errors happened
+        #   or publishing should stop at validation
+        if (
+            self.validated
+            and (self.has_validation_errors or self.up_validation)
+        ):
+            return True
+        return False
+
+
+class PublishIterAction(Enum):
+    Stop = auto()
+    Continue = auto()
+
+
+@dataclass
+class PublishIterInfo:
+    logic: "PublishLogic"
+    action: PublishIterAction
+    plugin: pyblish.api.Plugin | None = None
+    instance: pyblish.api.Instance | None = None
+    item_label: str | None = None
+
+    def __call__(self):
+        if self.action == PublishIterAction.Stop:
+            self.logic.stop_publish()
+            return
+
+        if self.plugin is None:
+            raise ValueError("Plugin is None but action is Continue")
+
+        self.logic._process_plugin(self.plugin, self.instance)
+
+
+@dataclass
+class PublishActionResult:
+    success: bool
+    action: pyblish.api.Action
+    exception: Exception | None = None
+
+
+def _plugin_is_hosts_compatible(
+    plugin: pyblish.api.Plugin,
+    hosts: list[str] | set[str],
+) -> bool:
+    """Determine whether plugin is compatible with the hosts.
+
+    Arguments:
+        plugin (Plugin): Plug-in to assess.
+        hosts (list[str] | set[str]): List or set of hosts to check against.
+
+    """
+    if "*" in plugin.hosts:
+        return True
+
+    return any(host in plugin.hosts for host in hosts)
+
+
+class PublishLogic:
+    def __init__(self) -> None:
+        self._log_handler: MessageHandler = MessageHandler()
+
+        self._log_to_console: bool = env_value_to_bool(
+            "AYON_PUBLISHER_PRINT_LOGS", default=False
+        )
+
+        self._publish_state = PublishState()
+
+        self._publish_plugins: list[pyblish.api.Plugin] = []
+        self._publish_plugins_proxy: PublishPluginsProxy = (
+            PublishPluginsProxy([])
+        )
+
+        # pyblish.api.Context
+        self._publish_context: pyblish.api.Context = pyblish.api.Context()
+        # Pyblish report
+        self._publish_report: PublishReportMaker = PublishReportMaker()
+        # Store exceptions of publish error
+        self._publish_errors: PublishErrors = PublishErrors()
+
+        # Plugin iterator
+        self._main_thread_iter: Generator[PublishIterInfo] = (
+            self._default_iterator()
+        )
+
+    def reset(
+        self,
+        project_name: str,
+        context: pyblish.api.Context | None = None,
+        plugins: list[pyblish.api.Plugin] | None = None,
+        targets: list[str] | None = None,
+        publish_discover_result: DiscoverResult | None = None,
+        project_settings: dict[str, Any] | None = None,
+    ) -> None:
+        if plugins is not None and publish_discover_result is None:
+            publish_discover_result = DiscoverResult(pyblish.api.Plugin)
+            publish_discover_result.plugins = plugins
+
+        self._reset(
+            project_name,
+            publish_context=context,
+            publish_targets=targets,
+            publish_discover_result=publish_discover_result,
+            project_settings=project_settings,
+        )
+
+    def reset_from_create_context(
+        self,
+        create_context: CreateContext,
+        context: pyblish.api.Context | None = None,
+        targets: list[str] | None = None,
+    ):
+        self._reset(
+            create_context.project_name,
+            publish_context=context,
+            publish_targets=targets,
+            publish_discover_result=create_context.publish_discover_result,
+            creator_discover_result=create_context.creator_discover_result,
+            convertor_discover_result=create_context.convertor_discover_result,
+            create_context=create_context,
+        )
+
+    def publish_up_validation(self) -> bool:
+        return self._publish_state.up_validation
+
+    def set_publish_up_validation(self, value: bool):
+        self._publish_state.up_validation = value
+
+    def start_publish(self, wait: bool = True):
+        """Run publishing.
+
+        Make sure all changes are saved before method is called (Call
+        'save_changes' and check output).
+        """
+        if self._publish_state.is_running:
+            return
+
+        if self._publish_state.should_stop():
+            return
+
+        self._publish_state.is_running = True
+        self._publish_state.started = True
+
+        if wait:
+            while self.is_running():
+                func = self.get_next_process_func()
+                func()
+
+    def get_next_process_func(self) -> PublishIterInfo:
+        # Raise error if this function is called when publishing
+        #   is not running
+        if not self._publish_state.is_running:
+            raise ValueError("Publish is not running")
+
+        if self._publish_state.should_stop():
+            return PublishIterInfo(self, PublishIterAction.Stop)
+
+        # Everything is ok so try to get new processing item
+        return next(self._main_thread_iter)
+
+    def stop_publish(self) -> None:
+        if self._publish_state.is_running:
+            self._publish_state.is_running = False
+
+    def is_running(self) -> bool:
+        return self._publish_state.is_running
+
+    def has_crashed(self) -> bool:
+        return self._publish_state.crashed
+
+    def has_started(self) -> bool:
+        return self._publish_state.started
+
+    def has_finished(self) -> bool:
+        return self._publish_state.finished
+
+    def has_validated(self) -> bool:
+        return self._publish_state.validated
+
+    def has_validation_errors(self) -> bool:
+        return self._publish_state.has_validation_errors
+
+    def publish_can_continue(self) -> bool:
+        return self._publish_state.can_continue()
+
+    def get_progress(self) -> int:
+        return self._publish_state.progress
+
+    def get_max_progress(self) -> int:
+        return self._publish_state.max_progress
+
+    def get_publish_report(self) -> PublishReport:
+        self._publish_report.update_publish_instances(self._publish_context)
+        return self._publish_report.get_report()
+
+    def get_publish_report_data(self) -> dict[str, Any]:
+        report: PublishReport = self.get_publish_report()
+        return report.to_data(self._publish_report.current_plugin_id)
+
+    def get_publish_errors_report(self) -> PublishErrorsReport:
+        return self._publish_errors.create_report()
+
+    def get_error_info(self) -> PublishErrorInfo | None:
+        return self._publish_state.error_info
+
+    def store_publish_report(self, filepath: str) -> None:
+        report: PublishReport = self.get_publish_report()
+        report.store_to_file(filepath)
+
+    def set_comment(self, comment: str) -> None:
+        # Ignore change of comment when publishing started
+        if self._publish_state.started:
+            return
+        self._publish_context.data["comment"] = comment
+        self._publish_state.comment_is_set = True
+
+    def run_action(
+        self, plugin_id: str, action_id: str
+    ) -> PublishActionResult:
+        plugin = self._publish_plugins_proxy.get_plugin(plugin_id)
+        action = self._publish_plugins_proxy.get_action(plugin_id, action_id)
+
+        result = pyblish.plugin.process(
+            plugin, self._publish_context, None, action.id
+        )
+        self._publish_report.add_action_result(action, result)
+
+        exception = result.get("error")
+        if not exception:
+            return PublishActionResult(True, action)
+        return PublishActionResult(False, action, exception)
+
+    def _reset(
+        self,
+        project_name: str,
+        publish_context: pyblish.api.Context | None = None,
+        publish_targets: list[str] | None = None,
+        # Hosts filtering is embedded into pyblish register and discover.
+        # - hard to change how it works, can be changed only for paths
+        #   discovery
+        # publish_hosts: list[str] | None = None,
+        publish_discover_result: DiscoverResult | None = None,
+        creator_discover_result: DiscoverResult | None = None,
+        convertor_discover_result: DiscoverResult | None = None,
+        create_context: CreateContext | None = None,
+        project_settings: dict[str, Any] | None = None,
+    ) -> None:
+        # Allow to change behavior during process lifetime
+        self._log_to_console = env_value_to_bool(
+            "AYON_PUBLISHER_PRINT_LOGS", default=False
+        )
+
+        self._publish_state = PublishState()
+
+        # Publish context preparation
+        if publish_context is None:
+            publish_context = pyblish.api.Context()
+
+        if publish_context.data.get("comment") is None:
+            publish_context.data["comment"] = ""
+
+        # Plugins preparation
+        if create_context is not None:
+            publish_context.data["create_context"] = create_context
+
+            # Use discover results from create context
+            if publish_discover_result is None:
+                publish_discover_result = (
+                    create_context.publish_discover_result
+                )
+            if creator_discover_result is None:
+                creator_discover_result = (
+                    create_context.creator_discover_result
+                )
+            if convertor_discover_result is None:
+                convertor_discover_result = (
+                    create_context.convertor_discover_result
+                )
+
+            if project_settings is None:
+                project_settings = (
+                    create_context.get_current_project_settings()
+                )
+
+        if publish_discover_result is None:
+            publish_discover_result: DiscoverResult = (
+                publish_plugins_discover()
+            )
+
+        if creator_discover_result is None:
+            creator_discover_result = DiscoverResult(None)
+
+        if convertor_discover_result is None:
+            convertor_discover_result = DiscoverResult(None)
+
+        if project_settings is None:
+            project_settings = get_project_settings(project_name)
+
+        discovered_publish_plugins = publish_discover_result.plugins
+        crashed_file_paths = publish_discover_result.crashed_file_paths
+
+        if publish_targets is None:
+            publish_targets = set(pyblish.logic.registered_targets())
+            publish_targets.add("default")
+            publish_targets = list(publish_targets)
+
+        plugins_by_targets = pyblish.logic.plugins_by_targets(
+            discovered_publish_plugins, publish_targets
+        )
+
+        blocking_crashed_paths = filter_crashed_publish_paths(
+            project_name,
+            set(crashed_file_paths),
+            project_settings=project_settings,
+        )
+
+        self._publish_report.reset_with_discover_results(
+            creator_discover_result,
+            convertor_discover_result,
+            publish_discover_result,
+            blocking_crashed_paths,
+        )
+
+        for plugin in discovered_publish_plugins:
+            if plugin not in plugins_by_targets:
+                self._publish_report.set_plugin_skipped(plugin.id)
+
+        self._publish_context = publish_context
+        self._publish_plugins = plugins_by_targets
+        self._publish_plugins_proxy = PublishPluginsProxy(
+            plugins_by_targets
+        )
+        self._publish_errors.reset(self._publish_plugins_proxy)
+
+        self._publish_state.max_progress = len(plugins_by_targets)
+
+        self._main_thread_iter = self._publish_iterator()
+
+    def _default_iterator(self):
+        """Iterator used on initialization.
+
+        Should be replaced by real iterator when 'reset' is called.
+
+        Returns:
+            collections.abc.Generator[PublishIterInfo]: Generator with partial
+                functions that should be called in main thread.
+
+        """
+        while True:
+            yield PublishIterInfo(self, PublishIterAction.Stop)
+
+    def _publish_iterator(self) -> Generator[PublishIterInfo, None, None]:
+        """Main logic center of publishing.
+
+        Iterator returns `PublishIterInfo` objects with callbacks that should
+        be processed in main thread (threaded in future?). Cares about
+        changing states of currently processed publish plugin and instance.
+        Also change state of processed orders like validation order
+        has passed etc.
+
+        Also stops publishing, if should stop on validation.
+        """
+
+        for idx, plugin in enumerate(self._publish_plugins):
+            self._publish_state.progress = idx
+
+            # Check if plugin is over validation order
+            if (
+                not self._publish_state.validated
+                and plugin.order >= VALIDATION_ORDER
+            ):
+                self._publish_state.validated = True
+                if (
+                    self._publish_state.up_validation
+                    or self._publish_state.has_validation_errors
+                ):
+                    yield PublishIterInfo(self, PublishIterAction.Stop)
+
+            # Add plugin to publish report
+            self._publish_report.add_plugin_iter(
+                plugin.id, self._publish_context
+            )
+
+            # WARNING This is hack fix for optional plugins
+            if not self._is_publish_plugin_active(plugin):
+                self._publish_report.set_plugin_skipped(plugin.id)
+                continue
+
+            # Plugin is instance plugin
+            if plugin.__instanceEnabled__:
+                instances = pyblish.logic.instances_by_plugin(
+                    self._publish_context, plugin
+                )
+                if not instances:
+                    self._publish_report.set_plugin_skipped(plugin.id)
+                    continue
+
+                for instance in instances:
+                    if instance.data.get("publish") is False:
+                        continue
+
+                    item_label = (
+                        instance.data.get("label")
+                        or instance.data["name"]
+                    )
+                    yield PublishIterInfo(
+                        self,
+                        PublishIterAction.Continue,
+                        plugin,
+                        instance,
+                        item_label,
+                    )
+            else:
+                families = collect_families_from_instances(
+                    self._publish_context, only_active=True
+                )
+                plugins = pyblish.logic.plugins_by_families(
+                    [plugin], families
+                )
+                if not plugins:
+                    self._publish_report.set_plugin_skipped(plugin.id)
+                    continue
+
+                item_label = (
+                    self._publish_context.data.get("label")
+                    or self._publish_context.data.get("name")
+                    or "Context"
+                )
+                yield PublishIterInfo(
+                    self,
+                    PublishIterAction.Continue,
+                    plugin,
+                    None,
+                    item_label,
+                )
+
+            self._publish_report.set_plugin_passed(plugin.id)
+
+        # Cleanup of publishing process
+        self._publish_state.finished = True
+        self._publish_state.progress = self._publish_state.max_progress
+
+        yield PublishIterInfo(self, PublishIterAction.Stop)
+
+    @contextmanager
+    def _log_manager(self, plugin: pyblish.api.Plugin):
+        root = logging.getLogger()
+        if not self._log_to_console:
+            plugin.log.propagate = False
+            plugin.log.addHandler(self._log_handler)
+            root.addHandler(self._log_handler)
+
+        try:
+            if self._log_to_console:
+                yield None
+            else:
+                yield self._log_handler
+
+        finally:
+            if not self._log_to_console:
+                plugin.log.propagate = True
+                plugin.log.removeHandler(self._log_handler)
+                root.removeHandler(self._log_handler)
+            self._log_handler.clear_records()
+
+    def _process_plugin(
+        self,
+        plugin: pyblish.api.Plugin,
+        instance: pyblish.api.Instance
+    ) -> None:
+        with self._log_manager(plugin) as log_handler:
+            result = pyblish.plugin.process(
+                plugin, self._publish_context, instance
+            )
+            if log_handler is not None:
+                records = log_handler.get_records()
+                exception = result.get("error")
+                if exception is not None and records:
+                    last_record = records[-1]
+                    if (
+                        last_record.name == "pyblish.plugin"
+                        and last_record.levelno == logging.ERROR
+                    ):
+                        # Remove last record made by pyblish
+                        # - `log.exception(formatted_traceback)`
+                        records.pop(-1)
+                result["records"] = records
+
+        exception = result.get("error")
+        if exception:
+            if (
+                isinstance(exception, PublishValidationError)
+                and not self._publish_state.validated
+            ):
+                result["is_validation_error"] = True
+                self._add_validation_error(result)
+
+            else:
+                if isinstance(exception, PublishError):
+                    if not exception.title:
+                        exception.title = plugin.label or plugin.__name__
+                    self._add_publish_error_to_report(result)
+
+                error_info = PublishErrorInfo.from_exception(exception)
+                self._publish_state.error_info = error_info
+                self._publish_state.crashed = True
+
+                result["is_validation_error"] = False
+
+        self._publish_report.add_result(plugin.id, result)
+
+    def _add_validation_error(self, result: dict[str, Any]):
+        self._publish_state.has_validation_errors = True
+        self._add_publish_error_to_report(result)
+
+    def _add_publish_error_to_report(self, result: dict[str, Any]):
+        self._publish_errors.add_error(
+            result["plugin"],
+            result["error"],
+            result["instance"]
+        )
+
+    def _is_publish_plugin_active(self, plugin: pyblish.api.Plugin) -> bool:
+        """Decide if publish plugin is active.
+
+        This is hack because 'active' is mis-used in mixin
+        'OptionalPyblishPluginMixin' where 'active' is used for default value
+        of optional plugins. Because of that is 'active' state of plugin
+        which inherit from 'OptionalPyblishPluginMixin' ignored. That affects
+        headless publishing inside host, potentially remote publishing.
+
+        We have to change that to match pyblish base, but we can do that
+        only when all hosts use Publisher because the change requires
+        change of settings schemas.
+
+        Args:
+            plugin (pyblish.api.Plugin): Plugin which should be checked if is
+                active.
+
+        Returns:
+            bool: Is plugin active.
+
+        """
+
+        if plugin.active:
+            return True
+
+        if not plugin.optional:
+            return False
+
+        if OptionalPyblishPluginMixin in inspect.getmro(plugin):
+            return True
+        return False

--- a/client/ayon_core/pipeline/publish/report.py
+++ b/client/ayon_core/pipeline/publish/report.py
@@ -665,9 +665,13 @@ class PublishReport:
             },
         )
 
-    def store_to_file(self, filepath: str) -> None:
+    def store_to_file(
+        self,
+        filepath: str,
+        current_plugin_id: str | None = None,
+    ) -> None:
         with open(filepath, "w", encoding="utf-8") as stream:
-            json.dump(self.to_data(), stream)
+            json.dump(self.to_data(current_plugin_id), stream)
 
 
 class PublishReportMaker:

--- a/client/ayon_core/pipeline/publish/report.py
+++ b/client/ayon_core/pipeline/publish/report.py
@@ -32,6 +32,7 @@ class ReportLog:
     thread_name: str | None = None
     threadName: InitVar[str | None] = None
     pathname: str | None = None
+    created: float | None = None
     msecs: float | None = None
     exc_info: str | None = None
     func: str | None = None
@@ -64,6 +65,7 @@ class ReportLog:
             "levelname": self.levelname,
             "threadName": self.thread_name,
             "pathname": self.pathname,
+            "created": self.created,
             "msecs": self.msecs,
             "exc_info": self.exc_info,
         }
@@ -80,6 +82,7 @@ class ReportLog:
             levelname=data.get("levelname"),
             thread_name=data.get("thread_name"),
             pathname=data.get("pathname"),
+            created=data.get("created"),
             msecs=data.get("msecs"),
             exc_info=data.get("exc_info"),
             func=data.get("func"),
@@ -115,6 +118,7 @@ class ReportLog:
                 thread_name=record.threadName,
                 filename=record.filename,
                 pathname=record.pathname,
+                created=record.created,
                 msecs=record.msecs,
                 exc_info=record_exc_info,
             ))

--- a/client/ayon_core/pipeline/publish/typing.py
+++ b/client/ayon_core/pipeline/publish/typing.py
@@ -1,0 +1,8 @@
+from typing import Type
+
+import pyblish.api
+
+
+# The pyblish logic is working with classes, not with objects
+PluginType = Type[pyblish.api.Plugin]
+ActionType = Type[pyblish.api.Action]

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -167,7 +167,7 @@ class UIPublishPluginActionItem:
 class UIPublishErrorItem:
     """Data driven publish error item.
 
-    Prepared data container with information about publish error and it's
+    Prepared data container with information about publish error and its
     source plugin.
 
     Can be converted to raw data and recreated should be used for controller

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -1,19 +1,26 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, asdict
+import collections
+from dataclasses import dataclass, asdict, field
 from typing import (
     Any,
     Callable,
     Iterable,
     TYPE_CHECKING,
 )
+import uuid
 
 from ayon_core.tools.common_models import (
     FolderItem,
     TaskItem,
     FolderTypeItem,
     TaskTypeItem,
+)
+from ayon_core.pipeline.publish import PublishError, KnownPublishError
+from ayon_core.pipeline.publish.logic import (
+    PublishErrorInfo,
+    ActionType,
 )
 
 if TYPE_CHECKING:
@@ -23,11 +30,7 @@ if TYPE_CHECKING:
         CreateContext,
         ConvertorItem,
     )
-    from ayon_core.pipeline.publish import PublishReport
-    from ayon_core.pipeline.publish.logic import (
-        PublishErrorInfo,
-        PublishErrorsReport,
-    )
+    from ayon_core.pipeline.publish import PublishReport, PublishLogic
 
     from .models import CreatorItem, InstanceItem
 
@@ -57,6 +60,273 @@ class PublishAttrDefsInfo:
     attr_defs: list[AbstractAttrDef]
     values: dict[str, list[tuple[str, Any, Any]]]
     instance_ids: list[str | None]
+
+
+@dataclass
+class UIFailInfo:
+    message: str
+    is_unknown_error: bool
+
+    @classmethod
+    def from_exception(cls, exc) -> "UIFailInfo":
+        if isinstance(exc, PublishError):
+            return cls(exc.message, False)
+
+        if isinstance(exc, KnownPublishError):
+            msg = str(exc)
+        else:
+            msg = (
+                "Something went wrong. Send report"
+                " to your supervisor or Ynput team."
+            )
+        return cls(msg, True)
+
+    def to_data(self) -> dict[str, Any]:
+        return {
+            "mesasge": self.message,
+            "is_unknown_error": self.is_unknown_error,
+        }
+
+    @classmethod
+    def from_data(cls, data: dict[str, Any]) -> "UIFailInfo":
+        return cls(data["message"], data["is_unknown_error"])
+
+
+@dataclass
+class UIPublishPluginActionItem:
+    """Representation of publish plugin action.
+
+    Data driven object which is used as proxy for controller and UI.
+
+    Attributes:
+        action_id (str): Action id.
+        plugin_id (str): Plugin id.
+        active (bool): Action is active.
+        on_filter (Literal["all", "notProcessed", "processed", "failed",
+            "warning", "failedOrWarning", "succeeded"]): Actions have 'on'
+            attribute which define  when can be action triggered
+            (e.g. 'all', 'failed', ...).
+        label (str): Action's label.
+        icon (str | None) Action's icon.
+
+    """
+    action_id: str
+    plugin_id: str
+    active: bool
+    on_filter: str
+    label: str
+    icon: str | None
+
+    @classmethod
+    def from_action(
+        cls, action: ActionType, plugin_id: str
+    ) -> "UIPublishPluginActionItem":
+        label = action.label or action.__name__
+        icon = getattr(action, "icon", None)
+        return cls(
+            action_id=action.id,
+            plugin_id=plugin_id,
+            active=action.active,
+            on_filter="all",
+            label=label,
+            icon=icon,
+        )
+
+    @classmethod
+    def from_data(
+        cls, data: dict[str, str | bool | None]
+    ) -> "UIPublishPluginActionItem":
+        """Create object from data.
+
+        Args:
+            data (dict[str, str | bool | None]): Data used to recreate
+                object.
+
+        Returns:
+            UIPublishPluginActionItem: Object created using data.
+
+        """
+        return cls(**data)
+
+    def to_data(self) -> dict[str, str | bool | None]:
+        """Serialize object to dictionary.
+
+        Returns:
+            dict[str, str | bool | None]: Serialized object.
+
+        """
+        return {
+            "action_id": self.action_id,
+            "plugin_id": self.plugin_id,
+            "active": self.active,
+            "on_filter": self.on_filter,
+            "label": self.label,
+            "icon": self.icon
+        }
+
+
+@dataclass
+class UIPublishErrorItem:
+    """Data driven publish error item.
+
+    Prepared data container with information about publish error and it's
+    source plugin.
+
+    Can be converted to raw data and recreated should be used for controller
+    and UI connection.
+
+    Args:
+        instance_id (str | None): Pyblish instance id to which is
+            publish error connected.
+        instance_label (str | None): Prepared instance label.
+        plugin_id (str): Pyblish plugin id which triggered the publish
+            error. Id is generated using 'PublishPluginsProxy'.
+        is_context_plugin (bool): Error happened on context.
+        is_validation_error (bool): Error is a validation error.
+        title (str | None): Error title.
+        description (str | None): Error description.
+        detail (str): Error detail.
+
+    """
+    instance_id: str | None
+    instance_label: str | None
+    plugin_id: str
+    is_context_plugin: bool
+    is_validation_error: bool
+    title: str | None
+    description: str | None
+    detail: str | None
+
+    @classmethod
+    def from_error_item(
+        cls, error_info: PublishErrorInfo
+    ) -> "UIPublishErrorItem":
+        """Create new object based on resukt from controller.
+
+        Returns:
+            PublishErrorItem: New object with filled data.
+        """
+        return cls(
+            instance_id=error_info.instance_id,
+            instance_label=error_info.instance_label,
+            plugin_id=error_info.plugin_id,
+            is_context_plugin=error_info.is_context_plugin,
+            is_validation_error=error_info.is_validation_error,
+            title=error_info.title,
+            description=error_info.description,
+            detail=error_info.detail,
+        )
+
+    def to_data(self) -> dict[str, str | bool | None]:
+        """Serialize object to dictionary.
+
+        Returns:
+            dict[str, str | bool | None]: Serialized object data.
+
+        """
+        return {
+            "instance_id": self.instance_id,
+            "instance_label": self.instance_label,
+            "plugin_id": self.plugin_id,
+            "is_context_plugin": self.is_context_plugin,
+            "is_validation_error": self.is_validation_error,
+            "title": self.title,
+            "description": self.description,
+            "detail": self.detail,
+        }
+
+    @classmethod
+    def from_data(cls, data):
+        return cls(**data)
+
+
+@dataclass
+class UIPublishErrorReport:
+    plugin_id: str
+    title: str
+    error_items: list[UIPublishErrorItem]
+    plugin_action_items: list[UIPublishPluginActionItem]
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+
+    @classmethod
+    def get_items_grouped_by_title(
+        cls, logic: PublishLogic
+    ) -> list[UIPublishErrorReport]:
+        """Group errors by plugin and their titles.
+
+        Items are grouped by plugin and title -> same title from different
+        plugin is different item. Items are ordered by plugin order.
+
+        Returns:
+            list[dict[str, Any]]: List where each item title, instance
+                information related to title and possible plugin actions.
+        """
+        ordered_plugin_ids = []
+        error_items_by_plugin_id = collections.defaultdict(list)
+        for error_item in logic.iter_all_error_info():
+            plugin_id = error_item.plugin_id
+            if plugin_id not in ordered_plugin_ids:
+                ordered_plugin_ids.append(plugin_id)
+            ui_error_item = UIPublishErrorItem.from_error_item(error_item)
+            error_items_by_plugin_id[plugin_id].append(ui_error_item)
+
+        grouped_error_items = []
+        for plugin_id in ordered_plugin_ids:
+            plugin_action_items = [
+                UIPublishPluginActionItem.from_action(
+                    action, plugin_id
+                )
+                for action in logic.get_publish_plugin_actions_by_id(plugin_id)
+            ]
+            error_items = error_items_by_plugin_id[plugin_id]
+
+            titles = []
+            error_items_by_title = collections.defaultdict(list)
+            for error_item in error_items:
+                title = error_item.title
+                if title not in titles:
+                    titles.append(error_item.title)
+                error_items_by_title[title].append(error_item)
+
+            for title in titles:
+                item = UIPublishErrorReport(
+                    plugin_id=plugin_id,
+                    title=title,
+                    error_items=error_items_by_title[title],
+                    plugin_action_items=plugin_action_items,
+                )
+                grouped_error_items.append(item)
+        return grouped_error_items
+
+    def to_data(self) -> dict[str, Any]:
+        """Serialize object to json supported dictionary."""
+        return {
+            "id": self.id,
+            "plugin_id": self.plugin_id,
+            "title": self.title,
+            "error_items": [ei.to_data() for ei in self.error_items],
+            "plugin_action_items": [
+                ai.to_data() for ai in self.plugin_action_items
+            ],
+        }
+
+    @classmethod
+    def from_data(cls, data: dict[str, Any]):
+        """Recreate object from data serialized using 'to_data'."""
+
+        return cls(
+            id=data["id"],
+            plugin_id=data["plugin_id"],
+            title=data["title"],
+            error_items=[
+                UIPublishErrorItem.from_data(ei)
+                for ei in data["error_items"]
+            ],
+            plugin_action_items=[
+                UIPublishPluginActionItem.from_data(ai)
+                for ai in data["plugin_action_items"]
+            ],
+        )
 
 
 class AbstractPublisherCommon(ABC):
@@ -652,7 +922,7 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
 
     @abstractmethod
     def publish_has_crashed(self) -> bool:
-        """Publishing crashed for any reason.
+        """Publishing crashed with an error during process iteration.
 
         Returns:
             bool: Publishing crashed.
@@ -691,11 +961,11 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         pass
 
     @abstractmethod
-    def get_publish_error_info(self) -> PublishErrorInfo | None:
+    def get_publish_fail_info(self) -> UIFailInfo | None:
         """Current error message which cause fail of publishing.
 
         Returns:
-            PublishErrorInfo | None: Error info or None.
+            UIFailInfo | None: Error info or None.
 
         """
         pass
@@ -709,7 +979,7 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         pass
 
     @abstractmethod
-    def get_publish_errors_report(self) -> PublishErrorsReport:
+    def get_publish_errors_reports(self) -> list[UIPublishErrorReport]:
         pass
 
     @abstractmethod

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -81,7 +81,7 @@ class UIFailInfo:
 
     def to_data(self) -> dict[str, Any]:
         return {
-            "mesasge": self.message,
+            "message": self.message,
             "is_unknown_error": self.is_unknown_error,
         }
 

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -139,6 +139,10 @@ class AbstractPublisherCommon(ABC):
         pass
 
     @abstractmethod
+    def get_project_settings(self, project_name: str | None) -> dict:
+        pass
+
+    @abstractmethod
     def host_context_has_changed(self) -> bool:
         """Host context changed after last reset.
 
@@ -202,10 +206,6 @@ class AbstractPublisherBackend(AbstractPublisherCommon):
         task_name: str,
         sender: str | None = None
     ) -> TaskItem | None:
-        pass
-
-    @abstractmethod
-    def get_project_settings(self, project_name: str | None) -> dict:
         pass
 
     @abstractmethod

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -63,12 +63,13 @@ class PublishAttrDefsInfo:
 @dataclass
 class UIFailInfo:
     message: str
-    is_unknown_error: bool
+    # Error caused by 'PublishError' exception.
+    is_publish_error: bool
 
     @classmethod
     def from_exception(cls, exc) -> "UIFailInfo":
         if isinstance(exc, PublishError):
-            return cls(exc.message, False)
+            return cls(exc.message, True)
 
         if isinstance(exc, KnownPublishError):
             msg = str(exc)
@@ -77,17 +78,17 @@ class UIFailInfo:
                 "Something went wrong. Send report"
                 " to your supervisor or Ynput team."
             )
-        return cls(msg, True)
+        return cls(msg, False)
 
     def to_data(self) -> dict[str, Any]:
         return {
             "message": self.message,
-            "is_unknown_error": self.is_unknown_error,
+            "is_publish_error": self.is_publish_error,
         }
 
     @classmethod
     def from_data(cls, data: dict[str, Any]) -> "UIFailInfo":
-        return cls(data["message"], data["is_unknown_error"])
+        return cls(data["message"], data["is_publish_error"])
 
 
 @dataclass

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -272,11 +272,12 @@ class UIPublishErrorReport:
 
         grouped_error_items = []
         for plugin_id in ordered_plugin_ids:
+            plugin = logic.get_publish_plugin_by_id(plugin_id)
             plugin_action_items = [
                 UIPublishPluginActionItem.from_action(
                     action, plugin_id
                 )
-                for action in logic.get_publish_plugin_actions_by_id(plugin_id)
+                for action in logic.get_publish_plugin_actions(plugin)
             ]
             error_items = error_items_by_plugin_id[plugin_id]
 

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -81,10 +81,10 @@ class UIFailInfo:
         return cls(msg, False)
 
     def to_data(self) -> dict[str, Any]:
-        return {
-            "message": self.message,
-            "is_publish_error": self.is_publish_error,
-        }
+        return dict(
+            message=self.message,
+            is_publish_error=self.is_publish_error,
+        )
 
     @classmethod
     def from_data(cls, data: dict[str, Any]) -> "UIFailInfo":
@@ -300,15 +300,15 @@ class UIPublishErrorReport:
 
     def to_data(self) -> dict[str, Any]:
         """Serialize object to json supported dictionary."""
-        return {
-            "id": self.id,
-            "plugin_id": self.plugin_id,
-            "title": self.title,
-            "error_items": [ei.to_data() for ei in self.error_items],
-            "plugin_action_items": [
+        return dict(
+            id=self.id,
+            plugin_id=self.plugin_id,
+            title=self.title,
+            error_items=[ei.to_data() for ei in self.error_items],
+            plugin_action_items=[
                 ai.to_data() for ai in self.plugin_action_items
             ],
-        }
+        )
 
     @classmethod
     def from_data(cls, data: dict[str, Any]):

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -3,24 +3,12 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, asdict
 from typing import (
-    Optional,
-    Dict,
-    List,
-    Tuple,
     Any,
     Callable,
-    Union,
     Iterable,
     TYPE_CHECKING,
 )
 
-from ayon_core.lib import AbstractAttrDef
-from ayon_core.host import AbstractHost
-from ayon_core.pipeline.publish import PublishReport
-from ayon_core.pipeline.create import (
-    CreateContext,
-    ConvertorItem,
-)
 from ayon_core.tools.common_models import (
     FolderItem,
     TaskItem,
@@ -29,7 +17,19 @@ from ayon_core.tools.common_models import (
 )
 
 if TYPE_CHECKING:
-    from .models import CreatorItem, PublishErrorInfo, InstanceItem
+    from ayon_core.lib import AbstractAttrDef
+    from ayon_core.host import AbstractHost
+    from ayon_core.pipeline.create import (
+        CreateContext,
+        ConvertorItem,
+    )
+    from ayon_core.pipeline.publish import PublishReport
+    from ayon_core.pipeline.publish.logic import (
+        PublishErrorInfo,
+        PublishErrorsReport,
+    )
+
+    from .models import CreatorItem, InstanceItem
 
 
 @dataclass
@@ -61,7 +61,7 @@ class PublishAttrDefsInfo:
 
 class AbstractPublisherCommon(ABC):
     @abstractmethod
-    def register_event_callback(self, topic, callback):
+    def register_event_callback(self, topic: str, callback: Callable) -> None:
         """Register event callback.
 
         Listen for events with given topic.
@@ -70,22 +70,22 @@ class AbstractPublisherCommon(ABC):
             topic (str): Name of topic.
             callback (Callable): Callback that will be called when event
                 is triggered.
-        """
 
+        """
         pass
 
     @abstractmethod
     def emit_event(
         self, topic: str,
-        data: Optional[Dict[str, Any]] = None,
-        source: Optional[str] = None
-    ):
+        data: dict[str, Any] | None = None,
+        source: str | None = None
+    ) -> None:
         """Emit event.
 
         Args:
             topic (str): Event topic used for callbacks filtering.
-            data (Optional[dict[str, Any]]): Event data.
-            source (Optional[str]): Event source.
+            data (dict[str, Any] | None): Event data.
+            source (str | None): Event source.
 
         """
         pass
@@ -94,8 +94,8 @@ class AbstractPublisherCommon(ABC):
     def emit_card_message(
         self,
         message: str,
-        message_type: Optional[str] = CardMessageTypes.standard
-    ):
+        message_type: str | None = CardMessageTypes.standard
+    ) -> None:
         """Emit a card message which can have a lifetime.
 
         This is for UI purposes. Method can be extended to more arguments
@@ -104,38 +104,38 @@ class AbstractPublisherCommon(ABC):
         Args:
             message (str): Message that will be shown.
             message_type (Optional[str]): Message type.
-        """
 
+        """
         pass
 
     @abstractmethod
-    def get_current_project_name(self) -> Union[str, None]:
+    def get_current_project_name(self) -> str | None:
         """Current context project name.
 
         Returns:
             str: Name of project.
-        """
 
+        """
         pass
 
     @abstractmethod
-    def get_current_folder_path(self) -> Union[str, None]:
+    def get_current_folder_path(self) -> str | None:
         """Current context folder path.
 
         Returns:
-            Union[str, None]: Folder path.
+            str | None: Folder path.
 
         """
         pass
 
     @abstractmethod
-    def get_current_task_name(self) -> Union[str, None]:
+    def get_current_task_name(self) -> str | None:
         """Current context task name.
 
         Returns:
-            Union[str, None]: Name of task.
-        """
+            str | None: Name of task.
 
+        """
         pass
 
     @abstractmethod
@@ -146,18 +146,18 @@ class AbstractPublisherCommon(ABC):
 
         Returns:
             bool: Context has changed.
-        """
 
+        """
         pass
 
     @abstractmethod
-    def reset(self):
+    def reset(self) -> None:
         """Reset whole controller.
 
         This should reset create context, publish context and all variables
         that are related to it.
-        """
 
+        """
         pass
 
     @abstractmethod
@@ -200,8 +200,8 @@ class AbstractPublisherBackend(AbstractPublisherCommon):
         project_name: str,
         folder_id: str,
         task_name: str,
-        sender: Optional[str] = None
-    ) -> Union[TaskItem, None]:
+        sender: str | None = None
+    ) -> TaskItem | None:
         pass
 
     @abstractmethod
@@ -211,40 +211,40 @@ class AbstractPublisherBackend(AbstractPublisherCommon):
     @abstractmethod
     def get_project_entity(
         self, project_name: str
-    ) -> Union[Dict[str, Any], None]:
+    ) -> dict[str, Any] | None:
         pass
 
     @abstractmethod
     def get_folder_entity(
         self, project_name: str, folder_id: str
-    ) -> Union[Dict[str, Any], None]:
+    ) -> dict[str, Any] | None:
         pass
 
     @abstractmethod
     def get_folder_item_by_path(
         self, project_name: str, folder_path: str
-    ) -> Union[FolderItem, None]:
+    ) -> FolderItem | None:
         pass
 
     @abstractmethod
     def get_task_entity(
         self, project_name: str, task_id: str
-    ) -> Union[Dict[str, Any], None]:
+    ) -> dict[str, Any] | None:
         pass
 
 
 class AbstractPublisherFrontend(AbstractPublisherCommon):
     @abstractmethod
-    def get_window_subtitle(self) -> Optional[str]:
+    def get_window_subtitle(self) -> str | None:
         """Get window subtitle.
 
         Returns:
-            Optional[str]: Window subtitle.
+            str | None: Window subtitle.
 
         """
 
     @abstractmethod
-    def register_event_callback(self, topic: str, callback: Callable):
+    def register_event_callback(self, topic: str, callback: Callable) -> None:
         pass
 
     @abstractmethod
@@ -261,44 +261,44 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         pass
 
     @abstractmethod
-    def get_context_title(self) -> Union[str, None]:
+    def get_context_title(self) -> str | None:
         """Get context title for artist shown at the top of main window.
 
         Returns:
-            Union[str, None]: Context title for window or None. In case of None
+            str | None: Context title for window or None. In case of None
                 a warning is displayed (not nice for artists).
-        """
 
+        """
         pass
 
     @abstractmethod
     def get_task_items_by_folder_paths(
         self, folder_paths: Iterable[str]
-    ) -> Dict[str, List[TaskItem]]:
+    ) -> dict[str, list[TaskItem]]:
         pass
 
     @abstractmethod
     def get_folder_items(
-        self, project_name: str, sender: Optional[str] = None
-    ) -> List[FolderItem]:
+        self, project_name: str, sender: str | None = None
+    ) -> list[FolderItem]:
         pass
 
     @abstractmethod
     def get_task_items(
-        self, project_name: str, folder_id: str, sender: Optional[str] = None
-    ) -> List[TaskItem]:
+        self, project_name: str, folder_id: str, sender: str | None = None
+    ) -> list[TaskItem]:
         pass
 
     @abstractmethod
     def get_folder_type_items(
-        self, project_name: str, sender: Optional[str] = None
-    ) -> List[FolderTypeItem]:
+        self, project_name: str, sender: str | None = None
+    ) -> list[FolderTypeItem]:
         pass
 
     @abstractmethod
     def get_task_type_items(
-        self, project_name: str, sender: Optional[str] = None
-    ) -> List[TaskTypeItem]:
+        self, project_name: str, sender: str | None = None
+    ) -> list[TaskTypeItem]:
         pass
 
     @abstractmethod
@@ -315,7 +315,7 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         pass
 
     @abstractmethod
-    def get_folder_id_from_path(self, folder_path: str) -> Optional[str]:
+    def get_folder_id_from_path(self, folder_path: str) -> str | None:
         """Get folder id from folder path."""
         pass
 
@@ -336,11 +336,11 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
 
     # --- Create ---
     @abstractmethod
-    def get_creator_items(self) -> Dict[str, "CreatorItem"]:
+    def get_creator_items(self) -> dict[str, CreatorItem]:
         """Creator items by identifier.
 
         Returns:
-            Dict[str, CreatorItem]: Creator items that will be shown to user.
+            dict[str, CreatorItem]: Creator items that will be shown to user.
 
         """
         pass
@@ -348,14 +348,14 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
     @abstractmethod
     def get_creator_item_by_id(
         self, identifier: str
-    ) -> Optional["CreatorItem"]:
+    ) -> CreatorItem | None:
         """Get creator item by identifier.
 
         Args:
             identifier (str): Create plugin identifier.
 
         Returns:
-            Optional[CreatorItem]: Creator item or None.
+            CreatorItem | None: Creator item or None.
 
         """
         pass
@@ -363,7 +363,7 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
     @abstractmethod
     def get_creator_icon(
         self, identifier: str
-    ) -> Union[str, Dict[str, Any], None]:
+    ) -> str | dict[str, Any] | None:
         """Receive creator's icon by identifier.
 
         Todos:
@@ -373,78 +373,78 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
             identifier (str): Creator's identifier.
 
         Returns:
-            Union[str, None]: Creator's icon string.
-        """
+            str | dict[str, Any] | None: Creator's icon string.
 
+        """
         pass
 
     @abstractmethod
-    def get_convertor_items(self) -> Dict[str, ConvertorItem]:
+    def get_convertor_items(self) -> dict[str, ConvertorItem]:
         """Convertor items by identifier.
 
         Returns:
-            Dict[str, ConvertorItem]: Convertor items that can be triggered
+            dict[str, ConvertorItem]: Convertor items that can be triggered
                 by user.
 
         """
         pass
 
     @abstractmethod
-    def get_instance_items(self) -> List["InstanceItem"]:
+    def get_instance_items(self) -> list[InstanceItem]:
         """Collected/created instances.
 
         Returns:
-            List[InstanceItem]: List of created instances.
+            list[InstanceItem]: List of created instances.
 
         """
         pass
 
     @abstractmethod
     def get_instance_items_by_id(
-        self, instance_ids: Optional[Iterable[str]] = None
-    ) -> Dict[str, Union["InstanceItem", None]]:
+        self, instance_ids: Iterable[str] | None = None
+    ) -> dict[str, InstanceItem | None]:
         pass
 
     @abstractmethod
     def get_instances_context_info(
-        self, instance_ids: Optional[Iterable[str]] = None
+        self, instance_ids: Iterable[str] | None = None
     ):
         pass
 
     @abstractmethod
     def set_instances_context_info(
-        self, changes_by_instance_id: Dict[str, Dict[str, Any]]
-    ):
+        self, changes_by_instance_id: dict[str, dict[str, Any]]
+    ) -> None:
         pass
 
     @abstractmethod
     def set_instances_active_state(
-        self, active_state_by_id: Dict[str, bool]
-    ):
+        self, active_state_by_id: dict[str, bool]
+    ) -> None:
         pass
 
     @abstractmethod
-    def get_existing_product_names(self, folder_path: str) -> List[str]:
+    def get_existing_product_names(self, folder_path: str) -> list[str]:
         pass
 
     @abstractmethod
     def get_creator_attribute_definitions(
         self, instance_ids: Iterable[str]
-    ) -> List[Tuple[AbstractAttrDef, Dict[str, Dict[str, Any]]]]:
+    ) -> list[tuple[AbstractAttrDef, dict[str, dict[str, Any]]]]:
         pass
 
     @abstractmethod
     def set_instances_create_attr_values(
         self, instance_ids: Iterable[str], key: str, value: Any
-    ):
+    ) -> None:
         pass
 
     @abstractmethod
     def revert_instances_create_attr_values(
         self,
-        instance_ids: List["Union[str, None]"],
+        instance_ids: list[str | None],
         key: str,
-    ):
+    ) -> None:
         pass
 
     @abstractmethod
@@ -462,16 +462,16 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         plugin_name: str,
         key: str,
         value: Any
-    ):
+    ) -> None:
         pass
 
     @abstractmethod
     def revert_instances_publish_attr_values(
         self,
-        instance_ids: List["Union[str, None]"],
+        instance_ids: list[str | None],
         plugin_name: str,
         key: str,
-    ):
+    ) -> None:
         pass
 
     @abstractmethod
@@ -503,9 +503,9 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         creator_identifier: str,
         product_type: str,
         variant: str,
-        folder_path: Union[str, None],
-        task_name: Union[str, None],
-        instance_id: Optional[str] = None
+        folder_path: str | None,
+        task_name: str | None,
+        instance_id: str | None = None
     ):
         """Get product name based on passed data.
 
@@ -514,12 +514,14 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
                 responsible for product name creation.
             product_type (str): Product type.
             variant (str): Variant value from user's input.
-            folder_path (str): Folder path for which is instance created.
-            task_name (str): Name of task for which is instance created.
-            instance_id (Union[str, None]): Existing instance id when product
+            folder_path (str | None): Folder path for which
+                is instance created.
+            task_name (str | None): Name of task for which
+                is instance created.
+            instance_id (str | None): Existing instance id when product
                 name is updated.
-        """
 
+        """
         pass
 
     @abstractmethod
@@ -527,33 +529,32 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         self,
         creator_identifier: str,
         product_name: str,
-        instance_data: Dict[str, Any],
-        options: Dict[str, Any],
-    ):
+        instance_data: dict[str, Any],
+        options: dict[str, Any],
+    ) -> None:
         """Trigger creation by creator identifier.
 
         Should also trigger refresh of instances.
 
         Args:
             creator_identifier (str): Identifier of Creator plugin.
-            product_type (str): Product type.
             product_name (str): Calculated product name.
-            instance_data (Dict[str, Any]): Base instance data with variant,
+            instance_data (dict[str, Any]): Base instance data with variant,
                 folder path and task name.
-            options (Dict[str, Any]): Data from pre-create attributes.
+            options (dict[str, Any]): Data from pre-create attributes.
+
         """
-
         pass
 
     @abstractmethod
-    def trigger_convertor_items(self, convertor_identifiers: List[str]):
+    def trigger_convertor_items(
+        self, convertor_identifiers: list[str]
+    ) -> None:
         pass
 
     @abstractmethod
-    def remove_instances(self, instance_ids: Iterable[str]):
+    def remove_instances(self, instance_ids: Iterable[str]) -> None:
         """Remove list of instances from create context."""
-        # TODO expect instance ids
-
         pass
 
     @abstractmethod
@@ -564,42 +565,39 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
 
         Returns:
             bool: Save was successful.
-        """
 
+        """
         pass
 
     # --- Publish ---
     @abstractmethod
-    def publish(self):
+    def publish(self) -> None:
         """Trigger publishing without any order limitations."""
-
         pass
 
     @abstractmethod
-    def validate(self):
+    def validate(self) -> None:
         """Trigger publishing which will stop after validation order."""
-
         pass
 
     @abstractmethod
-    def stop_publish(self):
+    def stop_publish(self) -> None:
         """Stop publishing can be also used to pause publishing.
 
         Pause of publishing is possible only if all plugins successfully
         finished.
         """
-
         pass
 
     @abstractmethod
-    def run_action(self, plugin_id: str, action_id: str):
+    def run_action(self, plugin_id: str, action_id: str) -> None:
         """Trigger pyblish action on a plugin.
 
         Args:
             plugin_id (str): Publish plugin id.
             action_id (str): Publish action id.
-        """
 
+        """
         pass
 
     @abstractmethod
@@ -608,8 +606,8 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
 
         Returns:
             bool: If publishing finished and all plugins were iterated.
-        """
 
+        """
         pass
 
     @abstractmethod
@@ -618,8 +616,8 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
 
         Returns:
             bool: If publishing finished and all plugins were iterated.
-        """
 
+        """
         pass
 
     @abstractmethod
@@ -628,8 +626,8 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
 
         Returns:
             bool: If publishing is in progress.
-        """
 
+        """
         pass
 
     @abstractmethod
@@ -643,7 +641,7 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         pass
 
     @abstractmethod
-    def publish_can_continue(self):
+    def publish_can_continue(self) -> bool:
         """Publish has still plugins to process and did not crash yet.
 
         Returns:
@@ -658,8 +656,8 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
 
         Returns:
             bool: Publishing crashed.
-        """
 
+        """
         pass
 
     @abstractmethod
@@ -668,8 +666,8 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
 
         Returns:
             bool: Validation error was raised during validation.
-        """
 
+        """
         pass
 
     @abstractmethod
@@ -688,16 +686,16 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
 
         Returns:
             int: Number that can be used as 100% of publish progress bar.
-        """
 
+        """
         pass
 
     @abstractmethod
-    def get_publish_error_info(self) -> Optional["PublishErrorInfo"]:
+    def get_publish_error_info(self) -> PublishErrorInfo | None:
         """Current error message which cause fail of publishing.
 
         Returns:
-            Optional[PublishErrorInfo]: Error info or None.
+            PublishErrorInfo | None: Error info or None.
 
         """
         pass
@@ -711,7 +709,7 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         pass
 
     @abstractmethod
-    def get_publish_errors_report(self):
+    def get_publish_errors_report(self) -> PublishErrorsReport:
         pass
 
     @abstractmethod
@@ -719,27 +717,27 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         pass
 
     @abstractmethod
-    def set_comment(self, comment: str):
+    def set_comment(self, comment: str) -> None:
         """Set comment on pyblish context.
 
         Set "comment" key on current pyblish.api.Context data.
 
         Args:
             comment (str): Artist's comment.
-        """
 
+        """
         pass
 
     @abstractmethod
     def get_thumbnail_paths_for_instances(
-        self, instance_ids: List[str]
-    ) -> Dict[str, Union[str, None]]:
+        self, instance_ids: list[str]
+    ) -> dict[str, str | None]:
         pass
 
     @abstractmethod
     def set_thumbnail_paths_for_instances(
-        self, thumbnail_path_mapping: Dict[str, Optional[str]]
-    ):
+        self, thumbnail_path_mapping: dict[str, str | None]
+    ) -> None:
         pass
 
     @abstractmethod
@@ -748,12 +746,11 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
 
         Returns:
             str: Path to a directory.
-        """
 
+        """
         pass
 
     @abstractmethod
-    def clear_thumbnail_temp_dir_path(self):
+    def clear_thumbnail_temp_dir_path(self) -> None:
         """Remove content of thumbnail temp directory."""
-
         pass

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -11,17 +11,7 @@ from typing import (
 )
 import uuid
 
-from ayon_core.tools.common_models import (
-    FolderItem,
-    TaskItem,
-    FolderTypeItem,
-    TaskTypeItem,
-)
 from ayon_core.pipeline.publish import PublishError, KnownPublishError
-from ayon_core.pipeline.publish.logic import (
-    PublishErrorInfo,
-    ActionType,
-)
 
 if TYPE_CHECKING:
     from ayon_core.lib import AbstractAttrDef
@@ -31,6 +21,14 @@ if TYPE_CHECKING:
         ConvertorItem,
     )
     from ayon_core.pipeline.publish import PublishReport, PublishLogic
+    from ayon_core.pipeline.publish.logic import ActionType, PublishErrorInfo
+
+    from ayon_core.tools.common_models import (
+        FolderItem,
+        TaskItem,
+        FolderTypeItem,
+        TaskTypeItem,
+    )
 
     from .models import CreatorItem, InstanceItem
 

--- a/client/ayon_core/tools/publisher/control.py
+++ b/client/ayon_core/tools/publisher/control.py
@@ -610,8 +610,8 @@ class PublisherController(
     def get_publish_progress(self):
         return self._publish_model.get_progress()
 
-    def get_publish_error_info(self):
-        return self._publish_model.get_error_info()
+    def get_publish_fail_info(self):
+        return self._publish_model.get_publish_fail_info()
 
     def get_publish_report(self):
         return self._publish_model.get_publish_report()
@@ -622,8 +622,8 @@ class PublisherController(
     def store_publish_report(self, filepath: str) -> None:
         self._publish_model.store_publish_report(filepath)
 
-    def get_publish_errors_report(self):
-        return self._publish_model.get_publish_errors_report()
+    def get_publish_errors_reports(self):
+        return self._publish_model.get_publish_errors_reports()
 
     def set_comment(self, comment: str) -> None:
         """Set comment from ui to pyblish context.

--- a/client/ayon_core/tools/publisher/control.py
+++ b/client/ayon_core/tools/publisher/control.py
@@ -625,7 +625,7 @@ class PublisherController(
     def get_publish_errors_report(self):
         return self._publish_model.get_publish_errors_report()
 
-    def set_comment(self, comment):
+    def set_comment(self, comment: str) -> None:
         """Set comment from ui to pyblish context.
 
         This should be called always before publishing is started but should
@@ -635,7 +635,7 @@ class PublisherController(
 
         self._publish_model.set_comment(comment)
 
-    def publish(self):
+    def publish(self) -> None:
         """Run publishing.
 
         Make sure all changes are saved before method is called (Call
@@ -643,7 +643,7 @@ class PublisherController(
         """
         self._start_publish(False)
 
-    def validate(self):
+    def validate(self) -> None:
         """Run publishing and stop after Validation.
 
         Make sure all changes are saved before method is called (Call
@@ -651,17 +651,17 @@ class PublisherController(
         """
         self._start_publish(True)
 
-    def stop_publish(self):
+    def stop_publish(self) -> None:
         """Stop publishing process (any reason)."""
         self._publish_model.stop_publish()
 
-    def run_action(self, plugin_id, action_id):
+    def run_action(self, plugin_id: str, action_id: str) -> None:
         self._publish_model.run_action(plugin_id, action_id)
 
     def _create_event_system(self):
         return QueuedEventSystem()
 
-    def _emit_event(self, topic, data=None):
+    def _emit_event(self, topic: str, data: dict | None = None) -> None:
         self.emit_event(topic, data, "controller")
 
     def _start_publish(self, up_validation: bool) -> None:

--- a/client/ayon_core/tools/publisher/control.py
+++ b/client/ayon_core/tools/publisher/control.py
@@ -76,17 +76,8 @@ class PublisherController(
         "publish.process.stopped" - Publishing stopped/paused process.
         "publish.process.plugin.changed" - Plugin state has changed.
         "publish.process.instance.changed" - Instance state has changed.
-        "publish.has_validated.changed" - Attr 'publish_has_validated'
-            changed.
-        "publish.is_running.changed" - Attr 'publish_is_running' changed.
-        "publish.has_crashed.changed" - Attr 'publish_has_crashed' changed.
-        "publish.publish_error.changed" - Attr 'publish_error'
-        "publish.has_validation_errors.changed" - Attr
-            'has_validation_errors' changed.
-        "publish.max_progress.changed" - Attr 'publish_max_progress'
-            changed.
-        "publish.progress.changed" - Attr 'publish_progress' changed.
-        "publish.finished.changed" - Attr 'publish_has_finished' changed.
+        "publish.has_validated" - Publishing validated.
+        "publish.finished" - Publishing finished.
 
     Args:
         headless (bool): Headless publishing. ATM not implemented or used.
@@ -605,7 +596,7 @@ class PublisherController(
         return self._publish_model.has_validated()
 
     def publish_has_crashed(self):
-        return self._publish_model.is_crashed()
+        return self._publish_model.has_crashed()
 
     def publish_has_validation_errors(self):
         return self._publish_model.has_validation_errors()
@@ -673,7 +664,7 @@ class PublisherController(
     def _emit_event(self, topic, data=None):
         self.emit_event(topic, data, "controller")
 
-    def _start_publish(self, up_validation):
+    def _start_publish(self, up_validation: bool) -> None:
         self._publish_model.set_publish_up_validation(up_validation)
         self._publish_model.start_publish(wait=True)
 

--- a/client/ayon_core/tools/publisher/control.py
+++ b/client/ayon_core/tools/publisher/control.py
@@ -650,8 +650,10 @@ class PublisherController(
     def _emit_event(self, topic: str, data: dict | None = None) -> None:
         self.emit_event(topic, data, "controller")
 
-    def _start_publish(self, up_validation: bool) -> None:
-        self._publish_model.set_publish_up_validation(up_validation)
+    def _start_publish(self, stop_after_validation: bool) -> None:
+        self._publish_model.set_stop_after_validation(
+            stop_after_validation
+        )
         self._publish_model.start_publish(wait=True)
 
     def get_comment_def(self) -> CommentDef:

--- a/client/ayon_core/tools/publisher/control.py
+++ b/client/ayon_core/tools/publisher/control.py
@@ -651,7 +651,7 @@ class PublisherController(
         self.emit_event(topic, data, "controller")
 
     def _start_publish(self, stop_after_validation: bool) -> None:
-        self._publish_model.set_stop_after_validation(
+        self._publish_model.set_publish_stop_after_validation(
             stop_after_validation
         )
         self._publish_model.start_publish(wait=True)

--- a/client/ayon_core/tools/publisher/control_qt.py
+++ b/client/ayon_core/tools/publisher/control_qt.py
@@ -106,8 +106,9 @@ class QtPublisherController(PublisherController):
             return
 
         self._item_process_in_loop = True
+        self._publish_model.process_next_iter()
         self._process_main_thread_item(
-            MainThreadItem(self._publish_model.process_next_iter)
+            MainThreadItem(self._next_publish_item_process)
         )
 
     def _process_main_thread_item(self, item):

--- a/client/ayon_core/tools/publisher/control_qt.py
+++ b/client/ayon_core/tools/publisher/control_qt.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import collections
 from dataclasses import dataclass
 
-import pyblish.api
 from qtpy import QtCore
 
 from ayon_core.pipeline.publish.logic import (
     PublishIterInfo,
     PublishIterAction,
+    PluginType,
 )
 
 from .control import PublisherController
@@ -83,7 +83,7 @@ class _IterData:
     # Store the label of the current item being processed
     item_label: str = ""
     # Store the current plugin being processed
-    plugin: pyblish.api.Plugin | None = None
+    plugin: PluginType | None = None
     # Store whether the publish process has been validated
     validated: bool = False
 

--- a/client/ayon_core/tools/publisher/control_qt.py
+++ b/client/ayon_core/tools/publisher/control_qt.py
@@ -130,57 +130,12 @@ class QtPublisherController(PublisherController):
         if not self._publish_model.is_running():
             # This removes '_next_publish_item_process' from loop
             self._item_process_in_loop = False
-            self._publish_model.process_stopped()
             return
 
         self._item_process_in_loop = True
-        iter_info = self._publish_model.get_next_process_func()
         self._process_main_thread_item(
-            MainThreadItem(self._process_iter_info, iter_info)
+            MainThreadItem(self._publish_model.process_next_iter)
         )
-
-    def _process_iter_info(self, iter_info: PublishIterInfo):
-        item_label = iter_info.item_label
-        plugin = iter_info.plugin
-        if (
-            plugin is not None
-            and plugin is not self._iter_data.plugin
-        ):
-            self._iter_data.plugin = plugin
-            plugin_label = getattr(plugin, "label", None)
-            if not plugin_label:
-                plugin_label = plugin.__name__
-
-            self._emit_event(
-                "publish.process.plugin.changed",
-                {"plugin_label": plugin_label},
-            )
-
-        if (
-            item_label is not None
-            and item_label != self._iter_data.item_label
-        ):
-            self._iter_data.item_label = item_label
-            self._emit_event(
-                "publish.process.instance.changed",
-                {"instance_label": item_label},
-            )
-
-        iter_info()
-        if (
-            not self._iter_data.validated
-            and self._publish_model.has_validated()
-        ):
-            self._iter_data.validated = True
-            self._emit_event("publish.has_validated")
-
-        if iter_info.action is PublishIterAction.Stop:
-            self._publish_model.process_stopped()
-            self._item_process_in_loop = False
-        else:
-            self._process_main_thread_item(
-                MainThreadItem(self._next_publish_item_process)
-            )
 
     def _process_main_thread_item(self, item):
         self._main_thread_processor.add_item(item)

--- a/client/ayon_core/tools/publisher/control_qt.py
+++ b/client/ayon_core/tools/publisher/control_qt.py
@@ -95,21 +95,19 @@ class QtPublisherController(PublisherController):
         # Make sure '_next_publish_item_process' is only once in
         #   the '_main_thread_processor' loop
         if not self._item_process_in_loop:
+            self._item_process_in_loop = True
             self._process_main_thread_item(
                 MainThreadItem(self._next_publish_item_process)
             )
 
     def _next_publish_item_process(self):
-        if not self._publish_model.is_running():
+        if self._publish_model.process_next_iter():
+            self._process_main_thread_item(
+                MainThreadItem(self._next_publish_item_process)
+            )
+        else:
             # This removes '_next_publish_item_process' from loop
             self._item_process_in_loop = False
-            return
-
-        self._item_process_in_loop = True
-        self._publish_model.process_next_iter()
-        self._process_main_thread_item(
-            MainThreadItem(self._next_publish_item_process)
-        )
 
     def _process_main_thread_item(self, item):
         self._main_thread_processor.add_item(item)

--- a/client/ayon_core/tools/publisher/control_qt.py
+++ b/client/ayon_core/tools/publisher/control_qt.py
@@ -1,20 +1,10 @@
 from __future__ import annotations
 
 import collections
-from dataclasses import dataclass
-import typing
 
 from qtpy import QtCore
 
-from ayon_core.pipeline.publish.logic import PublishIterAction
-
 from .control import PublisherController
-
-if typing.TYPE_CHECKING:
-    from ayon_core.pipeline.publish.logic import (
-        PublishIterInfo,
-        PluginType,
-    )
 
 
 class MainThreadItem:
@@ -76,21 +66,6 @@ class MainThreadProcess(QtCore.QObject):
         self.stop()
 
 
-@dataclass
-class _IterData:
-    """Store iteration data for a single publish process.
-
-    Changes of the value do trigger an event (not handled by this class).
-
-    """
-    # Store the label of the current item being processed
-    item_label: str = ""
-    # Store the current plugin being processed
-    plugin: PluginType | None = None
-    # Store whether the publish process has been validated
-    validated: bool = False
-
-
 class QtPublisherController(PublisherController):
     def __init__(self, *args, **kwargs):
         self._main_thread_processor = MainThreadProcess()
@@ -106,12 +81,10 @@ class QtPublisherController(PublisherController):
         # Capture if '_next_publish_item_process' is in
         #   '_main_thread_processor' loop
         self._item_process_in_loop = False
-        self._iter_data = _IterData()
 
     def reset(self):
         self._main_thread_processor.clear()
         self._item_process_in_loop = False
-        self._iter_data = _IterData()
         super().reset()
 
     def _start_publish(self, stop_after_validation: bool) -> None:

--- a/client/ayon_core/tools/publisher/control_qt.py
+++ b/client/ayon_core/tools/publisher/control_qt.py
@@ -115,7 +115,7 @@ class QtPublisherController(PublisherController):
         super().reset()
 
     def _start_publish(self, stop_after_validation: bool) -> None:
-        self._publish_model.set_stop_after_validation(
+        self._publish_model.set_publish_stop_after_validation(
             stop_after_validation
         )
         self._publish_model.start_publish(wait=False)

--- a/client/ayon_core/tools/publisher/control_qt.py
+++ b/client/ayon_core/tools/publisher/control_qt.py
@@ -114,8 +114,10 @@ class QtPublisherController(PublisherController):
         self._iter_data = _IterData()
         super().reset()
 
-    def _start_publish(self, up_validation: bool) -> None:
-        self._publish_model.set_publish_up_validation(up_validation)
+    def _start_publish(self, stop_after_validation: bool) -> None:
+        self._publish_model.set_stop_after_validation(
+            stop_after_validation
+        )
         self._publish_model.start_publish(wait=False)
         # Make sure '_next_publish_item_process' is only once in
         #   the '_main_thread_processor' loop

--- a/client/ayon_core/tools/publisher/control_qt.py
+++ b/client/ayon_core/tools/publisher/control_qt.py
@@ -2,16 +2,19 @@ from __future__ import annotations
 
 import collections
 from dataclasses import dataclass
+import typing
 
 from qtpy import QtCore
 
-from ayon_core.pipeline.publish.logic import (
-    PublishIterInfo,
-    PublishIterAction,
-    PluginType,
-)
+from ayon_core.pipeline.publish.logic import PublishIterAction
 
 from .control import PublisherController
+
+if typing.TYPE_CHECKING:
+    from ayon_core.pipeline.publish.logic import (
+        PublishIterInfo,
+        PluginType,
+    )
 
 
 class MainThreadItem:

--- a/client/ayon_core/tools/publisher/control_qt.py
+++ b/client/ayon_core/tools/publisher/control_qt.py
@@ -1,6 +1,15 @@
-import collections
+from __future__ import annotations
 
+import collections
+from dataclasses import dataclass
+
+import pyblish.api
 from qtpy import QtCore
+
+from ayon_core.pipeline.publish.logic import (
+    PublishIterInfo,
+    PublishIterAction,
+)
 
 from .control import PublisherController
 
@@ -64,6 +73,21 @@ class MainThreadProcess(QtCore.QObject):
         self.stop()
 
 
+@dataclass
+class _IterData:
+    """Store iteration data for a single publish process.
+
+    Changes of the value do trigger an event (not handled by this class).
+
+    """
+    # Store the label of the current item being processed
+    item_label: str = ""
+    # Store the current plugin being processed
+    plugin: pyblish.api.Plugin | None = None
+    # Store whether the publish process has been validated
+    validated: bool = False
+
+
 class QtPublisherController(PublisherController):
     def __init__(self, *args, **kwargs):
         self._main_thread_processor = MainThreadProcess()
@@ -79,13 +103,15 @@ class QtPublisherController(PublisherController):
         # Capture if '_next_publish_item_process' is in
         #   '_main_thread_processor' loop
         self._item_process_in_loop = False
+        self._iter_data = _IterData()
 
     def reset(self):
         self._main_thread_processor.clear()
         self._item_process_in_loop = False
+        self._iter_data = _IterData()
         super().reset()
 
-    def _start_publish(self, up_validation):
+    def _start_publish(self, up_validation: bool) -> None:
         self._publish_model.set_publish_up_validation(up_validation)
         self._publish_model.start_publish(wait=False)
         # Make sure '_next_publish_item_process' is only once in
@@ -99,14 +125,57 @@ class QtPublisherController(PublisherController):
         if not self._publish_model.is_running():
             # This removes '_next_publish_item_process' from loop
             self._item_process_in_loop = False
+            self._publish_model.process_stopped()
             return
 
         self._item_process_in_loop = True
-        func = self._publish_model.get_next_process_func()
-        self._process_main_thread_item(MainThreadItem(func))
+        iter_info = self._publish_model.get_next_process_func()
         self._process_main_thread_item(
-            MainThreadItem(self._next_publish_item_process)
+            MainThreadItem(self._process_iter_info, iter_info)
         )
+
+    def _process_iter_info(self, iter_info: PublishIterInfo):
+        item_label = iter_info.item_label
+        plugin = iter_info.plugin
+        if (
+            plugin is not None
+            and plugin is not self._iter_data.plugin
+        ):
+            self._iter_data.plugin = plugin
+            plugin_label = getattr(plugin, "label", None)
+            if not plugin_label:
+                plugin_label = plugin.__name__
+
+            self._emit_event(
+                "publish.process.plugin.changed",
+                {"plugin_label": plugin_label},
+            )
+
+        if (
+            item_label is not None
+            and item_label != self._iter_data.item_label
+        ):
+            self._iter_data.item_label = item_label
+            self._emit_event(
+                "publish.process.instance.changed",
+                {"instance_label": item_label},
+            )
+
+        iter_info()
+        if (
+            not self._iter_data.validated
+            and self._publish_model.has_validated()
+        ):
+            self._iter_data.validated = True
+            self._emit_event("publish.has_validated")
+
+        if iter_info.action is PublishIterAction.Stop:
+            self._publish_model.process_stopped()
+            self._item_process_in_loop = False
+        else:
+            self._process_main_thread_item(
+                MainThreadItem(self._next_publish_item_process)
+            )
 
     def _process_main_thread_item(self, item):
         self._main_thread_processor.add_item(item)

--- a/client/ayon_core/tools/publisher/models/__init__.py
+++ b/client/ayon_core/tools/publisher/models/__init__.py
@@ -1,5 +1,5 @@
 from .create import CreateModel, CreatorItem, InstanceItem
-from .publish import PublishModel, PublishErrorInfo
+from .publish import PublishModel, UIFailInfo
 
 
 __all__ = (
@@ -8,5 +8,5 @@ __all__ = (
     "InstanceItem",
 
     "PublishModel",
-    "PublishErrorInfo",
+    "UIFailInfo",
 )

--- a/client/ayon_core/tools/publisher/models/create.py
+++ b/client/ayon_core/tools/publisher/models/create.py
@@ -107,11 +107,11 @@ class CreatorUIItem:
         )
 
     def to_data(self) -> dict[str, Any]:
-        return {
-            "product_type": self.product_type,
-            "label": self.label,
-            "filtered": self.filtered,
-        }
+        return dict(
+            product_type=self.product_type,
+            label=self.label,
+            filtered=self.filtered,
+        )
 
 
 class CreatorItem:

--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -1,53 +1,24 @@
 from __future__ import annotations
 
 import traceback
-from functools import partial
-from typing import Any, Iterable
+from typing import Any
 
-import pyblish.plugin
 
+from ayon_core.lib import env_value_to_bool
 from ayon_core.pipeline.publish.logic import (
     PublishIterInfo,
     PublishLogic,
     PublishActionResult,
-    PublishErrorInfo,
-    PublishErrorsReport,
+    PublishFailReason,
 )
 from ayon_core.pipeline.publish.report import PublishReport
-from ayon_core.tools.publisher.abstract import AbstractPublisherBackend
+from ayon_core.tools.publisher.abstract import (
+    AbstractPublisherBackend,
+    UIFailInfo,
+    UIPublishErrorReport,
+)
 
 PUBLISH_EVENT_SOURCE = "publisher.publish.model"
-
-
-def collect_families_from_instances(
-    instances: list[pyblish.api.Instance],
-    only_active: bool = False,
-) -> list[str]:
-    """Collect all families for passed publish instances.
-
-    Args:
-        instances (list[pyblish.api.Instance]): List of publish instances from
-            which are families collected.
-        only_active (bool): Return families only for active instances.
-
-    Returns:
-        list[str]: Families available on instances.
-
-    """
-    all_families = set()
-    for instance in instances:
-        if only_active:
-            if instance.data.get("publish") is False:
-                continue
-        family = instance.data.get("family")
-        if family:
-            all_families.add(family)
-
-        families = instance.data.get("families") or tuple()
-        for family in families:
-            all_families.add(family)
-
-    return list(all_families)
 
 
 class PublishModel:
@@ -55,11 +26,20 @@ class PublishModel:
         self._controller = controller
 
         self._logic: PublishLogic = PublishLogic()
+        self._logic.set_strict_validation_error_handling(False)
+        self._logic.set_log_to_console(
+            env_value_to_bool("AYON_PUBLISHER_PRINT_LOGS", default=False)
+        )
 
     def reset(self):
         create_context = self._controller.get_create_context()
 
         self._logic.reset_from_create_context(create_context)
+        self._logic.set_strict_validation_error_handling(False)
+        # Allow to change behavior during process lifetime
+        self._logic.set_log_to_console(
+            env_value_to_bool("AYON_PUBLISHER_PRINT_LOGS", default=False)
+        )
 
         self._emit_event("publish.reset.finished")
 
@@ -112,7 +92,7 @@ class PublishModel:
 
     def process_stopped(self):
         self._emit_event("publish.process.stopped")
-        if self._logic.has_crashed():
+        if self._logic.has_failed():
             pass
         elif self._logic.has_finished():
             self._emit_event("publish.finished")
@@ -127,7 +107,7 @@ class PublishModel:
         return self._logic.is_running()
 
     def has_crashed(self) -> bool:
-        return self._logic.has_crashed()
+        return self._logic.get_fail_reason() == PublishFailReason.Error
 
     def has_started(self) -> bool:
         return self._logic.has_started()
@@ -156,15 +136,21 @@ class PublishModel:
     def get_publish_report_data(self) -> dict[str, Any]:
         return self._logic.get_publish_report_data()
 
-    def get_publish_errors_report(self) -> PublishErrorsReport:
-        return self._logic.get_publish_errors_report()
+    def get_publish_errors_reports(self) -> list[UIPublishErrorReport]:
+        return UIPublishErrorReport.get_items_grouped_by_title(self._logic)
 
-    def get_error_info(self) -> PublishErrorInfo | None:
-        return self._logic.get_error_info()
+    def get_publish_fail_info(self) -> UIFailInfo | None:
+        fail_reason = self._logic.get_fail_reason()
+        if fail_reason != PublishFailReason.Error:
+            return None
+
+        error_info = self._logic.get_error_info()
+        if error_info is None:
+            return None
+        return UIFailInfo.from_exception(error_info.exception)
 
     def store_publish_report(self, filepath: str) -> None:
-        report: PublishReport = self.get_publish_report()
-        report.store_to_file(filepath)
+        self._logic.store_publish_report(filepath)
 
     def set_comment(self, comment: str):
         self._logic.set_comment(comment)
@@ -197,103 +183,3 @@ class PublishModel:
 
     def _emit_event(self, topic: str, data: dict[str, Any] | None = None):
         self._controller.emit_event(topic, data, PUBLISH_EVENT_SOURCE)
-
-    def _publish_iterator(self) -> Iterable[partial]:
-        """Main logic center of publishing.
-
-        Iterator returns `partial` objects with callbacks that should be
-        processed in main thread (threaded in future?). Cares about changing
-        states of currently processed publish plugin and instance. Also
-        change state of processed orders like validation order has passed etc.
-
-        Also stops publishing, if should stop on validation.
-        """
-
-        for idx, plugin in enumerate(self._publish_plugins):
-            self._publish_progress = idx
-
-            # Check if plugin is over validation order
-            if (
-                not self._publish_has_validated
-                and plugin.order >= self._validation_order
-            ):
-                self._set_has_validated(True)
-                if (
-                    self._publish_up_validation
-                    or self._publish_has_validation_errors
-                ):
-                    yield partial(self.stop_publish)
-
-            # Add plugin to publish report
-            self._publish_report.add_plugin_iter(
-                plugin.id, self._publish_context)
-
-            # WARNING This is hack fix for optional plugins
-            if not self._is_publish_plugin_active(plugin):
-                self._publish_report.set_plugin_skipped(plugin.id)
-                continue
-
-            # Trigger callback that new plugin is going to be processed
-            plugin_label = plugin.__name__
-            if hasattr(plugin, "label") and plugin.label:
-                plugin_label = plugin.label
-            self._emit_event(
-                "publish.process.plugin.changed",
-                {"plugin_label": plugin_label}
-            )
-
-            # Plugin is instance plugin
-            if plugin.__instanceEnabled__:
-                instances = pyblish.logic.instances_by_plugin(
-                    self._publish_context, plugin
-                )
-                if not instances:
-                    self._publish_report.set_plugin_skipped(plugin.id)
-                    continue
-
-                for instance in instances:
-                    if instance.data.get("publish") is False:
-                        continue
-
-                    instance_label = (
-                        instance.data.get("label")
-                        or instance.data["name"]
-                    )
-                    self._emit_event(
-                        "publish.process.instance.changed",
-                        {"instance_label": instance_label}
-                    )
-
-                    yield partial(
-                        self._process_and_continue, plugin, instance
-                    )
-            else:
-                families = collect_families_from_instances(
-                    self._publish_context, only_active=True
-                )
-                plugins = pyblish.logic.plugins_by_families(
-                    [plugin], families
-                )
-                if not plugins:
-                    self._publish_report.set_plugin_skipped(plugin.id)
-                    continue
-
-                instance_label = (
-                    self._publish_context.data.get("label")
-                    or self._publish_context.data.get("name")
-                    or "Context"
-                )
-                self._emit_event(
-                    "publish.process.instance.changed",
-                    {"instance_label": instance_label}
-                )
-                yield partial(
-                    self._process_and_continue, plugin, None
-                )
-
-            self._publish_report.set_plugin_passed(plugin.id)
-
-        # Cleanup of publishing process
-        self._set_finished(True)
-        self._set_progress(self._publish_max_progress)
-        yield partial(self.stop_publish)

--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -12,7 +12,6 @@ from ayon_core.pipeline.publish.logic import (
     PublishFailReason,
 )
 from ayon_core.tools.publisher.abstract import (
-    AbstractPublisherBackend,
     UIFailInfo,
     UIPublishErrorReport,
 )
@@ -23,6 +22,7 @@ if typing.TYPE_CHECKING:
         PublishActionResult,
     )
     from ayon_core.pipeline.publish.report import PublishReport
+    from ayon_core.tools.publisher.abstract import AbstractPublisherBackend
 
 PUBLISH_EVENT_SOURCE = "publisher.publish.model"
 

--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -47,7 +47,7 @@ class PublishModel:
 
         self._emit_event("publish.reset.finished")
 
-    def set_stop_after_validation(self, value: bool) -> None:
+    def set_publish_stop_after_validation(self, value: bool) -> None:
         self._logic.set_stop_after_validation(value)
 
     def start_publish(self, wait: bool = True) -> None:

--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -37,7 +37,7 @@ class PublishModel:
     def __init__(self, controller: AbstractPublisherBackend):
         self._controller = controller
 
-        self._logic: PublishLogic = PublishLogic()
+        self._logic: PublishLogic = PublishLogic(reset=False)
         self._logic.set_strict_validation_error_handling(False)
         self._logic.set_log_to_console(
             env_value_to_bool("AYON_PUBLISHER_PRINT_LOGS", default=False)

--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -10,6 +10,7 @@ from ayon_core.lib import env_value_to_bool
 from ayon_core.pipeline.publish.logic import (
     PublishLogic,
     PublishFailReason,
+    PublishIterAction,
 )
 from ayon_core.tools.publisher.abstract import (
     AbstractPublisherBackend,
@@ -81,23 +82,23 @@ class PublishModel:
         func: PublishIterInfo = self._logic.get_next_process_func()
         plugin = func.plugin
         item_label = func.item_label
+        if func.action == PublishIterAction.Continue:
+            if self._publish_state.plugin is not plugin:
+                self._publish_state.plugin = plugin
+                plugin_label = getattr(plugin, "label", None)
+                if not plugin_label:
+                    plugin_label = plugin.__name__
+                self._emit_event(
+                "publish.process.plugin.changed",
+                {"plugin_label": plugin_label}
+                )
 
-        if self._publish_state.plugin is not plugin:
-            self._publish_state.plugin = plugin
-            plugin_label = getattr(plugin, "label", None)
-            if not plugin_label:
-                plugin_label = plugin.__name__
-            self._emit_event(
-            "publish.process.plugin.changed",
-            {"plugin_label": plugin_label}
-            )
-
-        if self._publish_state.item_label != item_label:
-            self._publish_state.item_label = item_label
-            self._emit_event(
-                "publish.process.instance.changed",
-                {"instance_label": item_label}
-            )
+            if self._publish_state.item_label != item_label:
+                self._publish_state.item_label = item_label
+                self._emit_event(
+                    "publish.process.instance.changed",
+                    {"instance_label": item_label}
+                )
 
         func()
         if not self._publish_state.validated and self._logic.has_validated():

--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -1,22 +1,26 @@
 from __future__ import annotations
 
 import traceback
+import typing
 from typing import Any
-
 
 from ayon_core.lib import env_value_to_bool
 from ayon_core.pipeline.publish.logic import (
-    PublishIterInfo,
     PublishLogic,
-    PublishActionResult,
     PublishFailReason,
 )
-from ayon_core.pipeline.publish.report import PublishReport
 from ayon_core.tools.publisher.abstract import (
     AbstractPublisherBackend,
     UIFailInfo,
     UIPublishErrorReport,
 )
+
+if typing.TYPE_CHECKING:
+    from ayon_core.pipeline.publish.logic import (
+        PublishIterInfo,
+        PublishActionResult,
+    )
+    from ayon_core.pipeline.publish.report import PublishReport
 
 PUBLISH_EVENT_SOURCE = "publisher.publish.model"
 

--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -10,7 +10,6 @@ from ayon_core.lib import env_value_to_bool
 from ayon_core.pipeline.publish.logic import (
     PublishLogic,
     PublishFailReason,
-    PublishIterAction,
 )
 from ayon_core.tools.publisher.abstract import (
     AbstractPublisherBackend,
@@ -78,39 +77,51 @@ class PublishModel:
             while self.is_running():
                 self.process_next_iter()
 
-    def process_next_iter(self) -> None:
+    def process_next_iter(self) -> bool:
+        """Process next iteration of publishing.
+
+        Returns:
+            bool: True if publishing is still running, False if finished.
+
+        """
+        if not self._logic.is_running():
+            self._emit_event("publish.process.stopped")
+            if not self._logic.has_failed() and self._logic.has_finished():
+                self._emit_event("publish.finished")
+            return False
+
         func: PublishIterInfo = self._logic.get_next_process_func()
         plugin = func.plugin
         item_label = func.item_label
-        if func.action == PublishIterAction.Continue:
-            if self._publish_state.plugin is not plugin:
-                self._publish_state.plugin = plugin
-                plugin_label = getattr(plugin, "label", None)
-                if not plugin_label:
-                    plugin_label = plugin.__name__
-                self._emit_event(
-                "publish.process.plugin.changed",
-                {"plugin_label": plugin_label}
-                )
+        if (
+            plugin is not None
+            and self._publish_state.plugin is not plugin
+        ):
+            self._publish_state.plugin = plugin
+            plugin_label = getattr(plugin, "label", None)
+            if not plugin_label:
+                plugin_label = plugin.__name__
+            self._emit_event(
+            "publish.process.plugin.changed",
+            {"plugin_label": plugin_label}
+            )
 
-            if self._publish_state.item_label != item_label:
-                self._publish_state.item_label = item_label
-                self._emit_event(
-                    "publish.process.instance.changed",
-                    {"instance_label": item_label}
-                )
+        if (
+            item_label is not None
+            and self._publish_state.item_label != item_label
+        ):
+            self._publish_state.item_label = item_label
+            self._emit_event(
+                "publish.process.instance.changed",
+                {"instance_label": item_label}
+            )
 
         func()
         if not self._publish_state.validated and self._logic.has_validated():
             self._publish_state.validated = True
             self._emit_event("publish.has_validated")
 
-        if not self.is_running():
-            self._emit_event("publish.process.stopped")
-            if self._logic.has_failed():
-                pass
-            elif self._logic.has_finished():
-                self._emit_event("publish.finished")
+        return True
 
     def stop_publish(self) -> None:
         self._logic.stop_publish()

--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -4,6 +4,8 @@ import traceback
 import typing
 from typing import Any
 
+import pyblish
+
 from ayon_core.lib import env_value_to_bool
 from ayon_core.pipeline.publish.logic import (
     PublishLogic,
@@ -25,6 +27,12 @@ if typing.TYPE_CHECKING:
 PUBLISH_EVENT_SOURCE = "publisher.publish.model"
 
 
+class CurrentPublishState:
+    plugin: pyblish.api.Plugin | None = None
+    item_label: str | None = None
+    validated: bool = False
+
+
 class PublishModel:
     def __init__(self, controller: AbstractPublisherBackend):
         self._controller = controller
@@ -35,6 +43,8 @@ class PublishModel:
             env_value_to_bool("AYON_PUBLISHER_PRINT_LOGS", default=False)
         )
 
+        self._publish_state = CurrentPublishState()
+
     def reset(self):
         create_context = self._controller.get_create_context()
 
@@ -44,6 +54,7 @@ class PublishModel:
         self._logic.set_log_to_console(
             env_value_to_bool("AYON_PUBLISHER_PRINT_LOGS", default=False)
         )
+        self._publish_state = CurrentPublishState()
 
         self._emit_event("publish.reset.finished")
 
@@ -62,47 +73,43 @@ class PublishModel:
         self._emit_event("publish.process.started")
 
         self._logic.start_publish(wait=False)
-        if not wait:
-            return
+        if wait:
+            while self.is_running():
+                self.process_next_iter()
 
-        plugin = None
-        item_label = None
-        validated = False
-        while self.is_running():
-            func: PublishIterInfo = self.get_next_process_func()
-            if plugin is not func.plugin:
-                plugin = func.plugin
-                plugin_label = getattr(plugin, "label", None)
-                if not plugin_label:
-                    plugin_label = plugin.__name__
-                self._emit_event(
-                "publish.process.plugin.changed",
-                {"plugin_label": plugin_label}
-                )
+    def process_next_iter(self) -> None:
+        func: PublishIterInfo = self._logic.get_next_process_func()
+        plugin = func.plugin
+        item_label = func.item_label
 
-            if item_label != func.item_label:
-                item_label = func.item_label
-                self._emit_event(
-                    "publish.process.instance.changed",
-                    {"instance_label": item_label}
-                )
+        if self._publish_state.plugin is not plugin:
+            self._publish_state.plugin = plugin
+            plugin_label = getattr(plugin, "label", None)
+            if not plugin_label:
+                plugin_label = plugin.__name__
+            self._emit_event(
+            "publish.process.plugin.changed",
+            {"plugin_label": plugin_label}
+            )
 
-            func()
-            if not validated and self._logic.has_validated():
-                validated = True
-                self._emit_event("publish.has_validated")
+        if self._publish_state.item_label != item_label:
+            self._publish_state.item_label = item_label
+            self._emit_event(
+                "publish.process.instance.changed",
+                {"instance_label": item_label}
+            )
 
-        self.process_stopped()
+        func()
+        if not self._publish_state.validated and self._logic.has_validated():
+            self._publish_state.validated = True
+            self._emit_event("publish.has_validated")
 
-    def process_stopped(self):
-        self._emit_event("publish.process.stopped")
-        if self._logic.has_failed():
-            pass
-        elif self._logic.has_finished():
-            self._emit_event("publish.finished")
-
-    def get_next_process_func(self) -> PublishIterInfo:
-        return self._logic.get_next_process_func()
+        if not self.is_running():
+            self._emit_event("publish.process.stopped")
+            if self._logic.has_failed():
+                pass
+            elif self._logic.has_finished():
+                self._emit_event("publish.finished")
 
     def stop_publish(self) -> None:
         self._logic.stop_publish()

--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -42,6 +42,7 @@ class PublishModel:
         self._logic.set_log_to_console(
             env_value_to_bool("AYON_PUBLISHER_PRINT_LOGS", default=False)
         )
+        self._publish_iter = None
 
         self._publish_state = CurrentPublishState()
 
@@ -54,6 +55,7 @@ class PublishModel:
         self._logic.set_log_to_console(
             env_value_to_bool("AYON_PUBLISHER_PRINT_LOGS", default=False)
         )
+        self._publish_iter = None
         self._publish_state = CurrentPublishState()
 
         self._emit_event("publish.reset.finished")
@@ -71,11 +73,10 @@ class PublishModel:
             return
 
         self._emit_event("publish.process.started")
-
-        self._logic.start_publish(wait=False)
+        self._publish_iter = self._logic.publish_iter()
         if wait:
-            while self.is_running():
-                self.process_next_iter()
+            for info in self._publish_iter:
+                info()
 
     def process_next_iter(self) -> bool:
         """Process next iteration of publishing.
@@ -84,13 +85,15 @@ class PublishModel:
             bool: True if publishing is still running, False if finished.
 
         """
-        if not self._logic.is_running():
+        func: PublishIterInfo | None = None
+        if self._publish_iter is not None:
+            func = next(self._publish_iter, None)
+        if func is None:
             self._emit_event("publish.process.stopped")
             if not self._logic.has_failed() and self._logic.has_finished():
                 self._emit_event("publish.finished")
             return False
 
-        func: PublishIterInfo = self._logic.get_next_process_func()
         plugin = func.plugin
         item_label = func.item_label
         if (

--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -47,8 +47,8 @@ class PublishModel:
 
         self._emit_event("publish.reset.finished")
 
-    def set_publish_up_validation(self, value: bool) -> None:
-        self._logic.set_publish_up_validation(value)
+    def set_stop_after_validation(self, value: bool) -> None:
+        self._logic.set_stop_after_validation(value)
 
     def start_publish(self, wait: bool = True) -> None:
         """Run publishing.

--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -18,7 +18,7 @@ from ayon_core.tools.publisher.abstract import (
 
 if typing.TYPE_CHECKING:
     from ayon_core.pipeline.publish.logic import (
-        PublishIterInfo,
+        PublishIterTask,
         PublishActionResult,
     )
     from ayon_core.pipeline.publish.report import PublishReport
@@ -75,8 +75,8 @@ class PublishModel:
         self._emit_event("publish.process.started")
         self._publish_iter = self._logic.publish_iter()
         if wait:
-            for info in self._publish_iter:
-                info()
+            for task in self._publish_iter:
+                task()
 
     def process_next_iter(self) -> bool:
         """Process next iteration of publishing.
@@ -85,17 +85,18 @@ class PublishModel:
             bool: True if publishing is still running, False if finished.
 
         """
-        func: PublishIterInfo | None = None
+        task: PublishIterTask | None = None
         if self._publish_iter is not None:
-            func = next(self._publish_iter, None)
-        if func is None:
+            task = next(self._publish_iter, None)
+
+        if task is None:
             self._emit_event("publish.process.stopped")
             if not self._logic.has_failed() and self._logic.has_finished():
                 self._emit_event("publish.finished")
             return False
 
-        plugin = func.plugin
-        item_label = func.item_label
+        plugin = task.plugin
+        item_label = task.item_label
         if (
             plugin is not None
             and self._publish_state.plugin is not plugin
@@ -119,7 +120,7 @@ class PublishModel:
                 {"instance_label": item_label}
             )
 
-        func()
+        task()
         if not self._publish_state.validated and self._logic.has_validated():
             self._publish_state.validated = True
             self._emit_event("publish.has_validated")

--- a/client/ayon_core/tools/publisher/models/publish.py
+++ b/client/ayon_core/tools/publisher/models/publish.py
@@ -1,557 +1,22 @@
 from __future__ import annotations
 
-import uuid
-import inspect
-import logging
 import traceback
-import collections
-from contextlib import contextmanager
 from functools import partial
-from typing import Any, Iterable, Generator
+from typing import Any, Iterable
 
 import pyblish.plugin
 
-from ayon_core.lib import env_value_to_bool
-from ayon_core.pipeline import (
-    PublishValidationError,
-    KnownPublishError,
-    OptionalPyblishPluginMixin,
+from ayon_core.pipeline.publish.logic import (
+    PublishIterInfo,
+    PublishLogic,
+    PublishActionResult,
+    PublishErrorInfo,
+    PublishErrorsReport,
 )
-from ayon_core.pipeline.publish import (
-    PublishError,
-    filter_crashed_publish_paths,
-)
-from ayon_core.pipeline.publish.report import (
-    PublishReportMaker,
-    PublishReport,
-)
+from ayon_core.pipeline.publish.report import PublishReport
 from ayon_core.tools.publisher.abstract import AbstractPublisherBackend
 
 PUBLISH_EVENT_SOURCE = "publisher.publish.model"
-# Define constant for plugin orders offset
-PLUGIN_ORDER_OFFSET = 0.5
-
-
-class MessageHandler(logging.Handler):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._records = []
-
-    def clear_records(self):
-        self._records = []
-
-    def emit(self, record):
-        try:
-            record.msg = record.getMessage()
-        except Exception:
-            record.msg = str(record.msg)
-        self._records.append(record)
-
-    def get_records(self):
-        return self._records
-
-
-class PublishErrorInfo:
-    def __init__(
-        self,
-        message: str,
-        is_unknown_error: bool,
-        description: str | None = None,
-        title: str | None = None,
-        detail: str | None = None,
-    ):
-        self.message: str = message
-        self.is_unknown_error = is_unknown_error
-        self.description: str = description or message
-        self.title: str = title or "Unknown error"
-        self.detail: str | None = detail
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, PublishErrorInfo):
-            return False
-        return (
-            self.description == other.description
-            and self.is_unknown_error == other.is_unknown_error
-            and self.title == other.title
-            and self.detail == other.detail
-        )
-
-    def __ne__(self, other: Any) -> bool:
-        return not self.__eq__(other)
-
-    @classmethod
-    def from_exception(cls, exc) -> "PublishErrorInfo":
-        if isinstance(exc, PublishError):
-            return cls(
-                exc.message,
-                False,
-                exc.description,
-                title=exc.title,
-                detail=exc.detail,
-            )
-        if isinstance(exc, KnownPublishError):
-            msg = str(exc)
-        else:
-            msg = (
-                "Something went wrong. Send report"
-                " to your supervisor or Ynput team."
-            )
-        return cls(msg, True)
-
-
-class PublishPluginActionItem:
-    """Representation of publish plugin action.
-
-    Data driven object which is used as proxy for controller and UI.
-
-    Args:
-        action_id (str): Action id.
-        plugin_id (str): Plugin id.
-        active (bool): Action is active.
-        on_filter (Literal["all", "notProcessed", "processed", "failed",
-            "warning", "failedOrWarning", "succeeded"]): Actions have 'on'
-            attribute which define  when can be action triggered
-            (e.g. 'all', 'failed', ...).
-        label (str): Action's label.
-        icon (str | None) Action's icon.
-    """
-
-    def __init__(
-        self,
-        action_id: str,
-        plugin_id: str,
-        active: bool,
-        on_filter: str,
-        label: str,
-        icon: str | None,
-    ):
-        self.action_id: str = action_id
-        self.plugin_id: str = plugin_id
-        self.active: bool = active
-        self.on_filter: str = on_filter
-        self.label: str = label
-        self.icon: str | None = icon
-
-    def to_data(self) -> dict[str, str | bool | None]:
-        """Serialize object to dictionary.
-
-        Returns:
-            dict[str, str | bool | None]: Serialized object.
-
-        """
-        return {
-            "action_id": self.action_id,
-            "plugin_id": self.plugin_id,
-            "active": self.active,
-            "on_filter": self.on_filter,
-            "label": self.label,
-            "icon": self.icon
-        }
-
-    @classmethod
-    def from_data(
-        cls, data: dict[str, str | bool | None]
-    ) -> "PublishPluginActionItem":
-        """Create object from data.
-
-        Args:
-            data (dict[str, str | bool | None]): Data used to recreate
-                object.
-
-        Returns:
-            PublishPluginActionItem: Object created using data.
-        """
-
-        return cls(**data)
-
-
-class PublishPluginsProxy:
-    """Wrapper around publish plugin.
-
-    Prepare mapping for publish plugins and actions. Also can create
-    serializable data for plugin actions so UI don't have to have access to
-    them.
-
-    This object is created in process where publishing is actually running.
-
-    Notes:
-        Actions have id but single action can be used on multiple plugins so
-            to run an action is needed combination of plugin and action.
-
-    Args:
-        plugins [list[pyblish.api.Plugin]]: Discovered plugins that will be
-            processed.
-    """
-
-    def __init__(self, plugins: list[pyblish.api.Plugin]):
-        plugins_by_id: dict[str, pyblish.api.Plugin] = {}
-        actions_by_plugin_id: dict[str, dict[str, pyblish.api.Action]] = {}
-        action_ids_by_plugin_id: dict[str, list[str]] = {}
-        for plugin in plugins:
-            plugin_id = plugin.id
-            plugins_by_id[plugin_id] = plugin
-
-            action_ids = []
-            actions_by_id = {}
-            action_ids_by_plugin_id[plugin_id] = action_ids
-            actions_by_plugin_id[plugin_id] = actions_by_id
-
-            actions = getattr(plugin, "actions", None) or []
-            for action in actions:
-                action_id = action.id
-                action_ids.append(action_id)
-                actions_by_id[action_id] = action
-
-        self._plugins_by_id: dict[str, pyblish.api.Plugin] = plugins_by_id
-        self._actions_by_plugin_id: dict[
-            str, dict[str, pyblish.api.Action]
-        ] = actions_by_plugin_id
-        self._action_ids_by_plugin_id: dict[str, list[str]] = (
-            action_ids_by_plugin_id
-        )
-
-    def get_action(
-        self, plugin_id: str, action_id: str
-    ) -> pyblish.api.Action:
-        return self._actions_by_plugin_id[plugin_id][action_id]
-
-    def get_plugin(self, plugin_id: str) -> pyblish.api.Plugin:
-        return self._plugins_by_id[plugin_id]
-
-    def get_plugin_id(self, plugin: pyblish.api.Plugin) -> str:
-        """Get id of plugin based on plugin object.
-
-        It's used for validation errors report.
-
-        Args:
-            plugin (pyblish.api.Plugin): Publish plugin for which id should be
-                returned.
-
-        Returns:
-            str: Plugin id.
-        """
-
-        return plugin.id
-
-    def get_plugin_action_items(
-        self, plugin_id: str
-    ) -> list[PublishPluginActionItem]:
-        """Get plugin action items for plugin by its id.
-
-        Args:
-            plugin_id (str): Publish plugin id.
-
-        Returns:
-            list[PublishPluginActionItem]: Items with information about publish
-                plugin actions.
-        """
-
-        return [
-            self._create_action_item(
-                self.get_action(plugin_id, action_id), plugin_id
-            )
-            for action_id in self._action_ids_by_plugin_id[plugin_id]
-        ]
-
-    def _create_action_item(
-        self, action: pyblish.api.Action, plugin_id: str
-    ) -> PublishPluginActionItem:
-        label = action.label or action.__name__
-        icon = getattr(action, "icon", None)
-        return PublishPluginActionItem(
-            action.id,
-            plugin_id,
-            action.active,
-            action.on,
-            label,
-            icon
-        )
-
-
-class PublishErrorItem:
-    """Data driven publish error item.
-
-    Prepared data container with information about publish error and it's
-    source plugin.
-
-    Can be converted to raw data and recreated should be used for controller
-    and UI connection.
-
-    Args:
-        instance_id (str | None): Pyblish instance id to which is
-            publish error connected.
-        instance_label (str | None): Prepared instance label.
-        plugin_id (str): Pyblish plugin id which triggered the publish
-            error. Id is generated using 'PublishPluginsProxy'.
-        is_context_plugin (bool): Error happened on context.
-        title (str): Error title.
-        description (str): Error description.
-        detail (str): Error detail.
-
-    """
-    def __init__(
-        self,
-        instance_id: str | None,
-        instance_label: str | None,
-        plugin_id: str,
-        is_context_plugin: bool,
-        is_validation_error: bool,
-        title: str,
-        description: str,
-        detail: str
-    ):
-        self.instance_id: str | None = instance_id
-        self.instance_label: str | None = instance_label
-        self.plugin_id: str = plugin_id
-        self.is_context_plugin: bool = is_context_plugin
-        self.is_validation_error: bool = is_validation_error
-        self.title: str = title
-        self.description: str = description
-        self.detail: str = detail
-
-    def to_data(self) -> dict[str, str | bool | None]:
-        """Serialize object to dictionary.
-
-        Returns:
-            dict[str, str | bool | None]: Serialized object data.
-
-        """
-        return {
-            "instance_id": self.instance_id,
-            "instance_label": self.instance_label,
-            "plugin_id": self.plugin_id,
-            "is_context_plugin": self.is_context_plugin,
-            "is_validation_error": self.is_validation_error,
-            "title": self.title,
-            "description": self.description,
-            "detail": self.detail,
-        }
-
-    @classmethod
-    def from_result(
-        cls,
-        plugin_id: str,
-        error: PublishError,
-        instance: pyblish.api.Instance | None
-    ):
-        """Create new object based on resukt from controller.
-
-        Returns:
-            PublishErrorItem: New object with filled data.
-        """
-
-        instance_label = None
-        instance_id = None
-        if instance is not None:
-            instance_label = (
-                instance.data.get("label") or instance.data.get("name")
-            )
-            instance_id = instance.id
-
-        return cls(
-            instance_id,
-            instance_label,
-            plugin_id,
-            instance is None,
-            isinstance(error, PublishValidationError),
-            error.title,
-            error.description,
-            error.detail,
-        )
-
-    @classmethod
-    def from_data(cls, data):
-        return cls(**data)
-
-
-class PublishErrorsReport:
-    """Publish errors report that can be parsed to raw data.
-
-    Args:
-        error_items (list[PublishErrorItem]): List of publish errors.
-        plugin_action_items (dict[str, list[PublishPluginActionItem]]): Action
-            items by plugin id.
-
-    """
-    def __init__(self, error_items, plugin_action_items):
-        self._error_items = error_items
-        self._plugin_action_items = plugin_action_items
-
-    def __iter__(self) -> Iterable[PublishErrorItem]:
-        for item in self._error_items:
-            yield item
-
-    def group_items_by_title(self) -> list[dict[str, Any]]:
-        """Group errors by plugin and their titles.
-
-        Items are grouped by plugin and title -> same title from different
-        plugin is different item. Items are ordered by plugin order.
-
-        Returns:
-            list[dict[str, Any]]: List where each item title, instance
-                information related to title and possible plugin actions.
-        """
-
-        ordered_plugin_ids = []
-        error_items_by_plugin_id = collections.defaultdict(list)
-        for error_item in self._error_items:
-            plugin_id = error_item.plugin_id
-            if plugin_id not in ordered_plugin_ids:
-                ordered_plugin_ids.append(plugin_id)
-            error_items_by_plugin_id[plugin_id].append(error_item)
-
-        grouped_error_items = []
-        for plugin_id in ordered_plugin_ids:
-            plugin_action_items = self._plugin_action_items[plugin_id]
-            error_items = error_items_by_plugin_id[plugin_id]
-
-            titles = []
-            error_items_by_title = collections.defaultdict(list)
-            for error_item in error_items:
-                title = error_item.title
-                if title not in titles:
-                    titles.append(error_item.title)
-                error_items_by_title[title].append(error_item)
-
-            for title in titles:
-                grouped_error_items.append({
-                    "id": uuid.uuid4().hex,
-                    "plugin_id": plugin_id,
-                    "plugin_action_items": list(plugin_action_items),
-                    "error_items": error_items_by_title[title],
-                    "title": title
-                })
-        return grouped_error_items
-
-    def to_data(self):
-        """Serialize object to dictionary.
-
-        Returns:
-            dict[str, Any]: Serialized data.
-        """
-
-        error_items = [
-            item.to_data()
-            for item in self._error_items
-        ]
-
-        plugin_action_items = {
-            plugin_id: [
-                action_item.to_data()
-                for action_item in action_items
-            ]
-            for plugin_id, action_items in self._plugin_action_items.items()
-        }
-
-        return {
-            "error_items": error_items,
-            "plugin_action_items": plugin_action_items
-        }
-
-    @classmethod
-    def from_data(
-        cls, data: dict[str, Any]
-    ) -> "PublishErrorsReport":
-        """Recreate object from data.
-
-        Args:
-            data (dict[str, Any]): Data to recreate object. Can be created
-                using 'to_data' method.
-
-        Returns:
-            PublishErrorsReport: New object based on data.
-        """
-
-        error_items = [
-            PublishErrorItem.from_data(error_item)
-            for error_item in data["error_items"]
-        ]
-        plugin_action_items = {}
-        for action_item in data["plugin_action_items"]:
-            item = PublishPluginActionItem.from_data(action_item)
-            action_items = plugin_action_items.setdefault(item.plugin_id, [])
-            action_items.append(item)
-
-        return cls(error_items, plugin_action_items)
-
-
-class PublishErrors:
-    """Object to keep track about publish errors by plugin."""
-
-    def __init__(self):
-        self._plugins_proxy: PublishPluginsProxy | None = None
-        self._error_items: list[PublishErrorItem] = []
-        self._plugin_action_items: dict[
-            str, list[PublishPluginActionItem]
-        ] = {}
-
-    def __bool__(self):
-        return self.has_errors
-
-    @property
-    def has_errors(self) -> bool:
-        """At least one error was added."""
-
-        return bool(self._error_items)
-
-    def reset(self, plugins_proxy: PublishPluginsProxy):
-        """Reset object to default state.
-
-        Args:
-            plugins_proxy (PublishPluginsProxy): Proxy which store plugins,
-                actions by ids and create mapping of action ids by plugin ids.
-        """
-
-        self._plugins_proxy = plugins_proxy
-        self._error_items = []
-        self._plugin_action_items = {}
-
-    def create_report(self) -> PublishErrorsReport:
-        """Create report based on currently existing errors.
-
-        Returns:
-            PublishErrorsReport: Publish error report with all
-                error information and publish plugin action items.
-        """
-
-        return PublishErrorsReport(
-            self._error_items, self._plugin_action_items
-        )
-
-    def add_error(
-        self,
-        plugin: pyblish.api.Plugin,
-        error: PublishError,
-        instance: pyblish.api.Instance | None
-    ):
-        """Add error from pyblish result.
-
-        Args:
-            plugin (pyblish.api.Plugin): Plugin which triggered error.
-            error (PublishError): Publish error.
-            instance (pyblish.api.Instance | None): Instance on which was
-                error raised or None if was raised on context.
-        """
-
-        # Make sure the cached report is cleared
-        plugin_id = self._plugins_proxy.get_plugin_id(plugin)
-        if not error.title:
-            if hasattr(plugin, "label") and plugin.label:
-                plugin_label = plugin.label
-            else:
-                plugin_label = plugin.__name__
-            error.title = plugin_label
-
-        self._error_items.append(
-            PublishErrorItem.from_result(plugin_id, error, instance)
-        )
-        if plugin_id in self._plugin_action_items:
-            return
-
-        plugin_actions = self._plugins_proxy.get_plugin_action_items(
-            plugin_id
-        )
-        self._plugin_action_items[plugin_id] = plugin_actions
 
 
 def collect_families_from_instances(
@@ -589,227 +54,128 @@ class PublishModel:
     def __init__(self, controller: AbstractPublisherBackend):
         self._controller = controller
 
-        self._log_to_console: bool = env_value_to_bool(
-            "AYON_PUBLISHER_PRINT_LOGS", default=False
-        )
-
-        # Publishing should stop at validation stage
-        self._publish_up_validation: bool = False
-        self._publish_comment_is_set: bool = False
-
-        # Any other exception that happened during publishing
-        self._publish_error_info: PublishErrorInfo | None = None
-        # Publishing is in progress
-        self._publish_is_running: bool = False
-        # Publishing is over validation order
-        self._publish_has_validated: bool = False
-
-        self._publish_has_validation_errors: bool = False
-        self._publish_has_crashed: bool = False
-        # All publish plugins are processed
-        self._publish_has_started: bool = False
-        self._publish_has_finished: bool = False
-        self._publish_max_progress: int = 0
-        self._publish_progress: int = 0
-
-        self._publish_plugins: list[pyblish.api.Plugin] = []
-        self._publish_plugins_proxy: PublishPluginsProxy = (
-            PublishPluginsProxy([])
-        )
-
-        # pyblish.api.Context
-        self._publish_context = None
-        # Pyblish report
-        self._publish_report: PublishReportMaker = PublishReportMaker()
-        # Store exceptions of publish error
-        self._publish_errors: PublishErrors = PublishErrors()
-
-        # This information is not much important for controller but for widget
-        #   which can change (and set) the comment.
-        self._publish_comment_is_set: bool = False
-
-        # Validation order
-        # - plugin with order same or higher than this value is extractor or
-        #   higher
-        self._validation_order: int = (
-            pyblish.api.ValidatorOrder + PLUGIN_ORDER_OFFSET
-        )
-
-        # Plugin iterator
-        self._main_thread_iter: Generator[partial] = self._default_iterator()
-
-        self._log_handler: MessageHandler = MessageHandler()
+        self._logic: PublishLogic = PublishLogic()
 
     def reset(self):
-        # Allow to change behavior during process lifetime
-        self._log_to_console = env_value_to_bool(
-            "AYON_PUBLISHER_PRINT_LOGS", default=False
-        )
-
         create_context = self._controller.get_create_context()
 
-        self._publish_up_validation = False
-        self._publish_comment_is_set = False
-        self._publish_has_started = False
-
-        self._set_publish_error_info(None)
-        self._set_progress(0)
-        self._set_is_running(False)
-        self._set_has_validated(False)
-        self._set_is_crashed(False)
-        self._set_has_validation_errors(False)
-        self._set_finished(False)
-
-        self._main_thread_iter = self._publish_iterator()
-        self._publish_context = pyblish.api.Context()
-        # Make sure "comment" is set on publish context
-        self._publish_context.data["comment"] = ""
-        # Add access to create context during publishing
-        # - must not be used for changing CreatedInstances during publishing!
-        # QUESTION
-        # - pop the key after first collector using it would be safest option?
-        self._publish_context.data["create_context"] = create_context
-        publish_plugins = create_context.publish_plugins
-        self._publish_plugins = publish_plugins
-        self._publish_plugins_proxy = PublishPluginsProxy(
-            publish_plugins
-        )
-        blocking_crashed_paths = filter_crashed_publish_paths(
-            create_context.get_current_project_name(),
-            set(create_context.publish_discover_result.crashed_file_paths),
-            project_settings=create_context.get_current_project_settings(),
-        )
-        self._publish_report.reset_with_discover_results(
-            create_context.creator_discover_result,
-            create_context.convertor_discover_result,
-            create_context.publish_discover_result,
-            blocking_crashed_paths,
-        )
-        for plugin in create_context.publish_plugins_mismatch_targets:
-            self._publish_report.set_plugin_skipped(plugin.id)
-        self._publish_errors.reset(self._publish_plugins_proxy)
-
-        self._set_max_progress(len(publish_plugins))
+        self._logic.reset_from_create_context(create_context)
 
         self._emit_event("publish.reset.finished")
 
-    def set_publish_up_validation(self, value: bool):
-        self._publish_up_validation = value
+    def set_publish_up_validation(self, value: bool) -> None:
+        self._logic.set_publish_up_validation(value)
 
-    def start_publish(self, wait: bool = True):
+    def start_publish(self, wait: bool = True) -> None:
         """Run publishing.
 
         Make sure all changes are saved before method is called (Call
         'save_changes' and check output).
         """
-        if self._publish_up_validation and self._publish_has_validated:
+        if self._logic.is_running():
             return
 
-        self._start_publish()
+        self._emit_event("publish.process.started")
 
+        self._logic.start_publish(wait=False)
         if not wait:
             return
 
+        plugin = None
+        item_label = None
+        validated = False
         while self.is_running():
-            func = self.get_next_process_func()
+            func: PublishIterInfo = self.get_next_process_func()
+            if plugin is not func.plugin:
+                plugin = func.plugin
+                plugin_label = getattr(plugin, "label", None)
+                if not plugin_label:
+                    plugin_label = plugin.__name__
+                self._emit_event(
+                "publish.process.plugin.changed",
+                {"plugin_label": plugin_label}
+                )
+
+            if item_label != func.item_label:
+                item_label = func.item_label
+                self._emit_event(
+                    "publish.process.instance.changed",
+                    {"instance_label": item_label}
+                )
+
             func()
+            if not validated and self._logic.has_validated():
+                validated = True
+                self._emit_event("publish.has_validated")
 
-    def get_next_process_func(self) -> partial:
-        # Raise error if this function is called when publishing
-        #   is not running
-        if not self._publish_is_running:
-            raise ValueError("Publish is not running")
+        self.process_stopped()
 
-        # Validations of progress before using iterator
-        # Any unexpected error happened
-        # - everything should stop
-        if self._publish_has_crashed:
-            return partial(self.stop_publish)
+    def process_stopped(self):
+        self._emit_event("publish.process.stopped")
+        if self._logic.has_crashed():
+            pass
+        elif self._logic.has_finished():
+            self._emit_event("publish.finished")
 
-        # Stop if validation is over and validation errors happened
-        #   or publishing should stop at validation
-        if (
-            self._publish_has_validated
-            and (
-                self._publish_has_validation_errors
-                or self._publish_up_validation
-            )
-        ):
-            return partial(self.stop_publish)
+    def get_next_process_func(self) -> PublishIterInfo:
+        return self._logic.get_next_process_func()
 
-        # Everything is ok so try to get new processing item
-        return next(self._main_thread_iter)
-
-    def stop_publish(self):
-        if self._publish_is_running:
-            self._stop_publish()
+    def stop_publish(self) -> None:
+        self._logic.stop_publish()
 
     def is_running(self) -> bool:
-        return self._publish_is_running
+        return self._logic.is_running()
 
-    def is_crashed(self) -> bool:
-        return self._publish_has_crashed
+    def has_crashed(self) -> bool:
+        return self._logic.has_crashed()
 
     def has_started(self) -> bool:
-        return self._publish_has_started
+        return self._logic.has_started()
 
     def has_finished(self) -> bool:
-        return self._publish_has_finished
+        return self._logic.has_finished()
 
     def has_validated(self) -> bool:
-        return self._publish_has_validated
+        return self._logic.has_validated()
 
     def has_validation_errors(self) -> bool:
-        return self._publish_has_validation_errors
+        return self._logic.has_validation_errors()
 
     def publish_can_continue(self) -> bool:
-        return (
-            not self._publish_has_crashed
-            and not self._publish_has_validation_errors
-            and not self._publish_has_finished
-        )
+        return self._logic.publish_can_continue()
 
     def get_progress(self) -> int:
-        return self._publish_progress
+        return self._logic.get_progress()
 
     def get_max_progress(self) -> int:
-        return self._publish_max_progress
+        return self._logic.get_max_progress()
 
     def get_publish_report(self) -> PublishReport:
-        self._publish_report.update_publish_instances(self._publish_context)
-        return self._publish_report.get_report()
+        return self._logic.get_publish_report()
 
     def get_publish_report_data(self) -> dict[str, Any]:
-        report: PublishReport = self.get_publish_report()
-        return report.to_data(self._publish_report.current_plugin_id)
+        return self._logic.get_publish_report_data()
 
     def get_publish_errors_report(self) -> PublishErrorsReport:
-        return self._publish_errors.create_report()
+        return self._logic.get_publish_errors_report()
 
     def get_error_info(self) -> PublishErrorInfo | None:
-        return self._publish_error_info
+        return self._logic.get_error_info()
 
     def store_publish_report(self, filepath: str) -> None:
         report: PublishReport = self.get_publish_report()
         report.store_to_file(filepath)
 
     def set_comment(self, comment: str):
-        # Ignore change of comment when publishing started
-        if self._publish_has_started:
-            return
-        self._publish_context.data["comment"] = comment
-        self._publish_comment_is_set = True
+        self._logic.set_comment(comment)
 
     def run_action(self, plugin_id: str, action_id: str):
-        # TODO handle result in UI
-        plugin = self._publish_plugins_proxy.get_plugin(plugin_id)
-        action = self._publish_plugins_proxy.get_action(plugin_id, action_id)
-
-        result = pyblish.plugin.process(
-            plugin, self._publish_context, None, action.id
+        result: PublishActionResult = self._logic.run_action(
+            plugin_id, action_id
         )
-        exception = result.get("error")
-        if exception:
+        if result.success is False:
+            exception = result.exception
+            action = result.action
             self._emit_event(
                 "publish.action.failed",
                 {
@@ -827,105 +193,10 @@ class PublishModel:
                 }
             )
 
-        self._publish_report.add_action_result(action, result)
-
         self._controller.emit_card_message("Action finished.")
 
     def _emit_event(self, topic: str, data: dict[str, Any] | None = None):
         self._controller.emit_event(topic, data, PUBLISH_EVENT_SOURCE)
-
-    def _set_finished(self, value: bool):
-        if self._publish_has_finished != value:
-            self._publish_has_finished = value
-            self._emit_event(
-                "publish.finished.changed",
-                {"value": value}
-            )
-
-    def _set_is_running(self, value: bool):
-        if self._publish_is_running != value:
-            self._publish_is_running = value
-            self._emit_event(
-                "publish.is_running.changed",
-                {"value": value}
-            )
-
-    def _set_has_validated(self, value: bool):
-        if self._publish_has_validated != value:
-            self._publish_has_validated = value
-            self._emit_event(
-                "publish.has_validated.changed",
-                {"value": value}
-            )
-
-    def _set_is_crashed(self, value: bool):
-        if self._publish_has_crashed != value:
-            self._publish_has_crashed = value
-            self._emit_event(
-                "publish.has_crashed.changed",
-                {"value": value}
-            )
-
-    def _set_has_validation_errors(self, value: bool):
-        if self._publish_has_validation_errors != value:
-            self._publish_has_validation_errors = value
-            self._emit_event(
-                "publish.has_validation_errors.changed",
-                {"value": value}
-            )
-
-    def _set_max_progress(self, value: int):
-        if self._publish_max_progress != value:
-            self._publish_max_progress = value
-            self._emit_event(
-                "publish.max_progress.changed",
-                {"value": value}
-            )
-
-    def _set_progress(self, value: int):
-        if self._publish_progress != value:
-            self._publish_progress = value
-            self._emit_event(
-                "publish.progress.changed",
-                {"value": value}
-            )
-
-    def _set_publish_error_info(self, value: PublishErrorInfo | None):
-        if self._publish_error_info != value:
-            self._publish_error_info = value
-            self._emit_event(
-                "publish.publish_error.changed",
-                {"value": value}
-            )
-
-    def _default_iterator(self):
-        """Iterator used on initialization.
-
-        Should be replaced by real iterator when 'reset' is called.
-
-        Returns:
-            collections.abc.Generator[partial]: Generator with partial
-                functions that should be called in main thread.
-
-        """
-        while True:
-            yield partial(self.stop_publish)
-
-    def _start_publish(self):
-        """Start or continue in publishing."""
-        if self._publish_is_running:
-            return
-
-        self._set_is_running(True)
-        self._publish_has_started = True
-
-        self._emit_event("publish.process.started")
-
-    def _stop_publish(self):
-        """Stop or pause publishing."""
-        self._set_is_running(False)
-
-        self._emit_event("publish.process.stopped")
 
     def _publish_iterator(self) -> Iterable[partial]:
         """Main logic center of publishing.
@@ -1026,112 +297,3 @@ class PublishModel:
         self._set_finished(True)
         self._set_progress(self._publish_max_progress)
         yield partial(self.stop_publish)
-
-    @contextmanager
-    def _log_manager(self, plugin: pyblish.api.Plugin):
-        root = logging.getLogger()
-        if not self._log_to_console:
-            plugin.log.propagate = False
-            plugin.log.addHandler(self._log_handler)
-            root.addHandler(self._log_handler)
-
-        try:
-            if self._log_to_console:
-                yield None
-            else:
-                yield self._log_handler
-
-        finally:
-            if not self._log_to_console:
-                plugin.log.propagate = True
-                plugin.log.removeHandler(self._log_handler)
-                root.removeHandler(self._log_handler)
-            self._log_handler.clear_records()
-
-    def _process_and_continue(
-        self,
-        plugin: pyblish.api.Plugin,
-        instance: pyblish.api.Instance
-    ):
-        with self._log_manager(plugin) as log_handler:
-            result = pyblish.plugin.process(
-                plugin, self._publish_context, instance
-            )
-            if log_handler is not None:
-                records = log_handler.get_records()
-                exception = result.get("error")
-                if exception is not None and records:
-                    last_record = records[-1]
-                    if (
-                        last_record.name == "pyblish.plugin"
-                        and last_record.levelno == logging.ERROR
-                    ):
-                        # Remove last record made by pyblish
-                        # - `log.exception(formatted_traceback)`
-                        records.pop(-1)
-                result["records"] = records
-
-        exception = result.get("error")
-        if exception:
-            if (
-                isinstance(exception, PublishValidationError)
-                and not self._publish_has_validated
-            ):
-                result["is_validation_error"] = True
-                self._add_validation_error(result)
-
-            else:
-                if isinstance(exception, PublishError):
-                    if not exception.title:
-                        exception.title = plugin.label or plugin.__name__
-                    self._add_publish_error_to_report(result)
-
-                error_info = PublishErrorInfo.from_exception(exception)
-                self._set_publish_error_info(error_info)
-                self._set_is_crashed(True)
-
-                result["is_validation_error"] = False
-
-        self._publish_report.add_result(plugin.id, result)
-
-    def _add_validation_error(self, result: dict[str, Any]):
-        self._set_has_validation_errors(True)
-        self._add_publish_error_to_report(result)
-
-    def _add_publish_error_to_report(self, result: dict[str, Any]):
-        self._publish_errors.add_error(
-            result["plugin"],
-            result["error"],
-            result["instance"]
-        )
-
-    def _is_publish_plugin_active(self, plugin: pyblish.api.Plugin) -> bool:
-        """Decide if publish plugin is active.
-
-        This is hack because 'active' is mis-used in mixin
-        'OptionalPyblishPluginMixin' where 'active' is used for default value
-        of optional plugins. Because of that is 'active' state of plugin
-        which inherit from 'OptionalPyblishPluginMixin' ignored. That affects
-        headless publishing inside host, potentially remote publishing.
-
-        We have to change that to match pyblish base, but we can do that
-        only when all hosts use Publisher because the change requires
-        change of settings schemas.
-
-        Args:
-            plugin (pyblish.Plugin): Plugin which should be checked if is
-                active.
-
-        Returns:
-            bool: Is plugin active.
-        """
-
-        if plugin.active:
-            return True
-
-        if not plugin.optional:
-            return False
-
-        if OptionalPyblishPluginMixin in inspect.getmro(plugin):
-            return True
-        return False

--- a/client/ayon_core/tools/publisher/widgets/create_context_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/create_context_widgets.py
@@ -125,6 +125,9 @@ class CreateHierarchyController:
     def get_project_name(self):
         return self._controller.get_current_project_name()
 
+    def get_project_settings(self, project_name):
+        return self._controller.get_project_settings(project_name)
+
     def get_folder_items(self, project_name, sender=None):
         return self._controller.get_folder_items(project_name, sender)
 

--- a/client/ayon_core/tools/publisher/widgets/publish_frame.py
+++ b/client/ayon_core/tools/publisher/widgets/publish_frame.py
@@ -171,7 +171,7 @@ class PublishFrame(QtWidgets.QWidget):
             "publish.process.started", self._on_publish_start
         )
         controller.register_event_callback(
-            "publish.has_validated.changed", self._on_publish_validated_change
+            "publish.has_validated", self._on_publish_validated
         )
         controller.register_event_callback(
             "publish.process.stopped", self._on_publish_stop
@@ -347,9 +347,8 @@ class PublishFrame(QtWidgets.QWidget):
 
         self.set_shrunk_state(False)
 
-    def _on_publish_validated_change(self, event):
-        if event["value"]:
-            self._validate_btn.setEnabled(False)
+    def _on_publish_validated(self):
+        self._validate_btn.setEnabled(False)
 
     def _on_instance_change(self, event):
         """Change instance label when instance is going to be processed."""

--- a/client/ayon_core/tools/publisher/widgets/publish_frame.py
+++ b/client/ayon_core/tools/publisher/widgets/publish_frame.py
@@ -396,7 +396,7 @@ class PublishFrame(QtWidgets.QWidget):
 
     def _set_stopped(self):
         main_label = "Publish paused"
-        if self._controller.publish_has_validated:
+        if self._controller.publish_has_validated():
             main_label += " - Validation passed"
 
         self._set_main_label(main_label)

--- a/client/ayon_core/tools/publisher/widgets/publish_frame.py
+++ b/client/ayon_core/tools/publisher/widgets/publish_frame.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from qtpy import QtWidgets, QtCore
+import typing
 
-from ayon_core.tools.publisher.abstract import (
-    AbstractPublisherFrontend,
-    UIFailInfo,
-)
+from qtpy import QtWidgets, QtCore
 
 from .widgets import (
     StopBtn,
@@ -14,6 +11,12 @@ from .widgets import (
     PublishBtn,
     PublishReportBtn,
 )
+
+if typing.TYPE_CHECKING:
+    from ayon_core.tools.publisher.abstract import (
+        AbstractPublisherFrontend,
+        UIFailInfo,
+    )
 
 
 class PublishFrame(QtWidgets.QWidget):

--- a/client/ayon_core/tools/publisher/widgets/publish_frame.py
+++ b/client/ayon_core/tools/publisher/widgets/publish_frame.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
 from qtpy import QtWidgets, QtCore
 
-from ayon_core.tools.publisher.abstract import AbstractPublisherFrontend
+from ayon_core.tools.publisher.abstract import (
+    AbstractPublisherFrontend,
+    UIFailInfo,
+)
 
 from .widgets import (
     StopBtn,
@@ -410,11 +415,13 @@ class PublishFrame(QtWidgets.QWidget):
         """Show error message to artist on publish crash."""
 
         self._set_main_label("Error happened")
-        error_info = self._controller.get_publish_error_info()
+        fail_info: UIFailInfo | None = (
+            self._controller.get_publish_fail_info()
+        )
 
         error_message = "Unknown error happened"
-        if error_info is not None:
-            error_message = error_info.message
+        if fail_info is not None:
+            error_message = fail_info.message
 
         self._message_label_top.setText(error_message)
 

--- a/client/ayon_core/tools/publisher/widgets/report_page.py
+++ b/client/ayon_core/tools/publisher/widgets/report_page.py
@@ -1856,7 +1856,7 @@ class ReportsWidget(QtWidgets.QWidget):
 
         publish_error_mode = False
         if fail_info is not None:
-            publish_error_mode = not fail_info.is_unknown_error
+            publish_error_mode = fail_info.is_publish_error
         elif has_validation_error:
             publish_error_mode = True
 

--- a/client/ayon_core/tools/publisher/widgets/report_page.py
+++ b/client/ayon_core/tools/publisher/widgets/report_page.py
@@ -27,7 +27,11 @@ from ayon_core.tools.utils import (
     paint_image_with_color,
     SeparatorWidget,
 )
-from ayon_core.tools.publisher.abstract import AbstractPublisherFrontend
+from ayon_core.tools.publisher.abstract import (
+    AbstractPublisherFrontend,
+    UIPublishErrorReport,
+    UIFailInfo,
+)
 from ayon_core.tools.publisher.constants import (
     INSTANCE_ID_ROLE,
     CONTEXT_LABEL,
@@ -131,7 +135,7 @@ class ActionButton(BaseClickableFrame):
     Action may have label or icon or both.
 
     Args:
-        plugin_action_item (PublishPluginActionItem): Action item that can be
+        plugin_action_item (UIPublishPluginActionItem): Action item that can be
             triggered by its id.
     """
 
@@ -236,7 +240,7 @@ class PublishActionsWidget(QtWidgets.QFrame):
             self.setVisible(False)
             return
 
-        plugin_action_items = error_info["plugin_action_items"]
+        plugin_action_items = error_info.plugin_action_items
         for plugin_action_item in plugin_action_items:
             if not plugin_action_item.active:
                 continue
@@ -298,12 +302,17 @@ class PublishErrorTitleWidget(QtWidgets.QWidget):
     instance_changed = QtCore.Signal(str)
     _error_pixmap = None
 
-    def __init__(self, title_id, error_info, parent):
+    def __init__(
+        self,
+        title_id: str,
+        error_info: UIPublishErrorReport,
+        parent: QtWidgets.QWidget,
+    ):
         super().__init__(parent)
 
-        self._title_id = title_id
-        self._error_info = error_info
-        self._selected = False
+        self._title_id: str = title_id
+        self._error_info: UIPublishErrorReport = error_info
+        self._selected: bool = False
 
         instances_model = QtGui.QStandardItemModel()
 
@@ -312,7 +321,7 @@ class PublishErrorTitleWidget(QtWidgets.QWidget):
         items = []
         is_context_plugin = False
         is_crashing_error = False
-        for error_item in error_info["error_items"]:
+        for error_item in error_info.error_items:
             is_crashing_error = not error_item.is_validation_error
             is_context_plugin = error_item.is_context_plugin
             if is_context_plugin:
@@ -350,7 +359,7 @@ class PublishErrorTitleWidget(QtWidgets.QWidget):
             error_pixmap = self._get_error_pixmap()
             icon_label = PublishPixmapLabel(error_pixmap, self)
 
-        label_widget = QtWidgets.QLabel(error_info["title"], title_frame)
+        label_widget = QtWidgets.QLabel(error_info.title, title_frame)
 
         title_frame_layout = QtWidgets.QHBoxLayout(title_frame)
         title_frame_layout.setContentsMargins(8, 8, 8, 8)
@@ -397,11 +406,11 @@ class PublishErrorTitleWidget(QtWidgets.QWidget):
         self._instances_model = instances_model
         self._instances_view = instances_view
 
-        self._is_context_plugin = is_context_plugin
-        self._is_crashing_error = is_crashing_error
+        self._is_context_plugin: bool = is_context_plugin
+        self._is_crashing_error: bool = is_crashing_error
 
-        self._instance_ids = instance_ids
-        self._expanded = False
+        self._instance_ids: list[str] = instance_ids
+        self._expanded: bool = False
 
     def sizeHint(self):
         result = super().sizeHint()
@@ -421,13 +430,13 @@ class PublishErrorTitleWidget(QtWidgets.QWidget):
     def minimumSizeHint(self):
         return self.sizeHint()
 
-    def _mouse_release_callback(self):
+    def _mouse_release_callback(self) -> None:
         """Mark this widget as selected on click."""
 
         self.set_selected(True)
 
     @property
-    def is_selected(self):
+    def is_selected(self) -> bool:
         """Is widget marked a selected.
 
         Returns:
@@ -437,21 +446,21 @@ class PublishErrorTitleWidget(QtWidgets.QWidget):
         return self._selected
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._title_id
 
     @property
-    def is_crashing_error(self):
+    def is_crashing_error(self) -> bool:
         return self._is_crashing_error
 
-    def _change_style_property(self, selected):
+    def _change_style_property(self, selected: bool) -> None:
         """Change style of widget based on selection."""
 
         value = "1" if selected else ""
         self._title_frame.setProperty("selected", value)
         self._title_frame.style().polish(self._title_frame)
 
-    def set_selected(self, selected=None):
+    def set_selected(self, selected: bool | None = None) -> None:
         """Change selected state of widget."""
 
         if selected is None:
@@ -477,12 +486,12 @@ class PublishErrorTitleWidget(QtWidgets.QWidget):
             cls._error_pixmap = get_pixmap("error")
         return cls._error_pixmap
 
-    def _on_toggle_btn_click(self):
+    def _on_toggle_btn_click(self) -> None:
         """Show/hide instances list."""
 
         self._set_expanded()
 
-    def _set_expanded(self, expanded=None):
+    def _set_expanded(self, expanded: bool | None = None) -> None:
         if expanded is None:
             expanded = not self._expanded
 
@@ -499,10 +508,10 @@ class PublishErrorTitleWidget(QtWidgets.QWidget):
         else:
             self._toggle_instance_btn.setArrowType(QtCore.Qt.RightArrow)
 
-    def _on_selection_change(self):
+    def _on_selection_change(self) -> None:
         self.instance_changed.emit(self._title_id)
 
-    def get_selected_instances(self):
+    def get_selected_instances(self) -> list[str]:
         if self._is_context_plugin:
             return [CONTEXT_ID]
         sel_model = self._instances_view.selectionModel()
@@ -512,7 +521,7 @@ class PublishErrorTitleWidget(QtWidgets.QWidget):
             if index.isValid()
         ]
 
-    def get_available_instances(self):
+    def get_available_instances(self) -> list[str]:
         return list(self._instance_ids)
 
 
@@ -541,8 +550,8 @@ class PublishErrorsView(QtWidgets.QWidget):
 
         self._errors_widget = errors_widget
         self._errors_layout = errors_layout
-        self._title_widgets = {}
-        self._previous_select = None
+        self._title_widgets: dict[str, PublishErrorTitleWidget] = {}
+        self._previous_select: PublishErrorTitleWidget | None = None
 
     def _clear(self):
         """Delete all dynamic widgets and hide all wrappers."""
@@ -555,11 +564,13 @@ class PublishErrorsView(QtWidgets.QWidget):
             if widget:
                 widget.deleteLater()
 
-    def set_errors(self, grouped_error_items):
+    def set_errors(
+        self, grouped_error_items: list[UIPublishErrorReport]
+    ) -> None:
         """Set errors into context and created titles.
 
         Args:
-            grouped_error_items (List[Dict[str, Any]]): Report
+            grouped_error_items (list[UIPublishErrorReport]): Report
                 with information about publish errors and publish plugin
                 actions.
         """
@@ -568,7 +579,7 @@ class PublishErrorsView(QtWidgets.QWidget):
 
         select_id = None
         for title_item in grouped_error_items:
-            title_id = title_item["id"]
+            title_id = title_item.id
             if select_id is None:
                 select_id = title_id
             widget = PublishErrorTitleWidget(title_id, title_item, self)
@@ -588,7 +599,7 @@ class PublishErrorsView(QtWidgets.QWidget):
 
         self.updateGeometry()
 
-    def _on_select(self, title_id):
+    def _on_select(self, title_id: str) -> None:
         if self._previous_select:
             if self._previous_select.id == title_id:
                 return
@@ -597,13 +608,13 @@ class PublishErrorsView(QtWidgets.QWidget):
         self._previous_select = self._title_widgets[title_id]
         self.selection_changed.emit()
 
-    def _on_instance_change(self, title_id):
+    def _on_instance_change(self, title_id: str) -> None:
         if self._previous_select and self._previous_select.id != title_id:
             self._title_widgets[title_id].set_selected(True)
         else:
             self.selection_changed.emit()
 
-    def get_selected_items(self):
+    def get_selected_items(self) -> tuple[str | None, list[str]]:
         if not self._previous_select:
             return None, []
 
@@ -1833,19 +1844,19 @@ class ReportsWidget(QtWidgets.QWidget):
 
         self._controller: AbstractPublisherFrontend = controller
 
-        self._publish_errors_by_id = {}
+        self._publish_errors_by_id: dict[str, UIPublishErrorReport] = {}
 
     def update_data(self):
         has_validation_error = self._controller.publish_has_validation_errors()
         has_finished = self._controller.publish_has_finished()
         has_crashed = self._controller.publish_has_crashed()
-        error_info = None
+        fail_info: UIFailInfo | None = None
         if has_crashed:
-            error_info = self._controller.get_publish_error_info()
+            fail_info = self._controller.get_publish_fail_info()
 
         publish_error_mode = False
-        if error_info is not None:
-            publish_error_mode = not error_info.is_unknown_error
+        if fail_info is not None:
+            publish_error_mode = not fail_info.is_unknown_error
         elif has_validation_error:
             publish_error_mode = True
 
@@ -1870,16 +1881,17 @@ class ReportsWidget(QtWidgets.QWidget):
         self._logs_view.update_report(report)
 
         # Publish errors
-        publish_errors_report = self._controller.get_publish_errors_report()
-        grouped_error_items = publish_errors_report.group_items_by_title()
+        publish_errors_reports: list[UIPublishErrorReport] = (
+            self._controller.get_publish_errors_reports()
+        )
 
         publish_errors_by_id = {
-            title_item["id"]: title_item
-            for title_item in grouped_error_items
+            title_item.id: title_item
+            for title_item in publish_errors_reports
         }
 
         self._publish_errors_by_id = publish_errors_by_id
-        self._publish_error_view.set_errors(grouped_error_items)
+        self._publish_error_view.set_errors(publish_errors_reports)
 
     def _on_instance_selection(self):
         instance_ids = self._instances_view.get_selected_instance_ids()
@@ -1895,10 +1907,10 @@ class ReportsWidget(QtWidgets.QWidget):
             return
 
         self._logs_view.set_instances_filter(instance_ids)
-        self._logs_view.set_plugins_filter({error_info["plugin_id"]})
+        self._logs_view.set_plugins_filter({error_info.plugin_id})
 
         match_error_item = None
-        for error_item in error_info["error_items"]:
+        for error_item in error_info.error_items:
             instance_id = error_item.instance_id or CONTEXT_ID
             if instance_id in instance_ids:
                 match_error_item = error_item

--- a/client/ayon_core/tools/publisher/window.py
+++ b/client/ayon_core/tools/publisher/window.py
@@ -313,10 +313,10 @@ class PublisherWindow(QtWidgets.QDialog):
             "publish.process.started", self._on_publish_start
         )
         controller.register_event_callback(
-            "publish.has_validated.changed", self._on_publish_validated_change
+            "publish.has_validated", self._on_publish_validated
         )
         controller.register_event_callback(
-            "publish.finished.changed", self._on_publish_finished_change
+            "publish.finished", self._on_publish_finished
         )
         controller.register_event_callback(
             "publish.process.stopped", self._on_publish_stop
@@ -974,14 +974,12 @@ class PublisherWindow(QtWidgets.QDialog):
         if self._is_on_create_tab():
             self._go_to_publish_tab()
 
-    def _on_publish_validated_change(self, event):
-        if event["value"]:
-            self._validate_btn.setEnabled(False)
+    def _on_publish_validated(self):
+        self._validate_btn.setEnabled(False)
 
-    def _on_publish_finished_change(self, event):
-        if event["value"]:
-            # Successful publish, remove comment from UI
-            self._comment_input.setText("")
+    def _on_publish_finished(self, event):
+        # Successful publish, remove comment from UI
+        self._comment_input.setText("")
 
     def _on_publish_stop(self):
         self._set_publish_overlay_visibility(False)

--- a/client/ayon_core/tools/publisher/window.py
+++ b/client/ayon_core/tools/publisher/window.py
@@ -541,7 +541,7 @@ class PublisherWindow(QtWidgets.QDialog):
             save_match = save_match == QtGui.QKeySequence.ExactMatch
 
         if save_match:
-            if not self._controller.publish_has_started:
+            if not self._controller.publish_has_started():
                 self._save_changes(True)
             event.accept()
             return
@@ -557,7 +557,7 @@ class PublisherWindow(QtWidgets.QDialog):
             )
 
         if reset_match_result == QtGui.QKeySequence.ExactMatch:
-            if not self._controller.publish_is_running:
+            if not self._controller.publish_is_running():
                 self.reset()
             event.accept()
             return


### PR DESCRIPTION
## Changelog Description
Move publishing logic from Publisher tool to publish api. Headless publishing now does work as publisher logic does and does allow to export reports when needed.

## Additional info
Moved publishing logic from publisher to pipline publish so it can be used on it's own. The logic is also used in publisher. It is kinda raw, the api does allow to pass a lot of arguments that might be confusing without knowing the logic.

I'm happy co change that, but it would be based on the use-cases.

### Dev notes
The report is not stored anywhere at this moment, it is possible though. We can store it to a file or send it to server, whatever is the goal can be done.

## Testing notes:
### Standard publishing
1. Publisher should start/stop at correct times, should reset and just work.
2. Try to publish reset publishing disable some instances and publish again, only correct instance should be published.

### Farm publishing
1. Farm publish jobs should work.

### Publish report viewer
1. Prepare publish reports json file created with older core versions.
2. Drop it to publish report viewer.
3. It should open.

1. Save publish report with this PR.
2. Drop it to publish report viewer.
3. It should open it.

Resolves https://github.com/ynput/ayon-core/issues/946