### PR TITLE
Backward compatibility of build template without profile won't return preset path None.

### DIFF
--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -729,7 +729,7 @@ class AbstractTemplateBuilder(ABC):
         ):
             preset = self.get_template_preset()
             # Path may e.g. be none if there's no active workfile template
-            # set for current text, which would indicate it's just disabled.
+            # set for current context, which would indicate it's just disabled.
             # In that case, do nothing
             if preset.path is None:
                 return

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -151,7 +151,7 @@ class TemplatePreset:
             bool: Preset has set path to an existing file.
 
         """
-        return self.path and os.path.exists(self.path)
+        return self.path is not None and os.path.exists(self.path)
 
 
 class AbstractTemplateBuilder(ABC):
@@ -729,8 +729,9 @@ class AbstractTemplateBuilder(ABC):
         ):
             preset = self.get_template_preset()
             if not preset.has_valid_path():
-                return
-
+                raise TemplateLoadFailed(
+                    f"Template path '{preset.path}' does not exist."
+                )
             template_path: str = preset.path
             if keep_placeholders is None:
                 keep_placeholders: bool = preset.keep_placeholder

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -728,10 +728,10 @@ class AbstractTemplateBuilder(ABC):
             or create_first_version is None
         ):
             preset = self.get_template_preset()
-            if not preset.has_valid_path():
-                if preset.path is None:
-                    return
+            if preset.path is None:
+                return
 
+            if not preset.has_valid_path():
                 raise TemplateLoadFailed(
                     f"Template path '{preset.path}' does not exist."
                 )

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -729,6 +729,8 @@ class AbstractTemplateBuilder(ABC):
         ):
             preset = self.get_template_preset()
             if not preset.has_valid_path():
+                self.log.info(
+                    f"Template path '{preset.path}' does not exist. ")
                 return
             template_path: str = preset.path
             if keep_placeholders is None:

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -729,9 +729,8 @@ class AbstractTemplateBuilder(ABC):
         ):
             preset = self.get_template_preset()
             if not preset.has_valid_path():
-                raise TemplateLoadFailed(
-                    f"Template path '{preset.path}' does not exist."
-                )
+                return
+
             template_path: str = preset.path
             if keep_placeholders is None:
                 keep_placeholders: bool = preset.keep_placeholder

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -729,6 +729,9 @@ class AbstractTemplateBuilder(ABC):
         ):
             preset = self.get_template_preset()
             if not preset.has_valid_path():
+                # Path may e.g. be none if there's no active workfile template
+                # set for current text, which would indicate it's just disabled.
+                # In that case, do nothing
                 if preset.path is None:
                     return
 

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -732,9 +732,9 @@ class AbstractTemplateBuilder(ABC):
                 if preset.path is None:
                     return
 
-                self.log.info(
-                    f"Template path '{preset.path}' does not exist. ")
-                return
+                raise TemplateLoadFailed(
+                    f"Template path '{preset.path}' does not exist."
+                )
             template_path: str = preset.path
             if keep_placeholders is None:
                 keep_placeholders: bool = preset.keep_placeholder

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -729,9 +729,8 @@ class AbstractTemplateBuilder(ABC):
         ):
             preset = self.get_template_preset()
             if not preset.has_valid_path():
-                self.log.info(
-                    f"Template path '{preset.path}' does not exist. ")
-                return
+                if preset.path is None:
+                    return
             template_path: str = preset.path
             if keep_placeholders is None:
                 keep_placeholders: bool = preset.keep_placeholder

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -731,6 +731,10 @@ class AbstractTemplateBuilder(ABC):
             if not preset.has_valid_path():
                 if preset.path is None:
                     return
+
+                self.log.info(
+                    f"Template path '{preset.path}' does not exist. ")
+                return
             template_path: str = preset.path
             if keep_placeholders is None:
                 keep_placeholders: bool = preset.keep_placeholder

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -151,7 +151,7 @@ class TemplatePreset:
             bool: Preset has set path to an existing file.
 
         """
-        return self.path is not None and os.path.exists(self.path)
+        return self.path and os.path.exists(self.path)
 
 
 class AbstractTemplateBuilder(ABC):
@@ -729,9 +729,7 @@ class AbstractTemplateBuilder(ABC):
         ):
             preset = self.get_template_preset()
             if not preset.has_valid_path():
-                raise TemplateLoadFailed(
-                    f"Template path '{preset.path}' does not exist."
-                )
+                return
             template_path: str = preset.path
             if keep_placeholders is None:
                 keep_placeholders: bool = preset.keep_placeholder


### PR DESCRIPTION
## Changelog Description
This PR is to make sure the backward compatibility of build template won't trigger the template-related error below when there is no profile 
Links to https://github.com/ynput/ayon-core/pull/1907
```
# Traceback (most recent call last):
#   File "D:\ayon-core\client\ayon_core\lib\events.py", line 338, in process_event
#     callback()
#     ~~~~~~~~^^
#   File "C:\Users\Kayla\AppData\Local\Ynput\AYON\addons\maya_0.6.11+dev\ayon_maya\api\pipeline.py", line 703, in on_new
#     create_first_workfile_template()
#     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
#   File "C:\Users\Kayla\AppData\Local\Ynput\AYON\addons\maya_0.6.11+dev\ayon_maya\api\workfile_template_builder.py", line 254, in create_first_workfile_template
#     builder.build_template(workfile_creation_enabled=True)
#     ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#   File "D:\ayon-core\client\ayon_core\pipeline\workfile\workfile_template_builder.py", line 598, in inner
#     return self.old_build_template(*args, **kwargs)
#            ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
#   File "D:\ayon-core\client\ayon_core\pipeline\workfile\workfile_template_builder.py", line 732, in old_build_template
#     raise TemplateLoadFailed(
#         f"Template path '{preset.path}' does not exist."
#     )
# ayon_core.pipeline.workfile.workfile_template_builder.TemplateLoadFailed: Template path 'None' does not exist.
```

## Additional info
Paragraphs of text giving context of additional technical information or code examples.

## Testing notes:
1. Launch Nuke and Houdini with this built branch in Core
2. The error log above should be gone
