### PR TITLE
Validate Workfile: Hosts filtering

### DIFF
--- a/client/ayon_core/plugins/publish/validate_file_saved.py
+++ b/client/ayon_core/plugins/publish/validate_file_saved.py
@@ -2,6 +2,8 @@ import inspect
 
 import pyblish.api
 
+from ayon_core.host import IWorkfileHost
+from ayon_core.pipeline import registered_host
 from ayon_core.pipeline.publish import PublishValidationError
 from ayon_core.tools.utils.host_tools import show_workfiles
 from ayon_core.pipeline.context_tools import version_up_current_workfile
@@ -42,6 +44,9 @@ class ValidateCurrentSaveFile(pyblish.api.ContextPlugin):
     actions = [SaveByVersionUpAction, ShowWorkfilesAction]
 
     def process(self, context):
+        host = registered_host()
+        if not isinstance(host, IWorkfileHost):
+            return
 
         current_file = context.data["currentFile"]
         if not current_file:

--- a/client/ayon_core/plugins/publish/validate_file_saved.py
+++ b/client/ayon_core/plugins/publish/validate_file_saved.py
@@ -5,8 +5,8 @@ import pyblish.api
 from ayon_core.host import IWorkfileHost
 from ayon_core.pipeline import registered_host
 from ayon_core.pipeline.publish import PublishValidationError
+from ayon_core.pipeline.workfile import save_next_version
 from ayon_core.tools.utils.host_tools import show_workfiles
-from ayon_core.pipeline.context_tools import version_up_current_workfile
 
 
 class SaveByVersionUpAction(pyblish.api.Action):
@@ -16,7 +16,7 @@ class SaveByVersionUpAction(pyblish.api.Action):
     icon = "save"
 
     def process(self, context, plugin):
-        version_up_current_workfile()
+        save_next_version()
 
 
 class ShowWorkfilesAction(pyblish.api.Action):

--- a/client/ayon_core/plugins/publish/validate_file_saved.py
+++ b/client/ayon_core/plugins/publish/validate_file_saved.py
@@ -38,9 +38,6 @@ class ValidateCurrentSaveFile(pyblish.api.ContextPlugin):
 
     label = "Validate File Saved"
     order = pyblish.api.ValidatorOrder - 0.1
-    hosts = ["fusion", "houdini", "max", "maya", "nuke", "substancepainter",
-             "cinema4d", "silhouette", "gaffer", "blender", "loki",
-             "photoshop"]
     actions = [SaveByVersionUpAction, ShowWorkfilesAction]
 
     def process(self, context):

--- a/client/ayon_core/plugins/publish/validate_file_saved.py
+++ b/client/ayon_core/plugins/publish/validate_file_saved.py
@@ -43,6 +43,10 @@ class ValidateCurrentSaveFile(pyblish.api.ContextPlugin):
     def process(self, context):
         host = registered_host()
         if not isinstance(host, IWorkfileHost):
+            self.log.debug(
+                "Skipping file save validation because host does "
+                "not implement workfiles."
+            )
             return
 
         current_file = context.data["currentFile"]


### PR DESCRIPTION
## Changelog Description
Remove hosts filters from `ValidateCurrentSaveFile` and run the logic only for hosts that do inherit from `IWorkfileHost`.

## Additional info
This is a proposal of the change, I'm not sure if this logic is 100% right as there were not all hosts listed in the plugin's `hosts` attribute.

Because it is context plugin, and the validation is not related to any instance we'd have to enable the plugin from host using predefined key on `context.data`.

Also replaced deprecated function `version_up_current_workfile` with `save_next_version`.

### Notes
- The plugin does not validate if the workfile is saved, it does validate if is set.
- There are hosts that do not inherit from `IWorkfileHost` but do set the `"currentFile"`, those would have to validate the key on their own -> which is probably ok.

## Testing notes:
1. Validate code changes.
2. This probably should be test in all hosts that can have a workfile.
