### PR TITLE
CLI: Add browser command

### DIFF
--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -208,7 +208,6 @@ def browser():
     app.exec_()
 
 
-
 @main_cli.command()
 @click.option("--build", help="Print only build version",
               is_flag=True, default=False)

--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -198,8 +198,8 @@ def interactive():
 @main_cli.command()
 def browser():
     """Show Browser tool."""
-    from ayon_core.tools.utils import get_ayon_qt_app
     from ayon_core.tools.loader.ui import LoaderWindow
+    from ayon_core.tools.utils import get_ayon_qt_app
 
     app = get_ayon_qt_app()
     browser_window = LoaderWindow()

--- a/client/ayon_core/cli.py
+++ b/client/ayon_core/cli.py
@@ -196,6 +196,20 @@ def interactive():
 
 
 @main_cli.command()
+def browser():
+    """Show Browser tool."""
+    from ayon_core.tools.utils import get_ayon_qt_app
+    from ayon_core.tools.loader.ui import LoaderWindow
+
+    app = get_ayon_qt_app()
+    browser_window = LoaderWindow()
+    browser_window.setWindowTitle("AYON Browser")
+    browser_window.show()
+    app.exec_()
+
+
+
+@main_cli.command()
 @click.option("--build", help="Print only build version",
               is_flag=True, default=False)
 def version(build):


### PR DESCRIPTION
## Changelog Description
Add `browser` command to cli.

## Additional info
I don't think this has a production use-case it is more likely for development purposes. Does not hurt to have it there.

## Testing notes:
1. Run `ayon.exe browser` in terminal.
2. Browser tool should show up.