### PR TITLE
Delivery: support per-representation template overrides

### DIFF
--- a/client/ayon_core/pipeline/delivery.py
+++ b/client/ayon_core/pipeline/delivery.py
@@ -190,6 +190,16 @@ def deliver_single_file(
     delivery_path = delivery_path.rstrip()
 
     delivery_folder = os.path.dirname(delivery_path)
+    # Remove frame number if is find in folder path
+    # usually due publishedFilename token used in directory
+    frame = anatomy_data.get("frame")
+    if frame is not None:
+        frame_pattern = f".{frame}"
+        if frame_pattern in delivery_folder:
+            delivery_folder = delivery_folder.replace(frame_pattern, "")
+            delivery_path = os.path.join(
+                delivery_folder, os.path.basename(delivery_path))
+
     if not os.path.exists(delivery_folder):
         os.makedirs(delivery_folder)
 
@@ -208,10 +218,8 @@ def deliver_sequence(
     format_dict,
     report_items,
     log,
-    *,
     has_renumbered_frame=False,
-    new_frame_start=0,
-    explicit_template_obj=None,
+    new_frame_start=0
 ):
     """ For Pype2(mainly - works in 3 too) where representation might not
         contain files.
@@ -234,9 +242,6 @@ def deliver_sequence(
         has_renumbered_frame (bool, optional): whether the frame has been
             renumbered.
         new_frame_start (int, optional): new frame start value.
-        explicit_template_obj (AnatomyTemplateItem, optional): Anatomy template
-            item to use instead of the one defined in the delivery template.
-
 
     Returns:
         (collections.defaultdict, int)
@@ -257,10 +262,7 @@ def deliver_sequence(
         report_items["Source file was not found"].append(msg)
         return report_items, 0
 
-    if explicit_template_obj is not None:
-        delivery_template = explicit_template_obj.get("path")
-    else:
-        delivery_template = anatomy.get_template_item(
+    delivery_template = anatomy.get_template_item(
             "delivery", template_name, "path", default=None
     )
     if delivery_template is None:

--- a/client/ayon_core/pipeline/delivery.py
+++ b/client/ayon_core/pipeline/delivery.py
@@ -66,7 +66,9 @@ def check_destination_path(
     anatomy,
     anatomy_data,
     datetime_data,
-    template_name
+    template_name,
+    *,
+    explicit_template_obj=None,
 ):
     """ Try to create destination path based on 'template_name'.
 
@@ -80,14 +82,20 @@ def check_destination_path(
         datetime_data (dict): Values with actual date.
         template_name (str): Name of template which should be used from anatomy
             templates.
+        explicit_template_obj (AnatomyTemplateItem, optional): Anatomy template
+            item to use instead of the one defined in the delivery template.
     Returns:
         Dict[str, List[str]]: Report of happened errors. Key is message title
             value is detailed information.
     """
 
     anatomy_data.update(datetime_data)
-    path_template = anatomy.get_template_item(
-        "delivery", template_name, "path"
+
+    if explicit_template_obj is not None:
+        path_template = explicit_template_obj.get("path")
+    else:
+        path_template = anatomy.get_template_item(
+            "delivery", template_name, "path"
     )
     dest_path = path_template.format(anatomy_data)
     report_items = collections.defaultdict(list)
@@ -131,7 +139,9 @@ def deliver_single_file(
     anatomy_data,
     format_dict,
     report_items,
-    log
+    log,
+    *,
+    explicit_template_obj=None
 ):
     """Copy single file to calculated path based on template
 
@@ -145,6 +155,8 @@ def deliver_single_file(
         format_dict (dict): root dictionary with names and values
         report_items (collections.defaultdict): to return error messages
         log (logging.Logger): for log printing
+        explicit_template_obj (AnatomyTemplateItem, optional): Anatomy template
+            item to use instead of the one defined in the delivery template.
 
     Returns:
         (collections.defaultdict, int)
@@ -161,8 +173,12 @@ def deliver_single_file(
     if format_dict:
         anatomy_data = copy.deepcopy(anatomy_data)
         anatomy_data["root"] = format_dict["root"]
-    template_obj = anatomy.get_template_item(
-        "delivery", template_name, "path"
+
+    if explicit_template_obj is not None:
+        template_obj = explicit_template_obj.get("path")
+    else:
+        template_obj = anatomy.get_template_item(
+            "delivery", template_name, "path"
     )
     delivery_path = template_obj.format_strict(anatomy_data)
 
@@ -192,8 +208,10 @@ def deliver_sequence(
     format_dict,
     report_items,
     log,
+    *,
     has_renumbered_frame=False,
-    new_frame_start=0
+    new_frame_start=0,
+    explicit_template_obj=None,
 ):
     """ For Pype2(mainly - works in 3 too) where representation might not
         contain files.
@@ -213,6 +231,12 @@ def deliver_sequence(
         format_dict (dict): root dictionary with names and values
         report_items (collections.defaultdict): to return error messages
         log (logging.Logger): for log printing
+        has_renumbered_frame (bool, optional): whether the frame has been
+            renumbered.
+        new_frame_start (int, optional): new frame start value.
+        explicit_template_obj (AnatomyTemplateItem, optional): Anatomy template
+            item to use instead of the one defined in the delivery template.
+
 
     Returns:
         (collections.defaultdict, int)
@@ -233,8 +257,11 @@ def deliver_sequence(
         report_items["Source file was not found"].append(msg)
         return report_items, 0
 
-    delivery_template = anatomy.get_template_item(
-        "delivery", template_name, "path", default=None
+    if explicit_template_obj is not None:
+        delivery_template = explicit_template_obj.get("path")
+    else:
+        delivery_template = anatomy.get_template_item(
+            "delivery", template_name, "path", default=None
     )
     if delivery_template is None:
         msg = (

--- a/client/ayon_core/tools/delivery/delivery.py
+++ b/client/ayon_core/tools/delivery/delivery.py
@@ -393,7 +393,6 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
                 m_directory_tmpl = m_directory_tmpl.replace(
                     "{file}", original_file
                 )
-        print(m_directory_tmpl)
 
         m_file_tmpl = (
             matching_rule["template_file"] or original_file

--- a/client/ayon_core/tools/delivery/delivery.py
+++ b/client/ayon_core/tools/delivery/delivery.py
@@ -1,26 +1,26 @@
+import logging
 import os
 import platform
-import logging
 from collections import defaultdict
 
 import ayon_api
-from qtpy import QtWidgets, QtCore, QtGui
+from qtpy import QtCore, QtGui, QtWidgets
 
 from ayon_core import resources, style
 from ayon_core.lib import (
-    format_file_size,
     collect_frames,
+    format_file_size,
     get_datetime_data,
 )
 from ayon_core.pipeline import Anatomy
-
-from ayon_core.pipeline.load import get_representation_path_with_anatomy
 from ayon_core.pipeline.delivery import (
-    get_format_dict,
     check_destination_path,
     deliver_single_file,
+    get_format_dict,
     get_representations_delivery_template_data,
 )
+from ayon_core.pipeline.load import get_representation_path_with_anatomy
+from ayon_core.settings import get_project_settings
 
 
 class DeliveryOptionsDialog(QtWidgets.QDialog):
@@ -229,7 +229,21 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
                 self.anatomy.project_name, repre_ids
             )
         )
+        # TODO: implement overrides
+        # get settings and check if template name in override presets
+        # if it is then get template data from self.templates with
+        # template name. Then get representation rules
+        core_settings = get_project_settings(self.anatomy.project_name)
+        overrides: list[dict] = core_settings["tools"]["delivery"]["overrides"]
+        # check if template name is in overrides keys
+        override_preset = None
+        for preset in overrides:
+            if preset["name"] == template_name:
+                override_preset = preset
+                break
+
         for repre in filtered_repres:
+            explicit_template_obj = None
             repre_path = get_representation_path_with_anatomy(
                 repre, self.anatomy
             )
@@ -237,6 +251,12 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
             template_data = template_data_by_repre_id[repre["id"]]
             if list_label:
                 template_data["list"] = {"label": list_label}
+
+            # TODO: check if representation is in override preset rules
+            # if it is then get override template data
+            # get format new explicit_template_obj and add it to args.
+            if override_preset:
+
 
             # Use temporary placeholder so we don't need to check destination
             # path per file of the representation
@@ -246,7 +266,8 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
                 self.anatomy,
                 template_data,
                 datetime_data,
-                template_name
+                template_name,
+                explicit_template_obj=explicit_template_obj,
             )
 
             report_items.update(new_report_items)
@@ -261,7 +282,8 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
                 template_data,
                 format_dict,
                 report_items,
-                self.log
+                self.log,
+                explicit_template_obj,
             ]
 
             # TODO: This will currently incorrectly detect 'resources'
@@ -283,11 +305,13 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
 
             for src_path, frame in sources_and_frames.items():
                 # Support {publishedFilename} token
-                template_data["publishedFilename"] = os.path.basename(
+                publish_basename = os.path.basename(
                     # Replace backslash to forward slashes so basename
                     # also resolves to filename only on POSIX
                     src_path.replace("\\", "/")
                 )
+                filename, _ = os.path.splitext(publish_basename)
+                template_data["publishedFilename"] = filename
                 args[0] = src_path
                 # Renumber frames
                 if renumber_frame and frame is not None:

--- a/client/ayon_core/tools/delivery/delivery.py
+++ b/client/ayon_core/tools/delivery/delivery.py
@@ -13,6 +13,7 @@ from ayon_core.lib import (
     get_datetime_data,
 )
 from ayon_core.pipeline import Anatomy
+from ayon_core.pipeline.anatomy.templates import TemplateItem
 from ayon_core.pipeline.delivery import (
     check_destination_path,
     deliver_single_file,
@@ -229,13 +230,10 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
                 self.anatomy.project_name, repre_ids
             )
         )
-        # TODO: implement overrides
-        # get settings and check if template name in override presets
-        # if it is then get template data from self.templates with
-        # template name. Then get representation rules
         core_settings = get_project_settings(self.anatomy.project_name)
-        overrides: list[dict] = core_settings["tools"]["delivery"]["overrides"]
-        # check if template name is in overrides keys
+        overrides: list[dict] = (
+            core_settings["core"]["tools"]["delivery"]["overrides"]
+        )
         override_preset = None
         for preset in overrides:
             if preset["name"] == template_name:
@@ -252,11 +250,10 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
             if list_label:
                 template_data["list"] = {"label": list_label}
 
-            # TODO: check if representation is in override preset rules
-            # if it is then get override template data
-            # get format new explicit_template_obj and add it to args.
             if override_preset:
-
+                explicit_template_obj = self._get_explicit_template_obj(
+                    repre, override_preset, template_name
+                )
 
             # Use temporary placeholder so we don't need to check destination
             # path per file of the representation
@@ -283,7 +280,6 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
                 format_dict,
                 report_items,
                 self.log,
-                explicit_template_obj,
             ]
 
             # TODO: This will currently incorrectly detect 'resources'
@@ -322,7 +318,10 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
                     # Add offset to new frame start
                     dst_frame = int(frame) + offset
                     if dst_frame < 0:
-                        msg = "Renumber frame has a smaller number than original frame"     # noqa
+                        msg = (
+                            "Renumber frame has a smaller number than "
+                            "original frame"
+                        )
                         report_items[msg].append(src_path)
                         self.log.warning("{} <{}>".format(
                             msg, dst_frame))
@@ -342,12 +341,77 @@ class DeliveryOptionsDialog(QtWidgets.QDialog):
                             " formatting data."
                         )
                         template_data["frame"] = frame
-                new_report_items, uploaded = deliver_single_file(*args)
+
+                new_report_items, uploaded = deliver_single_file(
+                    *args,
+                    explicit_template_obj=explicit_template_obj
+                )
                 report_items.update(new_report_items)
                 self._update_progress(uploaded)
 
         self.text_area.setText(self._format_report(report_items))
         self.text_area.setVisible(True)
+
+    def _get_explicit_template_obj(
+        self, repre, override_preset, template_name
+    ):
+        """Build an explicit template override for a representation."""
+        if not override_preset:
+            return None
+
+        matching_rule = None
+        for rule in override_preset["rules"]:
+            if rule["name"] == repre["name"]:
+                matching_rule = rule
+                break
+
+        if matching_rule is None:
+            return None
+
+        original_template = self.templates[template_name]
+        if (
+            not matching_rule["template_dir"]
+            and not matching_rule["template_file"]
+        ):
+            return None
+
+        original_directory = original_template["directory"]
+        original_file = original_template["file"]
+        # make sure if file or directory is in template it is
+        # wrapped into double braces so it is not formatted
+        # e.g. "{directory}" should be "{{directory}}" so it is not
+        # replaced by the format method
+        m_directory_tmpl = (
+            matching_rule["template_dir"] or original_directory
+        )
+        if m_directory_tmpl != original_directory:
+            if "{directory}" in m_directory_tmpl:
+                m_directory_tmpl = m_directory_tmpl.replace(
+                    "{directory}", original_directory
+                )
+            if "{file}" in m_directory_tmpl:
+                m_directory_tmpl = m_directory_tmpl.replace(
+                    "{file}", original_file
+                )
+        print(m_directory_tmpl)
+
+        m_file_tmpl = (
+            matching_rule["template_file"] or original_file
+        )
+        if m_file_tmpl != original_file:
+            if "{directory}" in m_file_tmpl:
+                m_file_tmpl = m_file_tmpl.replace(
+                    "{directory}", original_directory
+                )
+            if "{file}" in m_file_tmpl:
+                m_file_tmpl = m_file_tmpl.replace(
+                    "{file}", original_file
+                )
+
+        return TemplateItem(
+            self.anatomy.templates_obj,
+            {"directory": m_directory_tmpl, "file": m_file_tmpl},
+        )
 
     def _get_representation_names(self):
         """Get set of representation names for checkbox filtering."""

--- a/server/settings/tools.py
+++ b/server/settings/tools.py
@@ -451,6 +451,67 @@ class PublishToolModel(BaseSettingsModel):
     )
 
 
+class DeliveryRepresentationRuleModel(BaseSettingsModel):
+    name: str = SettingsField(
+        "",
+        title="Representation Name",
+        description="Name of the representation to match"
+    )
+    template_dir: str = SettingsField(
+        "",
+        title="Directory Template Override",
+        description=(
+            "Overriding 'Directory Template'. Additional tokens: \n"
+            "- `{directory}` - original 'Directory Template'\n"
+            "- `{file}` - original 'File Name Template'"
+        )
+    )
+    template_file: str = SettingsField(
+        "",
+        title="File Name Template Override",
+        description=(
+            "Overriding 'File Name Template'. Additional tokens: \n"
+            "- `{directory}` - original 'Directory Template'\n"
+            "- `{file}` - original 'File Name Template'"
+        )
+    )
+    @validator("name")
+    def normalize_value(cls, value):
+        return normalize_name(value)
+
+
+class DeliveryTemplateOverrideModel(BaseSettingsModel):
+    name: str = SettingsField(
+        "",
+        title="Anatomy DeliveryTemplate Name",
+        description="Name of the delivery category template to match"
+    )
+    rules: list[DeliveryRepresentationRuleModel] = SettingsField(
+        default_factory=list,
+        title="Representation Rules",
+        description=(
+            "Rules to override the chosen delivery template. "
+            "Rules are evaluated in order, and the first matching rule "
+            "determines the delivery template to use."
+        )
+    )
+    @validator("name")
+    def normalize_value(cls, value):
+        return normalize_name(value)
+
+
+class DeliveryToolModel(BaseSettingsModel):
+    overrides: list[DeliveryTemplateOverrideModel] = SettingsField(
+        default_factory=list,
+        title="Delivery Anatomy Template Override Presets",
+        description=(
+            "Overrides presets to override the chosen delivery template. "
+            "Evaluated in order, and the first matching override "
+            "determines the delivery template to use."
+        )
+    )
+
+
 class GlobalToolsModel(BaseSettingsModel):
     ayon_menu: AYONMenuModel = SettingsField(
         default_factory=AYONMenuModel,
@@ -475,6 +536,10 @@ class GlobalToolsModel(BaseSettingsModel):
     publish: PublishToolModel = SettingsField(
         default_factory=PublishToolModel,
         title="Publish"
+    )
+    delivery: DeliveryToolModel = SettingsField(
+        default_factory=DeliveryToolModel,
+        title="Delivery"
     )
 
 
@@ -772,5 +837,9 @@ DEFAULT_TOOLS_VALUES = {
             "ignore_paths": [],
         },
         "comment_minimum_required_chars": 0,
-    }
+    },
+    "delivery": {
+        "enabled": False,
+        "overrides": [],
+    },
 }

--- a/server/settings/tools.py
+++ b/server/settings/tools.py
@@ -475,6 +475,7 @@ class DeliveryRepresentationRuleModel(BaseSettingsModel):
             "- `{file}` - original 'File Name Template'"
         )
     )
+
     @validator("name")
     def normalize_value(cls, value):
         return normalize_name(value)
@@ -495,6 +496,7 @@ class DeliveryTemplateOverrideModel(BaseSettingsModel):
             "determines the delivery template to use."
         )
     )
+
     @validator("name")
     def normalize_value(cls, value):
         return normalize_name(value)


### PR DESCRIPTION
## Changelog Description
Adds configurable overrides for delivery templates on a per-representation basis. Studios can now define override presets in project settings that swap the directory/file template for specific representation names, instead of being locked to a single delivery template. Also adds support for using `{publishedFilename}` without its extension in templates.

## Additional info
- New settings models (`DeliveryToolModel`, `DeliveryTemplateOverrideModel`, `DeliveryRepresentationRuleModel`) expose override presets under Delivery tool settings, matched by representation name.
- `check_destination_path` and `deliver_single_file` accept an optional `explicit_template_obj` to bypass the named anatomy template lookup.
- Delivery UI builds the override template object per representation, merging `{directory}`/`{file}` tokens from the original template when only one side is overridden.
- Strips stray frame-number segments from the destination folder when `{publishedFilename}` (without extension) is used in a directory token.

<img width="618" height="363" alt="image" src="https://github.com/user-attachments/assets/e4d5cd62-e84b-4a9f-8873-b935fd2495de" />

<img width="713" height="287" alt="image" src="https://github.com/user-attachments/assets/a13f8691-3816-4576-bbd6-852f90bd9578" />

<img width="544" height="165" alt="image" src="https://github.com/user-attachments/assets/a729c067-bfeb-4062-b19c-d6bf1d9c0bbb" />


## Testing notes:
1. Configure a delivery override preset in project settings (AYON Core > Delivery) with a representation rule overriding directory/file template.
2. Run the Delivery tool against a representation matching the rule and confirm files land at the overridden path.
3. Verify representations without a matching rule still use the default delivery template.

## Dependency
Close https://github.com/ynput/ayon-core/issues/1961

## Related support tickets
[YN-0942](https://support.ayon.app/projects/Active_Clients/overview?project=Active_Clients&type=folder&id=05101f3b4072477cad4d865793e7410c)
