### PR TITLE
[YN-0943] Support slateFrame key for backward compatibility in ExtractReviewSlate

### DIFF
--- a/client/ayon_core/pipeline/farm/pyblish_functions.py
+++ b/client/ayon_core/pipeline/farm/pyblish_functions.py
@@ -514,7 +514,7 @@ def prepare_representations(
         if ext in skip_integration_repre_list:
             rep["tags"].append("delete")
 
-        if ext in slate_representation_ext:
+        if ext == slate_representation_ext:
             rep["tags"].append("slate-frame")
 
         if skeleton_data.get("multipartExr", False):

--- a/client/ayon_core/pipeline/farm/pyblish_functions.py
+++ b/client/ayon_core/pipeline/farm/pyblish_functions.py
@@ -360,6 +360,15 @@ def create_skeleton_instance(
         if item in instance.data.get("families", []):
             instance_skeleton_data["families"] += [item]
 
+    slate_representation_ext = instance.data.get(
+        "slateRepresentationExt")
+    if (
+        "slate" in families_transfer
+        and slate_representation_ext
+    ):
+        instance_skeleton_data["slateRepresentationExt"] = \
+            slate_representation_ext
+
     # transfer specific properties from original instance based on
     # mapping dictionary `instance_transfer`
     for key, values in instance_transfer.items():
@@ -428,6 +437,7 @@ def prepare_representations(
 
     """
     representations = []
+    slate_representation_ext = skeleton_data.get("slateRepresentationExt", [])
     host_name = os.environ.get("AYON_HOST_NAME", "")
     collections, remainders = clique.assemble(exp_files)
 
@@ -503,6 +513,9 @@ def prepare_representations(
         # poor man exclusion
         if ext in skip_integration_repre_list:
             rep["tags"].append("delete")
+
+        if ext in slate_representation_ext:
+            rep["tags"].append("slate-frame")
 
         if skeleton_data.get("multipartExr", False):
             rep["tags"].append("multipartExr")

--- a/client/ayon_core/plugins/publish/extract_review_slate.py
+++ b/client/ayon_core/plugins/publish/extract_review_slate.py
@@ -40,8 +40,8 @@ class ExtractReviewSlate(publish.Extractor):
 
         # get slates frame from upstream
         slates_data = inst_data.get("slateFrames")
-        slate_frame = inst_data.get("slateFrame")
-        if not slates_data and slate_frame is not None:
+        slate_frame = inst_data.get("slateFrame", 0)
+        if not slates_data and not slate_frame:
             # make it backward compatible and open for slates generator
             # premium plugin
             slates_data = {

--- a/client/ayon_core/plugins/publish/extract_review_slate.py
+++ b/client/ayon_core/plugins/publish/extract_review_slate.py
@@ -41,11 +41,11 @@ class ExtractReviewSlate(publish.Extractor):
         # get slates frame from upstream
         slates_data = inst_data.get("slateFrames")
         slate_frame = inst_data.get("slateFrame")
-        if not slates_data and slate_frame:
+        if not slates_data and slate_frame is not None:
             # make it backward compatible and open for slates generator
             # premium plugin
             slates_data = {
-                "*": inst_data["slateFrame"]
+                "*": slate_frame
             }
         if not slates_data:
             return

--- a/client/ayon_core/plugins/publish/extract_review_slate.py
+++ b/client/ayon_core/plugins/publish/extract_review_slate.py
@@ -40,8 +40,8 @@ class ExtractReviewSlate(publish.Extractor):
 
         # get slates frame from upstream
         slates_data = inst_data.get("slateFrames")
-        slate_frame = inst_data.get("slateFrame", 0)
-        if not slates_data and not slate_frame:
+        slate_frame = inst_data.get("slateFrame")
+        if not slates_data and slate_frame is not None:
             # make it backward compatible and open for slates generator
             # premium plugin
             slates_data = {

--- a/client/ayon_core/plugins/publish/extract_review_slate.py
+++ b/client/ayon_core/plugins/publish/extract_review_slate.py
@@ -40,12 +40,15 @@ class ExtractReviewSlate(publish.Extractor):
 
         # get slates frame from upstream
         slates_data = inst_data.get("slateFrames")
-        if not slates_data:
+        slate_frame = inst_data.get("slateFrame")
+        if not slates_data and slate_frame:
             # make it backward compatible and open for slates generator
             # premium plugin
             slates_data = {
                 "*": inst_data["slateFrame"]
             }
+        if not slates_data:
+            return
 
         self.log.debug("_ slates_data: {}".format(pformat(slates_data)))
 


### PR DESCRIPTION

## Changelog Description
The `ExtractReviewSlate` plugin now supports both `slateFrames` and `slateFrame` keys when extracting data from upstream, enabling backward compatibility with the Slates Generator plugin. When no slate frame data is provided at all (neither key exists or contains empty values), the plugin returns early instead of crashing. This prevents runtime crashes when downstream tasks receive no slate information from upstream plugins.

## Additional info
The change modifies `client/ayon_core/plugins/publish/extract_review_slate.py` to:
1. Support reading from both `slateFrames` and `slateFrame` dictionary keys
2. Perform an early return when neither key has data, avoiding crashes on the downstream side

## Testing notes:
1. Ensure ExtractReviewSlate runs without error when upstream provides slate frames in either format
2. Verify no crash occurs when upstream provides no slate frame data at all

## Dependency
Close [#333](https://github.com/ynput/ayon-nuke/issues/333)

## Related support tickets
[YN-0943](https://support.ayon.app/projects/Active_Clients/overview/projects/Active_Clients/overview/projects/Active_Clients?project=Active_Clients&type=task&id=f2d9f886affb455a9dbaa9ecc0221cca)
