### PR TITLE
Loader: Use selected rows for representations

### DIFF
--- a/client/ayon_core/tools/loader/ui/repres_widget.py
+++ b/client/ayon_core/tools/loader/ui/repres_widget.py
@@ -367,14 +367,11 @@ class RepresentationsWidget(QtWidgets.QWidget):
         selection_model = self._repre_view.selectionModel()
         model = self._repre_view.model()
         indexes_queue = collections.deque()
-        indexes_queue.extend(selection_model.selectedIndexes())
+        indexes_queue.extend(selection_model.selectedRows())
 
         selected_indexes = []
         while indexes_queue:
             index = indexes_queue.popleft()
-            if index.column() != 0:
-                continue
-
             group_type = model.data(index, GROUP_TYPE_ROLE)
             if group_type is None:
                 selected_indexes.append(index)


### PR DESCRIPTION
## Changelog Description
Use `selectedRows` instead of `selectedIndexes` to get selections.

## Additional info
Selected indexes does return all indexes from different columns (one row can return multiple indexes), using `selectedRows` is used the same but only one index per row.

## Testing notes:
1. Actions on representations do work no matter which column is used for selection.
