### PR TITLE
Chore: Don't use strict zip in collect addons

### DIFF
--- a/client/ayon_core/addon/base.py
+++ b/client/ayon_core/addon/base.py
@@ -1097,7 +1097,7 @@ class AddonsManager:
         ]
 
         # Convert columns to rows for print
-        rows = list(zip(*cols, strict=True))
+        rows = list(zip(*cols))
         # Top row contains labels
         top_row = rows.pop(0)
         # Last row contains totals


### PR DESCRIPTION
## Changelog Description
Don't use strict in zip function.

## Additional info
The `strict` kwarg is available since python 3.10.

## Testing notes:
1. The plugin works in DCCs with older python versions.
