### PR TITLE
Fix: Don't process hero version without trait representations.

### DIFF
--- a/client/ayon_core/plugins/publish/integrate_hero_version_with_traits.py
+++ b/client/ayon_core/plugins/publish/integrate_hero_version_with_traits.py
@@ -113,6 +113,22 @@ class IntegrateHeroVersionTraits(
                 "traits. Skipping")
             return
 
+        # don't allow both representations
+        # with traits and standard representations
+        if (
+                has_trait_representations(instance)
+                and instance.data.get("representations")
+        ):
+            msg = (
+                f"Instance '{instance.name}' has representations with traits "
+                "but also has standard representations. This is not allowed. "
+                "Please use either representations with traits or "
+                "standard representations, not both."
+            )
+            raise PublishError(
+                msg
+            )
+
         anatomy: Anatomy = instance.context.data["anatomy"]
         project_name = anatomy.project_name
 

--- a/client/ayon_core/plugins/publish/integrate_hero_version_with_traits.py
+++ b/client/ayon_core/plugins/publish/integrate_hero_version_with_traits.py
@@ -115,10 +115,7 @@ class IntegrateHeroVersionTraits(
 
         # don't allow both representations
         # with traits and standard representations
-        if (
-                has_trait_representations(instance)
-                and instance.data.get("representations")
-        ):
+        if instance.data.get("representations"):
             msg = (
                 f"Instance '{instance.name}' has representations with traits "
                 "but also has standard representations. This is not allowed. "

--- a/client/ayon_core/plugins/publish/integrate_hero_version_with_traits.py
+++ b/client/ayon_core/plugins/publish/integrate_hero_version_with_traits.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Optional
 
 from ayon_core.pipeline.publish import (
     get_publish_template_name,
+    has_trait_representations,
     OptionalPyblishPluginMixin,
     PublishError,
 )
@@ -104,6 +105,12 @@ class IntegrateHeroVersionTraits(
 
         """
         if not self.is_active(instance.data):
+            return
+
+        if not has_trait_representations(instance):
+            self.log.debug(
+                f"Instance '{instance.name}' has no representations with "
+                "traits. Skipping")
             return
 
         anatomy: Anatomy = instance.context.data["anatomy"]


### PR DESCRIPTION
## Changelog Description
Fix cases where *Integrate Hero Versions with traits* was triggered every time, messing with regular hero version integration.

## Testing notes:
Publishing of regular hero version should work.
