### PR TITLE
Enhancement: (Loader) Expand "My Tasks" toggle to menu with toggles for "My tasks" / "Linked breakdown / template"

### DIFF
--- a/client/ayon_core/tools/loader/ui/window.py
+++ b/client/ayon_core/tools/loader/ui/window.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import os
 from typing import Optional
 
+from ayon_api import get_folder_by_path, get_folder_links
 from qtpy import QtWidgets, QtCore, QtGui
 
+from ayon_core.host import AbstractHost
 from ayon_core.lib.icon_definitions import MaterialSymbolsIcon
 from ayon_core.resources import get_ayon_icon_filepath
 from ayon_core.style import load_stylesheet
@@ -15,9 +18,10 @@ from ayon_core.tools.utils import (
     RefreshButton,
     GoToCurrentButton,
     ProjectsCombobox,
+    NiceCheckbox,
     get_qt_icon,
-    FoldersFiltersWidget,
 )
+from ayon_core.tools.utils.folders_widget import FoldersFiltersWidgetBase
 from ayon_core.tools.attribute_defs import AttributeDefinitionsDialog
 from ayon_core.tools.utils.lib import center_window
 from ayon_core.tools.common_models import StatusItem
@@ -134,6 +138,116 @@ class RefreshHandler:
         self._products_refreshed = True
 
 
+class LoaderNiceCheckbox(QtWidgets.QWidget):
+    """Wraps NiceCheckBox in a Widget."""
+    state_changed = QtCore.Signal(bool)
+
+    def __init__(
+            self,
+            label: str,
+            tooltip: str = "",
+            checked: bool = False,
+            parent=None,
+        ):
+
+        super().__init__(parent)
+
+        layout = QtWidgets.QHBoxLayout(self)
+
+        _tooltip = (
+            tooltip
+        )
+        _label = QtWidgets.QLabel(label, self)
+        _label.setToolTip(_tooltip)
+
+        checkbox = NiceCheckbox(self)
+        checkbox.setChecked(checked)
+        checkbox.setToolTip(_tooltip)
+
+        checkbox.stateChanged.connect(self._on_state_change)
+
+        layout.addWidget(checkbox)
+        layout.addWidget(_label)
+
+        self._checkbox = checkbox
+        self.setLayout(layout)
+
+    def setChecked(self, checked: bool):
+        self._checkbox.setChecked(checked)
+
+    def isChecked(self):
+        return self._checkbox.isChecked()
+
+    def _on_state_change(self, _state: int) -> None:
+        self.state_changed.emit(self._checkbox.isChecked())
+
+
+class LoaderFiltersMenu(QtWidgets.QMenu):
+    """Menu that with My tasks, and Linked breakdown / template"""
+
+    check_state_changed = QtCore.Signal(tuple)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self._my_tasks_checkbox = LoaderNiceCheckbox(
+            "My tasks",
+            "Filter folders and task to only those you are assigned to.",
+            False,
+            self
+        )
+
+        self._linked_breakdown_checkbox = LoaderNiceCheckbox(
+            "Linked breakdown",
+            ("Filter folders to those that are linked to "
+            "current context as breakdown."),
+            False,
+            self
+        )
+
+        self._linked_template_checkbox = LoaderNiceCheckbox(
+            "Linked template",
+            ("Filter folders to those that are linked to "
+            "current context as template."),
+            False,
+            self
+        )
+
+        self._add_widget_as_action(self._my_tasks_checkbox)
+        self._add_widget_as_action(self._linked_breakdown_checkbox)
+        self._add_widget_as_action(self._linked_template_checkbox)
+
+        self._my_tasks_checkbox.state_changed.connect(self._on_filter_checkboxes_state_changed)
+        self._linked_breakdown_checkbox.state_changed.connect(self._on_filter_checkboxes_state_changed)
+        self._linked_template_checkbox.state_changed.connect(self._on_filter_checkboxes_state_changed)
+
+    def _add_widget_as_action(self, widget: QtWidgets.QWidget):
+        action = QtWidgets.QWidgetAction(self)
+        action.setDefaultWidget(widget)
+        self.addAction(action)
+        return action
+
+    def close_menu(self):
+        self.hide()
+
+    def _on_filter_checkboxes_state_changed(self, *args):
+        """Emit all checks as a tuple."""
+        self.check_state_changed.emit(
+            (
+                self._my_tasks_checkbox.isChecked(),
+                self._linked_breakdown_checkbox.isChecked(),
+                self._linked_template_checkbox.isChecked(),
+            )
+        )
+
+    def checkboxes_state(self):
+        return (
+                self._my_tasks_checkbox.isChecked(),
+                self._linked_breakdown_checkbox.isChecked(),
+                self._linked_template_checkbox.isChecked(),
+            )
+
+
 class LoaderWindow(QtWidgets.QWidget):
     def __init__(self, controller=None, parent=None):
         super().__init__(parent)
@@ -183,7 +297,17 @@ class LoaderWindow(QtWidgets.QWidget):
         context_top_layout.addWidget(go_to_current_btn, 0)
         context_top_layout.addWidget(refresh_btn, 0)
 
-        filters_widget = FoldersFiltersWidget(context_widget)
+        filters_widget = FoldersFiltersWidgetBase(context_widget)
+        filters_menu_button = QtWidgets.QPushButton(
+            "Filters...", parent=context_widget
+        )
+        filters_menu = LoaderFiltersMenu(parent=self)
+        filters_menu_button.setMenu(filters_menu)
+
+        self._filters_menu_button = filters_menu_button
+        self._filters_menu = filters_menu
+
+        filters_widget.layout().addWidget(filters_menu_button, 0)
 
         folders_widget = LoaderFoldersWidget(controller, context_widget)
 
@@ -262,9 +386,10 @@ class LoaderWindow(QtWidgets.QWidget):
         filters_widget.text_changed.connect(
             self._on_folder_filter_change
         )
-        filters_widget.my_tasks_changed.connect(
-            self._on_my_tasks_checkbox_state_changed
+        filters_menu.check_state_changed.connect(
+            self._on_filter_checkboxes_state_changed
         )
+
         search_bar.filter_changed.connect(self._on_filter_change)
         product_group_checkbox.stateChanged.connect(
             self._on_product_group_change
@@ -465,15 +590,84 @@ class LoaderWindow(QtWidgets.QWidget):
     def _on_folder_filter_change(self, text: str) -> None:
         self._folders_widget.set_name_filter(text)
 
-    def _on_my_tasks_checkbox_state_changed(self, enabled: bool) -> None:
+    def _get_path_context(self):
+        if self._controller._host and isinstance(
+            self._controller._host, AbstractHost
+        ):
+            folderpath = self._controller._host.get_current_folder_path()
+            if folderpath:
+                return folderpath
+
+        return os.environ.get("AYON_FOLDER_PATH")
+
+    def _get_context_linked_folder_ids(
+            self, use_breakdown: bool, use_template: bool
+        ):
+        project_name = self._selected_project_name
+        folder_path = self._get_path_context()
+
+        folder_entity = get_folder_by_path(project_name, folder_path)
+        folder_id = folder_entity.get("id")
+
+        if not folder_id:
+            return []
+
+        link_types = []
+
+        if use_breakdown:
+            link_types.append("breakdown")
+        if use_template:
+            link_types.append("template")
+
+        if not link_types:
+            return None
+
+        # Fetch breakdown in / template in
+        links = get_folder_links(
+            project_name,
+            folder_id,
+            link_types=link_types,
+            link_direction="in",
+        )
+
+        # Set comprehension to remove overlap
+        linked_folder_ids = {
+            link["entityId"]
+            for link in links
+            if link["entityType"] == "folder"
+        }
+
+        return list(linked_folder_ids)
+
+    def _on_filter_checkboxes_state_changed(self, states: tuple) -> None:
         folder_ids = None
         task_ids = None
-        if enabled:
+
+        task_enabled, breakdown_enabled, template_enabled = states
+
+        if any((breakdown_enabled, template_enabled)):
+            folder_ids = self._get_context_linked_folder_ids(
+                breakdown_enabled,
+                template_enabled
+            )
+
+        if task_enabled:
             entity_ids = self._controller.get_my_tasks_entity_ids(
                 self._selected_project_name
             )
-            folder_ids = entity_ids["folder_ids"]
+
+            if folder_ids is None:
+                folder_ids = entity_ids["folder_ids"]
+            else:
+                # Filter by previously found folders.
+                folder_ids = [
+                    folder_id for folder_id in
+                    entity_ids["folder_ids"]
+                    if folder_id in folder_ids
+                ]
+
             task_ids = entity_ids["task_ids"]
+
         self._folders_widget.set_folder_ids_filter(folder_ids)
         self._tasks_widget.set_task_ids_filter(task_ids)
 
@@ -539,8 +733,8 @@ class LoaderWindow(QtWidgets.QWidget):
             self._projects_combobox.refresh()
         self._update_filters()
         # Update my tasks
-        self._on_my_tasks_checkbox_state_changed(
-            self._filters_widget.is_my_tasks_checked()
+        self._on_filter_checkboxes_state_changed(
+            self._filters_menu.checkboxes_state()
         )
 
     def _on_load_finished(self, event):

--- a/client/ayon_core/tools/utils/folders_widget.py
+++ b/client/ayon_core/tools/utils/folders_widget.py
@@ -804,16 +804,37 @@ class SimpleFoldersWidget(FoldersWidget):
         pass
 
 
-class FoldersFiltersWidget(QtWidgets.QWidget):
-    """Helper widget for most commonly used filters in context selection."""
+class FoldersFiltersWidgetBase(QtWidgets.QWidget):
+    """Helper widget for text based filtering in context selection."""
+
     text_changed = QtCore.Signal(str)
-    my_tasks_changed = QtCore.Signal(bool)
 
     def __init__(self, parent: QtWidgets.QWidget) -> None:
         super().__init__(parent)
 
         folders_filter_input = PlaceholderLineEdit(self)
         folders_filter_input.setPlaceholderText("Folder name filter...")
+
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(5)
+        layout.addWidget(folders_filter_input, 1)
+
+        folders_filter_input.textChanged.connect(self.text_changed)
+
+    def text(self) -> str:
+        return self._folders_filter_input.text()
+
+    def set_text(self, text: str) -> None:
+        self._folders_filter_input.setText(text)
+
+
+class FoldersFiltersWidget(FoldersFiltersWidgetBase):
+    """Helper widget for most commonly used filters in context selection."""
+    my_tasks_changed = QtCore.Signal(bool)
+
+    def __init__(self, parent: QtWidgets.QWidget) -> None:
+        super().__init__(parent)
 
         my_tasks_tooltip = (
             "Filter folders and task to only those you are assigned to."
@@ -825,27 +846,16 @@ class FoldersFiltersWidget(QtWidgets.QWidget):
         my_tasks_checkbox.setChecked(False)
         my_tasks_checkbox.setToolTip(my_tasks_tooltip)
 
-        layout = QtWidgets.QHBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(5)
-        layout.addWidget(folders_filter_input, 1)
+        layout = self.layout()
+
         layout.addWidget(my_tasks_label, 0)
         layout.addWidget(my_tasks_checkbox, 0)
 
-        folders_filter_input.textChanged.connect(self.text_changed)
         my_tasks_checkbox.stateChanged.connect(self._on_my_tasks_change)
-
-        self._folders_filter_input = folders_filter_input
         self._my_tasks_checkbox = my_tasks_checkbox
 
     def is_my_tasks_checked(self) -> bool:
         return self._my_tasks_checkbox.isChecked()
-
-    def text(self) -> str:
-        return self._folders_filter_input.text()
-
-    def set_text(self, text: str) -> None:
-        self._folders_filter_input.setText(text)
 
     def set_my_tasks_checked(self, checked: bool) -> None:
         self._my_tasks_checkbox.setChecked(checked)


### PR DESCRIPTION
This pull request aims to build on the recently added "linked breakdown / template folders" feature on the ayon backend.
There's currently no way to access these from the loader, when this feature would naturally lend itself well to composing
libraries of assets for artists to work with. 

Let's say I'm working on a project that has some asset folders belonging to a certain environment / biome. 
If I want to load them, I would need to keep in mind the environment I am currently working on, in order to not fetch the
foliage assets that belong to grasslands when I am working on a scene set in a forest.
One could argue that consistent naming and text search would do the trick, but I would argue that linking the right asset folders
on the backend could save a lot of headaches, and it provides a nice composable setup (you can link multiple folders).

This PR replaces the "My tasks" toggle within the loader ui, with a "Filters..." button linked to a QMenu specialized for holding all the relevant toggles. These toggles work together!

The logic is as follows: 
- 'My tasks' filters out everything that isn't assigned to the current user
- 'Linked breakdown' / 'Linked template' uses the current folder context to fetch all linked folders
- If 'My tasks' already gave a result, 'Linked breakdown' / 'Linked template' will act as a filter upon that, think "linked breakdown folders assigned to me"

In the following example, my current context is "toonboom/sh0020" which is linked to "toonboom/sh0010" for testing.

<img width="1108" height="814" alt="core_filters_menu" src="https://github.com/user-attachments/assets/9d8fa232-6130-4e57-bf6c-8faba8767225" />

Toggling "linked breakdown" filters out the folders that aren't linked to the current context, so in this case, it will only show
"toonboom/sh0010" 

<img width="999" height="810" alt="core_filters_menu_toggled" src="https://github.com/user-attachments/assets/458bf356-e1c5-4c5c-8807-d393b2328225" />


## Changelog Description
- LoaderNiceCheckbox has been added as a specialization of a QMenu compatible, widget wrapped NiceCheckbox.
- LoaderFiltersMenu has been added to keep one reference to the menu and it's contents alive as well as manage signals.
- `tools.utils.folders_widget :: FoldersFiltersWidget` has gotten a baseclass, `FolderFiltersWidgetBase` to encompass just the text search. (This was to prevent awful popping / pushing of widgets to the layout.
- Existing `FoldersFiltersWidget` has been left intact so all other UI using it is not affected.

## Testing notes:
1. Build the plugin
2. Make sure that on launch, the workfile you launch into is in a folder that has at least 1 linked "In" breakdown/template folder associated with it on the site.
3. Use the "Load" menu from your favorite Ayon integration.

Thanks for your consideration,

Sas @ Studio Submarine