### PR TITLE
Fix Extract Thumbnail settings conversions appending more profiles on copy settings

### DIFF
--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -1,8 +1,10 @@
 import re
 import copy
+import json
 from typing import Any
 
 from semver import VersionInfo
+from server.settings.conversion import parse_version
 
 from .publish_plugins import DEFAULT_PUBLISH_VALUES
 
@@ -293,12 +295,29 @@ def _convert_publish_plugins(overrides):
     _convert_oiio_transcode_0_4_5(overrides["publish"])
 
 
-def _convert_extract_thumbnail(overrides):
+def _convert_extract_thumbnail(source_version, overrides):
     """ExtractThumbnail config settings did change to profiles."""
+    if parse_version(source_version) >= (1, 7, 0):
+        return
+
     extract_thumbnail_overrides = (
-        overrides.get("publish", {}).get("ExtractThumbnail")
+        overrides.get("publish", {}).get("ExtractThumbnail", {})
     )
-    if extract_thumbnail_overrides is None:
+    if not extract_thumbnail_overrides:
+        return
+
+    # Check if there are legacy overrides to the root keys
+    keys = (
+        "product_names",
+        "integrate_thumbnail",
+        "target_size",
+        "duration_split",
+        "oiiotool_defaults",
+        "ffmpeg_args",
+    )
+    if not any(
+        key in extract_thumbnail_overrides for key in keys
+    ):
         return
 
     base_value = {
@@ -316,14 +335,7 @@ def _convert_extract_thumbnail(overrides):
         },
         "ffmpeg_args": {"input": ["-apply_trc gamma22"], "output": []},
     }
-    for key in (
-        "product_names",
-        "integrate_thumbnail",
-        "target_size",
-        "duration_split",
-        "oiiotool_defaults",
-        "ffmpeg_args",
-    ):
+    for key in keys:
         if key in extract_thumbnail_overrides:
             base_value[key] = extract_thumbnail_overrides.pop(key)
 
@@ -362,6 +374,35 @@ def _convert_burnin_offset_1_8_6(
         burnin_options["x_offset"] = max(y_offset - bg_padding, 0)
 
 
+def _fix_duplicates_extract_thumbnail(source_version, overrides):
+    """Fix issue where settings conversion may have duplicated the base
+    profile each time on settings copy due to bug in
+    `_convert_extract_thumbnail` implementation."""
+    if parse_version(source_version) > (1, 9, 8):
+        # Nothing to fix anymore
+        return
+
+    extract_thumbnail_overrides = (
+        overrides.get("publish", {})
+        .get("ExtractThumbnail", {})
+    )
+    profiles: list[dict] = extract_thumbnail_overrides.get("profiles", [])
+    if not profiles:
+        return
+
+    processed_profiles: set[str] = set()
+    non_duplicate_profiles = []
+    for profile in list(profiles):
+        profile_hash = json.dumps(profile, sort_keys=True)
+        if profile_hash in processed_profiles:
+            # Skip duplicate
+            continue
+        processed_profiles.add(profile_hash)
+        non_duplicate_profiles.append(profile)
+
+    extract_thumbnail_overrides["profiles"] = non_duplicate_profiles
+
+
 def convert_settings_overrides(
     source_version: str,
     overrides: dict[str, Any],
@@ -376,4 +417,5 @@ def convert_settings_overrides(
     _convert_product_base_types_1_8_0(overrides)
     _convert_unify_profile_keys_1_8_0(overrides)
     _convert_burnin_offset_1_8_6(overrides, version)
+    _fix_duplicates_extract_thumbnail(source_version, overrides)
     return overrides

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -4,7 +4,6 @@ import json
 from typing import Any
 
 from semver import VersionInfo
-from server.settings.conversion import parse_version
 
 from .publish_plugins import DEFAULT_PUBLISH_VALUES
 
@@ -295,9 +294,10 @@ def _convert_publish_plugins(overrides):
     _convert_oiio_transcode_0_4_5(overrides["publish"])
 
 
-def _convert_extract_thumbnail(source_version, overrides):
+def _convert_extract_thumbnail(overrides, version: VersionInfo):
     """ExtractThumbnail config settings did change to profiles."""
-    if parse_version(source_version) >= (1, 7, 0):
+
+    if (version.major, version.minor, version.patch) >= (1, 7, 0):
         return
 
     extract_thumbnail_overrides = (
@@ -374,11 +374,11 @@ def _convert_burnin_offset_1_8_6(
         burnin_options["x_offset"] = max(y_offset - bg_padding, 0)
 
 
-def _fix_duplicates_extract_thumbnail(source_version, overrides):
+def _fix_duplicates_extract_thumbnail(overrides, version: VersionInfo):
     """Fix issue where settings conversion may have duplicated the base
     profile each time on settings copy due to bug in
     `_convert_extract_thumbnail` implementation."""
-    if parse_version(source_version) > (1, 9, 8):
+    if (version.major, version.minor, version.patch) > (1, 9, 8):
         # Nothing to fix anymore
         return
 
@@ -413,9 +413,9 @@ def convert_settings_overrides(
     _convert_product_name_templates_1_6_5(overrides)
     _convert_product_name_templates_1_7_0(overrides)
     _convert_publish_plugins(overrides)
-    _convert_extract_thumbnail(overrides)
+    _convert_extract_thumbnail(overrides, version)
     _convert_product_base_types_1_8_0(overrides)
     _convert_unify_profile_keys_1_8_0(overrides)
     _convert_burnin_offset_1_8_6(overrides, version)
-    _fix_duplicates_extract_thumbnail(source_version, overrides)
+    _fix_duplicates_extract_thumbnail(overrides, version)
     return overrides


### PR DESCRIPTION
## Changelog Description

Fix Extract Thumbnail settings conversions appending more profiles on copy settings

## Additional info

Bug was introduced with #1582

## Testing notes:
1. Duplicate profiles should be removed if copied from core <=1.9.8
2. Settings with overrides to Extract Thumbnail should correctly convert from core <1.7.0, without creating duplicates when copying settings again and again. Settings newer than 1.7.0 copied from should also not cause duplicates.