### PR TITLE
Publisher UI: Remove Traypublisher compatibility

### DIFF
--- a/client/ayon_core/tools/publisher/control.py
+++ b/client/ayon_core/tools/publisher/control.py
@@ -214,19 +214,6 @@ class PublisherController(
         """Current instances in create context."""
         return self._create_model.get_instance_items()
 
-    # --- Legacy for TrayPublisher ---
-    @property
-    def instances(self):
-        return self.get_instance_items()
-
-    def get_instances(self):
-        return self.get_instance_items()
-
-    def get_instances_by_id(self, *args, **kwargs):
-        return self.get_instance_items_by_id(*args, **kwargs)
-
-    # ---
-
     def get_instance_items_by_id(self, instance_ids=None):
         return self._create_model.get_instance_items_by_id(instance_ids)
 

--- a/package.py
+++ b/package.py
@@ -19,4 +19,5 @@ ayon_compatible_addons = {
     "harmony": ">0.4.0",
     "fusion": ">=0.3.3",
     "openrv": ">=1.0.2",
+    "traypublisher": ">=0.3.0",
 }


### PR DESCRIPTION
## Changelog Description
Remove legacy methods from Publisher that were for traypublisher compatibility.

## Additional info
Bumped compatible traypublisher to version which stopped to use the methods.

## Testing notes:
1. Validate that traypublisher works.
