### PR TITLE
Use pathlib to create tempdir

### DIFF
--- a/client/ayon_core/pipeline/tempdir.py
+++ b/client/ayon_core/pipeline/tempdir.py
@@ -68,7 +68,7 @@ def _create_local_staging_dir(prefix, suffix, dirpath=None):
     """
     # use pathlib for creating tempdir
     if dirpath is None:
-        dirpath = tempfile.gettempdir()
+        return tempfile.mkdtemp(prefix=prefix, suffix=suffix)
 
     # Use 'pathlib.Path.mkdir' to inherit permissions
     dirpath_p = Path(dirpath)

--- a/client/ayon_core/pipeline/tempdir.py
+++ b/client/ayon_core/pipeline/tempdir.py
@@ -70,11 +70,14 @@ def _create_local_staging_dir(prefix, suffix, dirpath=None):
     if dirpath is None:
         dirpath = tempfile.gettempdir()
 
-    unique_id = uuid.uuid4().hex[:8]
-    folder_name = f"{prefix}{unique_id}{suffix}"
-
     # Use 'pathlib.Path.mkdir' to inherit permissions
-    tmpdir = Path(dirpath) / folder_name
+    dirpath_p = Path(dirpath)
+    while True:
+        unique_id = uuid.uuid4().hex[:8]
+        folder_name = f"{prefix}{unique_id}{suffix}"
+        tmpdir = dirpath_p / folder_name
+        if not tmpdir.is_dir():
+            break
     tmpdir.mkdir(parents=True, exist_ok=False)
 
     return str(tmpdir)

--- a/client/ayon_core/pipeline/tempdir.py
+++ b/client/ayon_core/pipeline/tempdir.py
@@ -5,8 +5,8 @@ Temporary folder operations
 import os
 import tempfile
 from pathlib import Path
-import warnings
 import uuid
+import warnings
 
 from ayon_core.lib import StringTemplate
 from ayon_core.pipeline import Anatomy

--- a/client/ayon_core/pipeline/tempdir.py
+++ b/client/ayon_core/pipeline/tempdir.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 from pathlib import Path
 import warnings
+import uuid
 
 from ayon_core.lib import StringTemplate
 from ayon_core.pipeline import Anatomy
@@ -66,9 +67,16 @@ def _create_local_staging_dir(prefix, suffix, dirpath=None):
         str: path to tempdir
     """
     # use pathlib for creating tempdir
-    return tempfile.mkdtemp(
-        prefix=prefix, suffix=suffix, dir=dirpath
-    )
+    if dirpath is None:
+        dirpath = tempfile.gettempdir()
+
+    base_dir = Path(dirpath)
+    unique_id = str(uuid.uuid4().hex[:8])
+    folder_name = f"{prefix or ''}{unique_id}{suffix or ''}"
+    tmpdir = base_dir / folder_name
+    tmpdir.mkdir(parents=True, exist_ok=False)
+
+    return str(tmpdir)
 
 
 def create_custom_tempdir(project_name, anatomy=None):

--- a/client/ayon_core/pipeline/tempdir.py
+++ b/client/ayon_core/pipeline/tempdir.py
@@ -70,10 +70,11 @@ def _create_local_staging_dir(prefix, suffix, dirpath=None):
     if dirpath is None:
         dirpath = tempfile.gettempdir()
 
-    base_dir = Path(dirpath)
-    unique_id = str(uuid.uuid4().hex[:8])
-    folder_name = f"{prefix or ''}{unique_id}{suffix or ''}"
-    tmpdir = base_dir / folder_name
+    unique_id = uuid.uuid4().hex[:8]
+    folder_name = f"{prefix}{unique_id}{suffix}"
+
+    # Use 'pathlib.Path.mkdir' to inherit permissions
+    tmpdir = Path(dirpath) / folder_name
     tmpdir.mkdir(parents=True, exist_ok=False)
 
     return str(tmpdir)


### PR DESCRIPTION
## Changelog Description
Updated the _create_local_staging_dir function to use pathlib.

This is because if the temp directory is on a different os server, for example if the function is ran on a windows computer to create a temp file on a linux server, the permissions isn't inherited correctly from the parent folder which causes the writing of the file to the temp directory to error.

## Testing notes:
1. start with this step
Create a review from 3dsmax with a temp directory set on another os server with the environment variable AYON_TMPDIR.
2. follow this step
Check if it works
