### PR TITLE
Chore: Remove avalon mentions

### DIFF
--- a/client/ayon_core/pipeline/actions/launcher.py
+++ b/client/ayon_core/pipeline/actions/launcher.py
@@ -66,11 +66,11 @@ class LauncherActionSelection:
             ),
             category=DeprecationWarning
         )
-        if key in {"AYON_PROJECT_NAME", "AVALON_PROJECT"}:
+        if key == "AYON_PROJECT_NAME":
             return self.project_name
-        if key in {"AYON_FOLDER_PATH", "AVALON_ASSET"}:
+        if key == "AYON_FOLDER_PATH":
             return self.folder_path
-        if key in {"AYON_TASK_NAME", "AVALON_TASK"}:
+        if key == "AYON_TASK_NAME":
             return self.task_name
         raise KeyError(f"Key: {key} not found")
 
@@ -88,20 +88,11 @@ class LauncherActionSelection:
             category=DeprecationWarning
         )
         # Fake missing keys check for backwards compatibility
-        if key in {
-            "AYON_PROJECT_NAME",
-            "AVALON_PROJECT",
-        }:
+        if key == "AYON_PROJECT_NAME":
             return self._project_name is not None
-        if key in {
-            "AYON_FOLDER_PATH",
-            "AVALON_ASSET",
-        }:
+        if key == "AYON_FOLDER_PATH":
             return self._folder_id is not None
-        if key in {
-            "AYON_TASK_NAME",
-            "AVALON_TASK",
-        }:
+        if key == "AYON_TASK_NAME":
             return self._task_id is not None
         return False
 

--- a/client/ayon_core/pipeline/context_tools.py
+++ b/client/ayon_core/pipeline/context_tools.py
@@ -258,7 +258,7 @@ def uninstall_host():
 
     deregister_host()
 
-    log.info("Successfully uninstalled Avalon!")
+    log.info("Successfully uninstalled AYON!")
 
 
 def is_installed():

--- a/client/ayon_core/pipeline/create/context.py
+++ b/client/ayon_core/pipeline/create/context.py
@@ -163,10 +163,6 @@ class CreateContext:
     Context itself also can store data related to whole creation (workfile).
     - those are mainly for Context publish plugins
 
-    Todos:
-        Don't use 'AvalonMongoDB'. It's used only to keep track about current
-            context which should be handled by host.
-
     Args:
         host (IPublishHost): Host implementation which handles implementation
             and global metadata.

--- a/client/ayon_core/pipeline/create/creator_plugins.py
+++ b/client/ayon_core/pipeline/create/creator_plugins.py
@@ -139,9 +139,6 @@ class ProductConvertorPlugin(ABC):
 class BaseCreator(ABC):
     """Plugin that create and modify instance data before publishing process.
 
-    We should maybe find better name as creation is only one part of its logic
-    and to avoid expectations that it is the same as `avalon.api.Creator`.
-
     Single object should be used for multiple instances instead of single
     instance per one creator object. Do not store temp data or mid-process data
     to `self` if it's not Plugin specific.
@@ -489,12 +486,7 @@ class BaseCreator(ABC):
 
     @abstractmethod
     def create(self):
-        """Create new instance.
-
-        Replacement of `process` method from avalon implementation.
-        - must expect all data that were passed to init in previous
-            implementation
-        """
+        """Trigger creation logic usually to create new instance/s."""
 
     @abstractmethod
     def collect_instances(self):

--- a/client/ayon_core/pipeline/publish/lib.py
+++ b/client/ayon_core/pipeline/publish/lib.py
@@ -1176,20 +1176,6 @@ def main_cli_publish(
     if not isinstance(path, str):
         raise RuntimeError("Path to JSON must be a string.")
 
-    # Fix older jobs
-    for src_key, dst_key in (
-        ("AVALON_PROJECT", "AYON_PROJECT_NAME"),
-        ("AVALON_ASSET", "AYON_FOLDER_PATH"),
-        ("AVALON_TASK", "AYON_TASK_NAME"),
-        ("AVALON_WORKDIR", "AYON_WORKDIR"),
-        ("AVALON_APP_NAME", "AYON_APP_NAME"),
-        ("AVALON_APP", "AYON_HOST_NAME"),
-    ):
-        if src_key in os.environ and dst_key not in os.environ:
-            os.environ[dst_key] = os.environ[src_key]
-        # Remove old keys, so we're sure they're not used
-        os.environ.pop(src_key, None)
-
     log = Logger.get_logger("CLI-publish")
 
     # Make public ayon api behave as other user

--- a/client/ayon_core/plugins/publish/collect_host_name.py
+++ b/client/ayon_core/plugins/publish/collect_host_name.py
@@ -10,7 +10,7 @@ import pyblish.api
 
 
 class CollectHostName(pyblish.api.ContextPlugin):
-    """Collect avalon host name to context."""
+    """Collect AYON host name to context."""
 
     label = "Collect Host Name"
     order = pyblish.api.CollectorOrder - 0.5

--- a/client/ayon_core/tools/publisher/control.py
+++ b/client/ayon_core/tools/publisher/control.py
@@ -107,7 +107,6 @@ class PublisherController(
         self._create_model = CreateModel(self)
         self._publish_model = PublishModel(self)
 
-        # Cacher of avalon documents
         self._projects_model = ProjectsModel(self)
         self._hierarchy_model = HierarchyModel(self)
         self._users_model = UsersModel(self)

--- a/client/ayon_core/tools/texture_copy/app.py
+++ b/client/ayon_core/tools/texture_copy/app.py
@@ -133,7 +133,7 @@ class TextureCopy:
 @click.option('--path', required=True)
 def texture_copy(project, folder, path):
     t.echo("*** Running Texture tool ***")
-    t.echo(">>> Initializing avalon session ...")
+    t.echo(">>> Initializing AYON session ...")
     os.environ["AYON_PROJECT_NAME"] = project
     os.environ["AYON_FOLDER_PATH"] = folder
     TextureCopy().process(project, folder, path)

--- a/client/ayon_core/tools/utils/delegates.py
+++ b/client/ayon_core/tools/utils/delegates.py
@@ -85,8 +85,7 @@ def pretty_timestamp(t, now=None):
     if isinstance(t, float):
         dt = datetime.fromtimestamp(t)
     else:
-        # Parse the time format as if it is `str` result from
-        # `pyblish.lib.time()` which usually is stored in Avalon database.
+        # Parse the time from datetime format
         try:
             t = time.strptime(t, "%Y%m%dT%H%M%SZ")
         except ValueError as e:


### PR DESCRIPTION
## Changelog Description
Remove avalon mentions and backwards compatibilities.

## Additional info
I do believe we don't need to support `AVALON_` env variables anymore. Some of the modified methods are deprecated anyways.

NOTE: There are still places that do use avalon (more scary to remove)...

## Testing notes:
1. Validate code changes.
