### PR TITLE
Handle missing colorspace from display and view

### DIFF
--- a/client/ayon_core/plugins/publish/integrate.py
+++ b/client/ayon_core/plugins/publish/integrate.py
@@ -623,7 +623,13 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
 
         # add template data for colorspaceData
         if repre.get("colorspaceData"):
-            colorspace = repre["colorspaceData"]["colorspace"]
+            colorspace = repre["colorspaceData"].get("colorspace")
+            display = repre["colorspaceData"].get("display")
+            view = repre["colorspaceData"].get("view")
+            if not colorspace and (display and view):
+                colorspace = f"{display}_{view}"
+            elif not colorspace and not display and view:
+                colorspace = view
             # replace spaces with underscores
             # pipeline.colorspace.parse_colorspace_from_filepath
             # is checking it with underscores too


### PR DESCRIPTION
## Summary
Derive the colorspace template value from `display` and `view` when `colorspace` is unavailable, with a `view`-only fallback.

## Testing
ideally test with https://github.com/ynput/ayon-nuke/pull/347