### PR TITLE
Publisher: Better default UI state

### DIFF
--- a/client/ayon_core/tools/publisher/widgets/product_info.py
+++ b/client/ayon_core/tools/publisher/widgets/product_info.py
@@ -53,6 +53,8 @@ class ProductInfoWidget(QtWidgets.QWidget):
 
         # Convert button widget (with layout to handle stretch)
         convert_widget = QtWidgets.QWidget(creator_widget)
+        convert_widget.setVisible(False)
+
         convert_label = QtWidgets.QLabel(creator_widget)
         # Set the label text with 'setText' to apply html
         convert_label.setText(

--- a/client/ayon_core/tools/publisher/widgets/publish_frame.py
+++ b/client/ayon_core/tools/publisher/widgets/publish_frame.py
@@ -116,6 +116,10 @@ class PublishFrame(QtWidgets.QWidget):
         validate_btn = ValidateBtn(footer_widget)
         publish_btn = PublishBtn(footer_widget)
 
+        stop_btn.setEnabled(False)
+        validate_btn.setEnabled(False)
+        publish_btn.setEnabled(False)
+
         report_btn.add_action("Go to details", "go_to_report")
         report_btn.add_action("Copy report", "copy_report")
         report_btn.add_action("Export report", "export_report")

--- a/client/ayon_core/tools/publisher/window.py
+++ b/client/ayon_core/tools/publisher/window.py
@@ -144,6 +144,11 @@ class PublisherWindow(QtWidgets.QDialog):
         validate_btn = ValidateBtn(footer_widget)
         publish_btn = PublishBtn(footer_widget)
 
+        save_btn.setEnabled(False)
+        stop_btn.setEnabled(False)
+        validate_btn.setEnabled(False)
+        publish_btn.setEnabled(False)
+
         footer_bottom_layout = QtWidgets.QHBoxLayout(footer_bottom_widget)
         footer_bottom_layout.setContentsMargins(0, 0, 0, 0)
         footer_bottom_layout.addStretch(1)


### PR DESCRIPTION
## Changelog Description
Hide conversions label and disable buttons on initialization.

## Additional info
In case Publisher's reset fails the window is in unfinished init state and the states of these widgets are not set to expected default. By explicitly setting them we do avoid such issue. There is also issue with reports widget that sohuld be fixed with https://github.com/ynput/ayon-core/pull/1949 .

## Testing notes:
1. Open any host.
2. Shutdown server.
3. Open Publisher in the host.
4. It should not show that there are items to convert and have enabled publish/validate buttons.
