### PR TITLE
Addons report: Don't separate server addons 

### DIFF
--- a/client/ayon_core/addon/base.py
+++ b/client/ayon_core/addon/base.py
@@ -1054,7 +1054,7 @@ class AddonsManager:
             report_row
             for report_row in sorted(
                 self._report_by_name.values(),
-                key=lambda item: (int(item.server_addon), item.name)
+                key=lambda item: item.name
             )
         ]
         sorted_rows.append(self._total_row)

--- a/client/ayon_core/plugins/publish/collect_addons.py
+++ b/client/ayon_core/plugins/publish/collect_addons.py
@@ -89,21 +89,20 @@ class CollectAddons(pyblish.api.ContextPlugin):
                 label,
             ))
 
-        server_items = []
+        items = []
         for addon_name in server_only_addons:
             server_version = server_version_by_name[addon_name]
             name_width = max(name_width, len(addon_name))
             server_version_width = max(
                 server_version_width, len(server_version)
             )
-            server_items.append(AddonInfo(
+            items.append(AddonInfo(
                 addon_name,
                 None,
                 server_version,
             ))
 
         items.sort(key=lambda x: x.name)
-        server_items.sort(key=lambda x: x.name)
 
         title = (
             f"{title_name:<{name_width}}"
@@ -140,12 +139,6 @@ class CollectAddons(pyblish.api.ContextPlugin):
             item.get_row(name_width, version_width, server_version_width)
             for item in items
         )
-        if server_items:
-            lines.append(sep_line)
-            lines.extend(
-                item.get_row(name_width, version_width, server_version_width)
-                for item in server_items
-            )
-            lines.append(sep_line)
+        lines.append(sep_line)
 
         self.log.debug("\n".join(lines))

--- a/client/ayon_core/plugins/publish/collect_addons.py
+++ b/client/ayon_core/plugins/publish/collect_addons.py
@@ -89,7 +89,6 @@ class CollectAddons(pyblish.api.ContextPlugin):
                 label,
             ))
 
-        items = []
         for addon_name in server_only_addons:
             server_version = server_version_by_name[addon_name]
             name_width = max(name_width, len(addon_name))


### PR DESCRIPTION
## Changelog Description
Sort all addons by name in reports. Do not separate server addons to the bottom.

## Additional info
Following PR to https://github.com/ynput/ayon-core/pull/1962.

## Testing notes:
1. All addons are sorted by name.
