### PR TITLE
Workfiles tool: Folders refersh fix for 3dsMax 2027

### DIFF
--- a/client/ayon_core/tools/utils/folders_widget.py
+++ b/client/ayon_core/tools/utils/folders_widget.py
@@ -214,10 +214,10 @@ class FoldersQtModel(QtGui.QStandardItemModel):
         self._refresh_tasks[refresh_task.id] = refresh_task
         refresh_task.finished.connect(self._on_refresh_task)
         self._refresh_threadpool.start(refresh_task)
-        # NOTE: The time.sleep was added to fix workfiles tool refresh in
-        #   3ds Max. It looks like there must be one more line running a code
-        #   after the start of the thread task. The thread would not
-        #   be started but will trigger 'finished' signal.
+        # NOTE: The `msleep` was added to fix workfiles tool refresh in
+        #   3ds Max 2027. It looks like there must be one more line running 
+        #   code after the start of the thread task. Otherwise, the thread
+        #   would not be started but will trigger 'finished' signal directly.
         QtCore.QThread.msleep(5)
 
     @classmethod

--- a/client/ayon_core/tools/utils/folders_widget.py
+++ b/client/ayon_core/tools/utils/folders_widget.py
@@ -212,6 +212,15 @@ class FoldersQtModel(QtGui.QStandardItemModel):
         self._refresh_tasks[refresh_task.id] = refresh_task
         refresh_task.finished.connect(self._on_refresh_task)
         self._refresh_threadpool.start(refresh_task)
+        # NOTE The tryStart and print are in fact NOT NEEDED, it was added to
+        #   fix workfiles tool refresh in 3ds Max. It looks like there must be
+        #   one more line after the start of the thread task. The thread won't
+        #   be started but will trigger 'finished' signal.
+        # Adding the print won't hurt... I guess
+        if not self._refresh_threadpool.tryStart(refresh_task):
+            print(
+                f"Failed to start refresh thread for project: {project_name}"
+            )
 
     @classmethod
     def _get_default_folder_icon(cls):

--- a/client/ayon_core/tools/utils/folders_widget.py
+++ b/client/ayon_core/tools/utils/folders_widget.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 import collections
-from typing import Optional
+from functools import partial
+from typing import Callable, Any, Optional
+import sys
+import traceback
 
 from qtpy import QtWidgets, QtGui, QtCore
 
@@ -18,7 +21,7 @@ from ayon_core.tools.common_models import (
 
 from .models import RecursiveSortFilterProxyModel
 from .views import TreeView
-from .lib import RefreshThread, get_qt_icon
+from .lib import get_qt_icon
 from .widgets import PlaceholderLineEdit
 from .nice_checkbox import NiceCheckbox
 
@@ -28,6 +31,56 @@ FOLDER_ID_ROLE = QtCore.Qt.UserRole + 1
 FOLDER_NAME_ROLE = QtCore.Qt.UserRole + 2
 FOLDER_PATH_ROLE = QtCore.Qt.UserRole + 3
 FOLDER_TYPE_ROLE = QtCore.Qt.UserRole + 4
+
+
+class RefreshTask(QtCore.QObject, QtCore.QRunnable):
+    finished = QtCore.Signal(str, bool)
+
+    def __init__(
+        self,
+        refresh_task_id: str,
+        default_output: Any,
+        func: Callable,
+        *args,
+        **kwargs,
+    ):
+        QtCore.QObject.__init__(self)
+        QtCore.QRunnable.__init__(self)
+
+        self.id = refresh_task_id
+        self.started = False
+        self._callback = partial(func, *args, **kwargs)
+        self._exception = None
+        self._traceback = None
+        self._result = default_output
+
+    def is_failed(self) -> bool:
+        return self._exception is not None
+
+    def get_result(self):
+        return self._result
+
+    def print_traceback(self):
+        if self._traceback:
+            print(self._traceback)
+
+    def run(self) -> None:
+        self.started = True
+        success = False
+        try:
+            self._result = self._callback()
+
+            success = True
+        except Exception as exc:
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            err_traceback = "".join(traceback.format_exception(
+                exc_type, exc_value, exc_traceback
+            ))
+            self._traceback = err_traceback
+            self._exception = exc
+
+        finally:
+            self.finished.emit(self.id, success)
 
 
 class FoldersQtModel(QtGui.QStandardItemModel):
@@ -43,6 +96,9 @@ class FoldersQtModel(QtGui.QStandardItemModel):
     def __init__(self, controller):
         super().__init__()
 
+        refresh_threadpool = QtCore.QThreadPool()
+        refresh_threadpool.setMaxThreadCount(2)
+
         self.setColumnCount(1)
         self.setHeaderData(0, QtCore.Qt.Horizontal, "Folders")
 
@@ -50,8 +106,9 @@ class FoldersQtModel(QtGui.QStandardItemModel):
         self._items_by_id = {}
         self._parent_id_by_id = {}
 
-        self._refresh_threads = {}
-        self._current_refresh_thread = None
+        self._refresh_threadpool = refresh_threadpool
+        self._refresh_tasks = {}
+        self._current_refresh_task = None
         self._last_project_name = None
 
         self._has_content = False
@@ -130,8 +187,8 @@ class FoldersQtModel(QtGui.QStandardItemModel):
 
         if not project_name:
             self._last_project_name = project_name
-            self._fill_items({}, {})
-            self._current_refresh_thread = None
+            self._fill_items({}, [])
+            self._current_refresh_task = None
             return
 
         self._is_refreshing = True
@@ -140,20 +197,21 @@ class FoldersQtModel(QtGui.QStandardItemModel):
             self._clear_items()
         self._last_project_name = project_name
 
-        thread = self._refresh_threads.get(project_name)
-        if thread is not None:
-            self._current_refresh_thread = thread
+        refresh_task = self._refresh_tasks.get(project_name)
+        if refresh_task is not None:
+            self._current_refresh_task = refresh_task
             return
 
-        thread = RefreshThread(
+        refresh_task = RefreshTask(
             project_name,
+            ({}, []),
             self._thread_getter,
-            project_name
+            project_name,
         )
-        self._current_refresh_thread = thread
-        self._refresh_threads[thread.id] = thread
-        thread.refresh_finished.connect(self._on_refresh_thread)
-        thread.start()
+        self._current_refresh_task = refresh_task
+        self._refresh_tasks[refresh_task.id] = refresh_task
+        refresh_task.finished.connect(self._on_refresh_task)
+        self._refresh_threadpool.start(refresh_task)
 
     @classmethod
     def _get_default_folder_icon(cls):
@@ -184,7 +242,7 @@ class FoldersQtModel(QtGui.QStandardItemModel):
             )
         return folder_items, folder_type_items
 
-    def _on_refresh_thread(self, thread_id):
+    def _on_refresh_task(self, refresh_task_id: str, success: bool):
         """Callback when refresh thread is finished.
 
         Technically can be running multiple refresh threads at the same time,
@@ -194,23 +252,27 @@ class FoldersQtModel(QtGui.QStandardItemModel):
         Folders are stored by id.
 
         Args:
-            thread_id (str): Thread id.
-        """
+            refresh_task_id (str): Thread id.
+            success (bool): True if refresh was successful.
 
+        """
         # Make sure to remove thread from '_refresh_threads' dict
-        thread = self._refresh_threads.pop(thread_id)
+        refresh_task = self._refresh_tasks.pop(refresh_task_id)
+        refresh_task.print_traceback()
         if (
-            self._current_refresh_thread is None
-            or thread_id != self._current_refresh_thread.id
+            self._current_refresh_task is None
+            or refresh_task_id != self._current_refresh_task.id
         ):
             return
-        if thread.failed:
-            # TODO visualize that refresh failed
-            folder_items, folder_type_items = {}, []
-        else:
-            folder_items, folder_type_items = thread.get_result()
+
+        # TODO visualize that refresh failed
+        # if not success:
+        #     pass
+
+        folder_items, folder_type_items = refresh_task.get_result()
+
         self._fill_items(folder_items, folder_type_items)
-        self._current_refresh_thread = None
+        self._current_refresh_task = None
 
     def _get_folder_item_icon(
         self,

--- a/client/ayon_core/tools/utils/folders_widget.py
+++ b/client/ayon_core/tools/utils/folders_widget.py
@@ -4,7 +4,6 @@ import collections
 from functools import partial
 import sys
 from typing import Callable, Any, Optional
-import time
 import traceback
 
 from qtpy import QtWidgets, QtGui, QtCore
@@ -219,7 +218,7 @@ class FoldersQtModel(QtGui.QStandardItemModel):
         #   3ds Max. It looks like there must be one more line running a code
         #   after the start of the thread task. The thread would not
         #   be started but will trigger 'finished' signal.
-        time.sleep(0.01)
+        QtCore.QThread.msleep(1)
 
     @classmethod
     def _get_default_folder_icon(cls):

--- a/client/ayon_core/tools/utils/folders_widget.py
+++ b/client/ayon_core/tools/utils/folders_widget.py
@@ -211,7 +211,6 @@ class FoldersQtModel(QtGui.QStandardItemModel):
         self._current_refresh_task = refresh_task
         self._refresh_tasks[refresh_task.id] = refresh_task
         refresh_task.finished.connect(self._on_refresh_task)
-        self._refresh_threadpool.start(refresh_task)
         # NOTE The tryStart and print are in fact NOT NEEDED, it was added to
         #   fix workfiles tool refresh in 3ds Max. It looks like there must be
         #   one more line after the start of the thread task. The thread won't

--- a/client/ayon_core/tools/utils/folders_widget.py
+++ b/client/ayon_core/tools/utils/folders_widget.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
+
 import collections
 from functools import partial
-from typing import Callable, Any, Optional
 import sys
+from typing import Callable, Any, Optional
+import time
 import traceback
 
 from qtpy import QtWidgets, QtGui, QtCore
@@ -208,18 +210,16 @@ class FoldersQtModel(QtGui.QStandardItemModel):
             self._thread_getter,
             project_name,
         )
+
         self._current_refresh_task = refresh_task
         self._refresh_tasks[refresh_task.id] = refresh_task
         refresh_task.finished.connect(self._on_refresh_task)
-        # NOTE The tryStart and print are in fact NOT NEEDED, it was added to
-        #   fix workfiles tool refresh in 3ds Max. It looks like there must be
-        #   one more line after the start of the thread task. The thread won't
+        self._refresh_threadpool.start(refresh_task)
+        # NOTE: The time.sleep was added to fix workfiles tool refresh in
+        #   3ds Max. It looks like there must be one more line running a code
+        #   after the start of the thread task. The thread would not
         #   be started but will trigger 'finished' signal.
-        # Adding the print won't hurt... I guess
-        if not self._refresh_threadpool.tryStart(refresh_task):
-            print(
-                f"Failed to start refresh thread for project: {project_name}"
-            )
+        time.sleep(0.01)
 
     @classmethod
     def _get_default_folder_icon(cls):

--- a/client/ayon_core/tools/utils/folders_widget.py
+++ b/client/ayon_core/tools/utils/folders_widget.py
@@ -215,7 +215,7 @@ class FoldersQtModel(QtGui.QStandardItemModel):
         refresh_task.finished.connect(self._on_refresh_task)
         self._refresh_threadpool.start(refresh_task)
         # NOTE: The `msleep` was added to fix workfiles tool refresh in
-        #   3ds Max 2027. It looks like there must be one more line running 
+        #   3ds Max 2027. It looks like there must be one more line running
         #   code after the start of the thread task. Otherwise, the thread
         #   would not be started but will trigger 'finished' signal directly.
         QtCore.QThread.msleep(5)

--- a/client/ayon_core/tools/utils/folders_widget.py
+++ b/client/ayon_core/tools/utils/folders_widget.py
@@ -218,7 +218,7 @@ class FoldersQtModel(QtGui.QStandardItemModel):
         #   3ds Max. It looks like there must be one more line running a code
         #   after the start of the thread task. The thread would not
         #   be started but will trigger 'finished' signal.
-        QtCore.QThread.msleep(1)
+        QtCore.QThread.msleep(5)
 
     @classmethod
     def _get_default_folder_icon(cls):


### PR DESCRIPTION
## Changelog Description
Fix refresh of folders in workfiles widget for 3dsMax 2027.

## Additional info
It looks like the 3ds Max runtime execution fails to start thread properly, BUT if a line of code is added, it looks like the issue is fixed, for whatever reason.

I tried multiple fixes and ended up using threadpool with workers. The advantage of using threadpool is that it has `tryStart` which can be actually used in this usecase. Added a comment why the tryStart and print is used.

## Testing notes:
1. Workfiles tool does refresh folders correctly in 3ds Max AND also in other DCCs.

Resolves https://github.com/ynput/ayon-3dsmax/issues/158