### PR TITLE
Explore here action fix Windows behavior when path has spaces.

### DIFF
--- a/client/ayon_core/plugins/actions/open_file_explorer.py
+++ b/client/ayon_core/plugins/actions/open_file_explorer.py
@@ -97,7 +97,8 @@ class OpenTaskPath(LauncherAction):
     def open_in_explorer(path):
         platform_name = platform.system().lower()
         if platform_name == "windows":
-            args = ["start", "", path]
+            os.startfile(path)
+            return
         elif platform_name == "darwin":
             args = ["open", "-R", path]
         elif platform_name == "linux":

--- a/client/ayon_core/plugins/actions/open_file_explorer.py
+++ b/client/ayon_core/plugins/actions/open_file_explorer.py
@@ -97,7 +97,7 @@ class OpenTaskPath(LauncherAction):
     def open_in_explorer(path):
         platform_name = platform.system().lower()
         if platform_name == "windows":
-            args = ["start", path]
+            args = ["start", "", path]
         elif platform_name == "darwin":
             args = ["open", "-R", path]
         elif platform_name == "linux":


### PR DESCRIPTION
## Changelog Description

Explore here action fix Windows behavior when path has spaces.

## Additional info

The `start` command allows to pass the window title and then the app to launch. When a path with spaces was passed then Windows started to think the value was supposed to be the title because it was quoted instead of the executable. By forcefully passing the initial quotes Windows never makes the wrong assumption.

Reported here: https://community.ynput.io/t/explore-here-not-working-with-custom-path/3247

## Testing notes:

1. Explore here should work on path with spaces