### PR TITLE
Collect Hierarchy: Allow skipping certain attributes on shot update (editorial)

### DIFF
--- a/client/ayon_core/plugins/publish/collect_hierarchy.py
+++ b/client/ayon_core/plugins/publish/collect_hierarchy.py
@@ -180,10 +180,10 @@ class CollectHierarchy(
                         continue
 
                     shot_data["attributes"][shot_attr] = attr_value
-                else:
-                    self.log.debug(
-                        "Shot attributes will not be updated."
-                    )
+            else:
+                self.log.debug(
+                    "Shot attributes will not be updated."
+                )
 
             # Split by '/' for AYON where asset is a path
             name = folder_path.split("/")[-1]

--- a/client/ayon_core/plugins/publish/collect_hierarchy.py
+++ b/client/ayon_core/plugins/publish/collect_hierarchy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pyblish.api
 import ayon_api
 
@@ -36,6 +38,7 @@ class CollectHierarchy(
     settings_category = "core"
 
     edit_shot_attributes_on_update = True
+    skip_shot_attributes_on_update: list[str] = []
 
     @classmethod
     def get_attr_defs_for_context(cls, create_context):
@@ -130,6 +133,10 @@ class CollectHierarchy(
         existing_entities = self.get_existing_folder_entities(
             project_name, shot_instances)
 
+        skip_shot_attributes_on_update: set[str] = set(
+            self.skip_shot_attributes_on_update
+        )
+
         for instance in shot_instances:
             folder_path = instance.data["folderPath"]
             self.log.debug(
@@ -156,6 +163,10 @@ class CollectHierarchy(
                 or not folder_entity
             ):
                 for shot_attr in SHOT_ATTRS:
+                    if shot_attr in skip_shot_attributes_on_update:
+                        self.log.debug("%s shot attribute skipped.", shot_attr)
+                        continue
+
                     attr_value = instance.data.get(shot_attr)
                     if attr_value is None:
                         # Shot attribute might not be defined (e.g. CSV ingest)

--- a/client/ayon_core/plugins/publish/collect_hierarchy.py
+++ b/client/ayon_core/plugins/publish/collect_hierarchy.py
@@ -163,16 +163,19 @@ class CollectHierarchy(
                 or not folder_entity
             ):
                 for shot_attr in SHOT_ATTRS:
-                    if shot_attr in skip_shot_attributes_on_update:
-                        self.log.debug("%s shot attribute skipped.", shot_attr)
-                        continue
-
                     attr_value = instance.data.get(shot_attr)
                     if attr_value is None:
                         # Shot attribute might not be defined (e.g. CSV ingest)
                         self.log.debug(
                             "%s shot attribute is not defined for instance.",
                             shot_attr
+                        )
+                        continue
+
+                    if shot_attr in skip_shot_attributes_on_update:
+                        self.log.debug(
+                            "%s shot attribute skipped as the attribute is"
+                            " blacklisted for update in settings.", shot_attr
                         )
                         continue
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -2,7 +2,6 @@ from pydantic import validator
 from typing import Any
 
 from ayon_server.enum import EnumItem
-from ayon_server.lib.postgres import Postgres
 from ayon_server.settings import (
     BaseSettingsModel,
     SettingsField,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -118,7 +118,7 @@ class CollectHierarchyModel(BaseSettingsModel):
         default_factory=list,
         title="Skip shot attributes on update",
         description=(
-            "Attributes set here will not be update on the folder entities if"
+            "Attributes set here will not be updated on the folder entities if"
             " *Edit shot attributes on update* was enabled."
         ),
         enum_resolver=version_attributes_enum,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -60,7 +60,7 @@ def _handle_missing_frames_enum():
     ]
 
 
-async def version_attributes_enum() -> list[EnumItem]:
+async def folder_attributes_enum() -> list[EnumItem]:
     result: list[EnumItem] = []
 
     res = await Postgres.fetch(
@@ -69,7 +69,7 @@ async def version_attributes_enum() -> list[EnumItem]:
         WHERE $1 && scope
         ORDER BY COALESCE(data->>'title', name) ASC
         """,
-        ["version"],
+        ["folder"],
     )
     for name, data in res:
         result.append(
@@ -120,7 +120,7 @@ class CollectHierarchyModel(BaseSettingsModel):
             "Attributes set here will not be updated on the folder entities if"
             " *Edit shot attributes on update* was enabled."
         ),
-        enum_resolver=version_attributes_enum,
+        enum_resolver=folder_attributes_enum,
     )
 
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -1,6 +1,8 @@
 from pydantic import validator
 from typing import Any
 
+from ayon_server.enum import EnumItem
+from ayon_server.lib.postgres import Postgres
 from ayon_server.settings import (
     BaseSettingsModel,
     SettingsField,
@@ -39,6 +41,27 @@ def _handle_missing_frames_enum():
     ]
 
 
+async def version_attributes_enum() -> list[EnumItem]:
+    result: list[EnumItem] = []
+
+    res = await Postgres.fetch(
+        """
+        SELECT name, data FROM attributes
+        WHERE $1 && scope
+        ORDER BY COALESCE(data->>'title', name) ASC
+        """,
+        ["version"],
+    )
+    for name, data in res:
+        result.append(
+            EnumItem(
+                value=name,
+                label=data.get("title") or name,
+            )
+        )
+    return result
+
+
 class EnabledModel(BaseSettingsModel):
     enabled: bool = SettingsField(True)
 
@@ -70,6 +93,15 @@ class CollectHierarchyModel(BaseSettingsModel):
     edit_shot_attributes_on_update: bool = SettingsField(
         True,
         title="Edit shot attributes on update"
+    )
+    skip_shot_attributes_on_update: list[str] = SettingsField(
+        default_factory=list,
+        title="Skip shot attributes on update",
+        description=(
+            "Attributes set here will not be update on the folder entities if"
+            " *Edit shot attributes on update* was enabled."
+        ),
+        enum_resolver=version_attributes_enum,
     )
 
 
@@ -1670,6 +1702,7 @@ DEFAULT_PUBLISH_VALUES = {
     },
     "CollectHierarchy": {
         "edit_shot_attributes_on_update": True,
+        "skip_shot_attributes_on_update": [],
     },
     "CollectVersionTags": {
         "enabled": False


### PR DESCRIPTION
## Changelog Description

Collect Hierarchy: Allow skipping certain attributes on shot update (editorial)

## Additional info

This allows e.g. editorial publishes to skip updating certain shot attributes, like e.g. resolution width and height.

Fix #1951

## Testing notes:

1. Skipping attributes should work from settings.
