### PR TITLE
Move scene version collector earlier

### DIFF
--- a/client/ayon_core/plugins/publish/collect_scene_version.py
+++ b/client/ayon_core/plugins/publish/collect_scene_version.py
@@ -11,7 +11,7 @@ class CollectSceneVersion(pyblish.api.ContextPlugin):
         version (int, optional): version number of the publish
     """
 
-    order = pyblish.api.CollectorOrder - 0.45
+    order = pyblish.api.CollectorOrder - 0.5
     label = "Collect Scene Version"
     # configurable in Settings
     hosts = ["*"]

--- a/client/ayon_core/plugins/publish/collect_scene_version.py
+++ b/client/ayon_core/plugins/publish/collect_scene_version.py
@@ -11,7 +11,7 @@ class CollectSceneVersion(pyblish.api.ContextPlugin):
         version (int, optional): version number of the publish
     """
 
-    order = pyblish.api.CollectorOrder - 0.5
+    order = pyblish.api.CollectorOrder - 0.39
     label = "Collect Scene Version"
     # configurable in Settings
     hosts = ["*"]

--- a/client/ayon_core/plugins/publish/collect_scene_version.py
+++ b/client/ayon_core/plugins/publish/collect_scene_version.py
@@ -11,7 +11,7 @@ class CollectSceneVersion(pyblish.api.ContextPlugin):
         version (int, optional): version number of the publish
     """
 
-    order = pyblish.api.CollectorOrder
+    order = pyblish.api.CollectorOrder - 0.45
     label = "Collect Scene Version"
     # configurable in Settings
     hosts = ["*"]


### PR DESCRIPTION
## Changelog Description
Move `CollectSceneVersion` earlier regarding to https://github.com/ynput/ayon-aftereffects/pull/90

## Additional info
Draft PR for ongoing discussion.

## Testing notes:
1. Add the host into `ayon+settings://core/publish/CollectSceneVersion` if it is not the default host.
2. Testing publishing or any kind
