### PR TITLE
Raise `TemplateProfileNotFound` if profile not found

### DIFF
--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -736,8 +736,11 @@ class AbstractTemplateBuilder(ABC):
             # Path may e.g. be none if there's no active workfile template
             # set for current context, which would indicate it's just disabled.
             # In that case, do nothing
-            if preset.path is None:
-                return
+
+            if not preset.profile:
+                raise TemplateProfileNotFound(
+                    "No matching profile found for current context."
+                )
 
             if not preset.has_valid_path():
                 raise TemplateLoadFailed(

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1160,7 +1160,10 @@ class AbstractTemplateBuilder(ABC):
             logger=self.log
         )
         if not profile:
-            return TemplatePreset()
+            raise TemplateProfileNotFound(
+                f"No matching profile found for task '{task_name}' "
+                f"of type '{task_type}' with host '{self.host_name}'"
+            )
 
         path = profile["path"]
         # resolve path from ayon entity url

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -667,6 +667,11 @@ class AbstractTemplateBuilder(ABC):
         if preset is None:
             preset = self.get_template_preset()
 
+        if not preset.profile:
+            raise TemplateProfileNotFound(
+                "No matching profile found for current context."
+            )
+
         if not preset.has_valid_path():
             raise TemplateLoadFailed(
                 f"Template path '{preset.path}' does not exist."

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1166,10 +1166,7 @@ class AbstractTemplateBuilder(ABC):
             logger=self.log
         )
         if not profile:
-            raise TemplateProfileNotFound(
-                f"No matching profile found for task '{task_name}' "
-                f"of type '{task_type}' with host '{self.host_name}'"
-            )
+            return TemplatePreset()
 
         path = profile["path"]
         # resolve path from ayon entity url


### PR DESCRIPTION
## Changelog Description
- Raise `TemplateProfileNotFound` if profile not found.

## Additional info
The PR revert small change from this commit https://github.com/ynput/ayon-core/commit/50fed1219de248486e10e17564f316282899eb4b

## Testing notes:
On launching Houdini without a template profile, template build will be skipped safely.
<img width="1558" height="646" alt="image" src="https://github.com/user-attachments/assets/cf99db20-d519-4dec-94b4-19f2c7dab68c" />

Resolve #1984
