### PR TITLE
added Flame to OCIOEnvHook hosts set

### DIFF
--- a/client/ayon_core/hooks/pre_ocio_hook.py
+++ b/client/ayon_core/hooks/pre_ocio_hook.py
@@ -19,6 +19,7 @@ class OCIOEnvHook(PreLaunchHook):
         "maya",
         "nuke",
         "hiero",
+        "flame",
         "photoshop",
         "resolve",
         "openrv",


### PR DESCRIPTION
Adds `flame` to the hosts handled by the core OCIO prelaunch hook, so launching flame now gets the resolved OCIO config path in the `OCIO` environment variable, like the other colour managed hosts.

[Flame 2026 dropped colour policies in favour of OCIO configs](https://help.autodesk.com/view/FLAME/2026/ENU/?guid=wn-2026-ocio), and the flame addon needs the config path at project creation time.

[_This PR is paired with this ayon-flame one_](https://github.com/ynput/ayon-flame/pull/145)