### PR TITLE
Workfiles tool: Fix copy of published workfile

### DIFF
--- a/client/ayon_core/tools/workfiles/models/workfiles.py
+++ b/client/ayon_core/tools/workfiles/models/workfiles.py
@@ -216,7 +216,7 @@ class WorkfilesModel:
             anatomy=self._controller.project_anatomy,
             project_settings=self._controller.project_settings,
             rootless_path=rootless_path,
-            representation_path=representation_filepath,
+            src_representation_path=representation_filepath,
             workfile_entities=self.get_workfile_entities(task_id),
             src_anatomy=self._controller.project_anatomy,
         )


### PR DESCRIPTION
## Changelog Description
Use correct kwarg for representation path when copying published workfile.

## Testing notes:
1. It is possible to copy published workfile using Workfiles tool.
