### PR TITLE
Publisher tool: Add some type hints

### DIFF
--- a/client/ayon_core/tools/attribute_defs/__init__.py
+++ b/client/ayon_core/tools/attribute_defs/__init__.py
@@ -2,6 +2,7 @@ from .widgets import (
     create_widget_for_attr_def,
     AttributeDefinitionsWidget,
     AttributeDefinitionsLabel,
+    BaseAttrDefWidget,
 )
 
 from .dialog import (
@@ -13,6 +14,7 @@ __all__ = (
     "create_widget_for_attr_def",
     "AttributeDefinitionsWidget",
     "AttributeDefinitionsLabel",
+    "BaseAttrDefWidget",
 
     "AttributeDefinitionsDialog",
 )

--- a/client/ayon_core/tools/attribute_defs/widgets.py
+++ b/client/ayon_core/tools/attribute_defs/widgets.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import typing
 from typing import Optional
@@ -56,7 +58,7 @@ def create_widget_for_attr_def(
 
 def _create_widget_for_attr_def(
     attr_def: AbstractAttrDef,
-    parent: "Union[QtWidgets.QWidget, None]",
+    parent: QtWidgets.QWidget | None,
     handle_revert_to_default: bool,
 ):
     if not isinstance(attr_def, AbstractAttrDef):
@@ -293,7 +295,7 @@ class AttributeDefinitionsWidget(QtWidgets.QWidget):
             label.set_overridden(value != widget.attr_def.default)
 
 
-class _BaseAttrDefWidget(QtWidgets.QWidget):
+class BaseAttrDefWidget(QtWidgets.QWidget):
     # Type 'object' may not work with older PySide versions
     value_changed = QtCore.Signal(object, str)
     revert_to_default_requested = QtCore.Signal(str)
@@ -301,7 +303,7 @@ class _BaseAttrDefWidget(QtWidgets.QWidget):
     def __init__(
         self,
         attr_def: AbstractAttrDef,
-        parent: "Union[QtWidgets.QWidget, None]",
+        parent: QtWidgets.QWidget | None,
         handle_revert_to_default: Optional[bool] = True,
     ):
         super().__init__(parent)
@@ -347,7 +349,7 @@ class _BaseAttrDefWidget(QtWidgets.QWidget):
         )
 
 
-class SeparatorAttrWidget(_BaseAttrDefWidget):
+class SeparatorAttrWidget(BaseAttrDefWidget):
     def _ui_init(self):
         input_widget = QtWidgets.QWidget(self)
         input_widget.setObjectName("Separator")
@@ -359,7 +361,7 @@ class SeparatorAttrWidget(_BaseAttrDefWidget):
         self.main_layout.addWidget(input_widget, 0)
 
 
-class LabelAttrWidget(_BaseAttrDefWidget):
+class LabelAttrWidget(BaseAttrDefWidget):
     def _ui_init(self):
         input_widget = MarkdownLabel(self)
         label = self.attr_def.label
@@ -374,7 +376,7 @@ class LabelAttrWidget(_BaseAttrDefWidget):
         self.main_layout.addWidget(input_widget, 0)
 
 
-class ButtonAttrWidget(_BaseAttrDefWidget):
+class ButtonAttrWidget(BaseAttrDefWidget):
     def _ui_init(self):
         input_widget = QtWidgets.QPushButton(self)
         text = self.attr_def.text
@@ -424,7 +426,7 @@ class ClickableLineEdit(QtWidgets.QLineEdit):
         super().mouseReleaseEvent(event)
 
 
-class NumberAttrWidget(_BaseAttrDefWidget):
+class NumberAttrWidget(BaseAttrDefWidget):
     def _ui_init(self):
         decimals = self.attr_def.decimals
         if decimals > 0:
@@ -537,7 +539,7 @@ class NumberAttrWidget(_BaseAttrDefWidget):
         )
 
 
-class TextAttrWidget(_BaseAttrDefWidget):
+class TextAttrWidget(BaseAttrDefWidget):
     def _ui_init(self):
         # TODO Solve how to handle regex
         # self.attr_def.regex
@@ -618,7 +620,7 @@ class TextAttrWidget(_BaseAttrDefWidget):
                 self._input_widget.blockSignals(False)
 
 
-class BoolAttrWidget(_BaseAttrDefWidget):
+class BoolAttrWidget(BaseAttrDefWidget):
     def _ui_init(self):
         input_widget = NiceCheckbox(parent=self)
         input_widget.setChecked(self.attr_def.default)
@@ -672,7 +674,7 @@ class BoolAttrWidget(_BaseAttrDefWidget):
             self._input_widget.setChecked(value)
 
 
-class EnumAttrWidget(_BaseAttrDefWidget):
+class EnumAttrWidget(BaseAttrDefWidget):
     def __init__(self, *args, **kwargs):
         self._multivalue = False
         super().__init__(*args, **kwargs)
@@ -797,7 +799,7 @@ class EnumAttrWidget(_BaseAttrDefWidget):
         self._multivalue = multivalue
 
 
-class UnknownAttrWidget(_BaseAttrDefWidget):
+class UnknownAttrWidget(BaseAttrDefWidget):
     def _ui_init(self):
         input_widget = QtWidgets.QLabel(self)
         self._value = self.attr_def.default
@@ -826,7 +828,7 @@ class UnknownAttrWidget(_BaseAttrDefWidget):
             self._input_widget.setText(str_value)
 
 
-class HiddenAttrWidget(_BaseAttrDefWidget):
+class HiddenAttrWidget(BaseAttrDefWidget):
     def _ui_init(self):
         self.setVisible(False)
         self._value = self.attr_def.default
@@ -849,7 +851,7 @@ class HiddenAttrWidget(_BaseAttrDefWidget):
         self._multivalue = multivalue
 
 
-class FileAttrWidget(_BaseAttrDefWidget):
+class FileAttrWidget(BaseAttrDefWidget):
     def _ui_init(self):
         input_widget = FilesWidget(
             self.attr_def.single_item,

--- a/client/ayon_core/tools/attribute_defs/widgets.py
+++ b/client/ayon_core/tools/attribute_defs/widgets.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import copy
-import typing
-from typing import Optional
 
 from qtpy import QtWidgets, QtCore, QtGui
 
@@ -36,15 +34,12 @@ from ayon_core.tools.utils import NiceCheckbox
 from ._constants import REVERT_TO_DEFAULT_LABEL
 from .files_widget import FilesWidget
 
-if typing.TYPE_CHECKING:
-    from typing import Union
-
 
 def create_widget_for_attr_def(
     attr_def: AbstractAttrDef,
-    parent: Optional[QtWidgets.QWidget] = None,
-    handle_revert_to_default: Optional[bool] = True,
-):
+    parent: QtWidgets.QWidget | None = None,
+    handle_revert_to_default: bool = True,
+) -> BaseAttrDefWidget:
     widget = _create_widget_for_attr_def(
         attr_def, parent, handle_revert_to_default
     )
@@ -60,11 +55,12 @@ def _create_widget_for_attr_def(
     attr_def: AbstractAttrDef,
     parent: QtWidgets.QWidget | None,
     handle_revert_to_default: bool,
-):
+) -> BaseAttrDefWidget:
     if not isinstance(attr_def, AbstractAttrDef):
-        raise TypeError("Unexpected type \"{}\" expected \"{}\"".format(
-            str(type(attr_def)), AbstractAttrDef
-        ))
+        raise TypeError(
+            f"Unexpected type \"{type(attr_def)}\""
+            " expected subclass of \"AbstractAttrDef\"."
+        )
 
     cls = None
     if isinstance(attr_def, NumberDef):
@@ -304,7 +300,7 @@ class BaseAttrDefWidget(QtWidgets.QWidget):
         self,
         attr_def: AbstractAttrDef,
         parent: QtWidgets.QWidget | None,
-        handle_revert_to_default: Optional[bool] = True,
+        handle_revert_to_default: bool = True,
     ):
         super().__init__(parent)
 

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -719,9 +719,7 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         pass
 
     @abstractmethod
-    def get_existing_product_names(
-        self, folder_path: str | None
-    ) -> set[str] | None:
+    def get_existing_product_names(self, folder_path: str) -> set[str] | None:
         pass
 
     @abstractmethod

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -719,7 +719,7 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         pass
 
     @abstractmethod
-    def get_existing_product_names(self, folder_path: str) -> list[str]:
+    def get_existing_product_names(self, folder_path: str) -> set[str] | None:
         pass
 
     @abstractmethod

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -3,21 +3,17 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 import collections
 from dataclasses import dataclass, asdict, field
-from typing import (
-    Any,
-    Callable,
-    Iterable,
-    TYPE_CHECKING,
-)
+import typing
+from typing import Any, Callable, Iterable
 import uuid
 
-from ayon_core.pipeline.publish import PublishError, KnownPublishError
 from ayon_core.lib.attribute_definitions import (
     serialize_attr_defs,
     deserialize_attr_defs,
 )
+from ayon_core.pipeline.publish import PublishError, KnownPublishError
 
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from ayon_core.tools.common_models.settings import TaskSortMode
     from ayon_core.lib import AbstractAttrDef
     from ayon_core.host import AbstractHost
@@ -370,7 +366,7 @@ class AbstractPublisherCommon(ABC):
     def emit_event(
         self, topic: str,
         data: dict[str, Any] | None = None,
-        source: str | None = None
+        source: str | None = None,
     ) -> None:
         """Emit event.
 
@@ -386,7 +382,7 @@ class AbstractPublisherCommon(ABC):
     def emit_card_message(
         self,
         message: str,
-        message_type: str | None = CardMessageTypes.standard
+        message_type: str = CardMessageTypes.standard
     ) -> None:
         """Emit a card message which can have a lifetime.
 
@@ -395,8 +391,7 @@ class AbstractPublisherCommon(ABC):
 
         Args:
             message (str): Message that will be shown.
-            message_type (Optional[str]): Message type.
-
+            message_type (str): Message type.
         """
         pass
 
@@ -573,14 +568,14 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
 
     @abstractmethod
     def get_task_items_by_folder_paths(
-        self, folder_paths: Iterable[str]
+        self, folder_paths: set[str]
     ) -> dict[str, list[TaskItem]]:
         pass
 
     @abstractmethod
     def get_folder_items(
         self, project_name: str, sender: str | None = None
-    ) -> list[FolderItem]:
+    ) -> dict[str, FolderItem]:
         pass
 
     @abstractmethod

--- a/client/ayon_core/tools/publisher/abstract.py
+++ b/client/ayon_core/tools/publisher/abstract.py
@@ -719,7 +719,9 @@ class AbstractPublisherFrontend(AbstractPublisherCommon):
         pass
 
     @abstractmethod
-    def get_existing_product_names(self, folder_path: str) -> set[str] | None:
+    def get_existing_product_names(
+        self, folder_path: str | None
+    ) -> set[str] | None:
         pass
 
     @abstractmethod

--- a/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
@@ -21,35 +21,37 @@ Only one item can be selected at a time.
 """
 from __future__ import annotations
 
+from collections import defaultdict, deque
+from enum import Enum, auto
 import re
-import collections
-from typing import Optional
+import typing
 
 from qtpy import QtWidgets, QtCore
 
-from ayon_core.pipeline.create import (
-    InstanceContextInfo,
-    ParentFlags,
-)
+from ayon_core.pipeline.create import ParentFlags
 from ayon_core.pipeline.publish.report import CONTEXT_ID
 
 from ayon_core.tools.utils import BaseClickableFrame, NiceCheckbox
 from ayon_core.tools.utils.lib import html_escape
-from ayon_core.tools.publisher.abstract import AbstractPublisherFrontend
 from ayon_core.tools.publisher.constants import (
     CONTEXT_LABEL,
     CONTEXT_GROUP,
     CONVERTOR_ITEM_GROUP,
 )
-from ayon_core.tools.publisher.models.create import (
-    InstanceItem,
-)
 from .widgets import (
     AbstractInstanceView,
     ContextWarningLabel,
     IconValuePixmapLabel,
-    PublishPixmapLabel
+    PublishPixmapLabel,
+    InstancesSelection,
 )
+
+if typing.TYPE_CHECKING:
+    from ayon_core.pipeline.create import ConvertorItem, InstanceContextInfo
+    from ayon_core.tools.publisher.abstract import AbstractPublisherFrontend
+    from ayon_core.tools.publisher.models.create import (
+        InstanceItem,
+    )
 
 
 class SelectionTypes:
@@ -63,7 +65,9 @@ class BaseGroupWidget(QtWidgets.QWidget):
     removed_selected = QtCore.Signal()
     double_clicked = QtCore.Signal()
 
-    def __init__(self, group_name, parent):
+    def __init__(
+        self, group_name: str, parent: QtWidgets.QWidget
+    ) -> None:
         super().__init__(parent)
 
         label_widget = QtWidgets.QLabel(group_name, self)
@@ -92,7 +96,7 @@ class BaseGroupWidget(QtWidgets.QWidget):
         self._content_layout = layout
 
     @property
-    def group_name(self):
+    def group_name(self) -> str:
         """Group which widget represent.
 
         Returns:
@@ -114,15 +118,14 @@ class BaseGroupWidget(QtWidgets.QWidget):
             self._widgets_by_id[item_id] = widget
             idx += 1
 
-    def take_widgets(self, widget_ids: set[str]):
+    def take_widgets(self, widget_ids: set[str]) -> None:
         for widget_id in widget_ids:
             widget = self._widgets_by_id.pop(widget_id)
             index = self._content_layout.indexOf(widget)
             if index >= 0:
                 self._content_layout.takeAt(index)
 
-    def _remove_all_except(self, item_ids):
-        item_ids = set(item_ids)
+    def _remove_all_except(self, item_ids: set[str]) -> None:
         # Remove instance widgets that are not in passed instances
         for item_id in tuple(self._widgets_by_id.keys()):
             if item_id in item_ids:
@@ -146,12 +149,12 @@ class CardWidget(BaseClickableFrame):
     _group_identifier = None
     double_clicked = QtCore.Signal()
 
-    def __init__(self, parent):
+    def __init__(self, parent: QtWidgets.QWidget) -> None:
         super().__init__(parent)
         self.setObjectName("CardViewWidget")
 
-        self._selected = False
-        self._id = None
+        self._selected: bool = False
+        self._id: str = None
 
     def mouseDoubleClickEvent(self, event):
         super().mouseDoubleClickEvent(event)
@@ -159,17 +162,16 @@ class CardWidget(BaseClickableFrame):
             self.double_clicked.emit()
 
     @property
-    def id(self):
+    def id(self) -> str:
         """Id of card."""
-
         return self._id
 
     @property
-    def is_selected(self):
+    def is_selected(self) -> bool:
         """Is card selected."""
         return self._selected
 
-    def set_selected(self, selected):
+    def set_selected(self, selected: bool) -> None:
         """Set card as selected."""
         if selected is self._selected:
             return
@@ -179,7 +181,7 @@ class CardWidget(BaseClickableFrame):
         self.setProperty("state", state)
         self.style().polish(self)
 
-    def _mouse_release_callback(self):
+    def _mouse_release_callback(self) -> None:
         """Trigger selected signal."""
 
         modifiers = QtWidgets.QApplication.keyboardModifiers()
@@ -192,7 +194,7 @@ class CardWidget(BaseClickableFrame):
 
         self.selected.emit(self._id, self._group_identifier, selection_type)
 
-    def _is_valid_double_click(self, event):
+    def _is_valid_double_click(self, event) -> bool:
         return True
 
 
@@ -202,7 +204,7 @@ class ContextCardWidget(CardWidget):
     Is not visually under group widget and is always at the top of card view.
     """
 
-    def __init__(self, parent: QtWidgets.QWidget):
+    def __init__(self, parent: QtWidgets.QWidget) -> None:
         super().__init__(parent)
 
         self._id = CONTEXT_ID
@@ -237,7 +239,9 @@ class ConvertorItemCardWidget(CardWidget):
     Is not visually under group widget and is always at the top of card view.
     """
 
-    def __init__(self, item, parent):
+    def __init__(
+        self, item: ConvertorItem, parent: QtWidgets.QWidget
+    ) -> None:
         super().__init__(parent)
 
         self._id = item.id
@@ -261,7 +265,7 @@ class ConvertorItemCardWidget(CardWidget):
         self._icon_widget = icon_widget
         self._label_widget = label_widget
 
-    def update_item(self, item):
+    def update_item(self, item: ConvertorItem) -> None:
         self._id = item.id
         self.identifier = item.identifier
 
@@ -273,12 +277,13 @@ class InstanceCardWidget(CardWidget):
 
     def __init__(
         self,
-        instance,
-        context_info,
+        instance: InstanceItem,
+        context_info: InstanceContextInfo,
         is_parent_active: bool,
+        # TODO find out what type is 'group_icon'
         group_icon,
         parent: BaseGroupWidget,
-    ):
+    ) -> None:
         super().__init__(parent)
 
         self.instance = instance
@@ -356,7 +361,7 @@ class InstanceCardWidget(CardWidget):
     def is_active(self) -> bool:
         return self._active_checkbox.isChecked()
 
-    def set_active(self, active: Optional[bool]) -> None:
+    def set_active(self, active: bool | None) -> None:
         if not self.is_checkbox_enabled():
             return
         if active is None:
@@ -379,21 +384,28 @@ class InstanceCardWidget(CardWidget):
             and not self.instance.is_mandatory
         )
 
-    def update_instance(self, instance, context_info, is_parent_active):
+    def update_instance(
+        self,
+        instance: InstanceItem,
+        context_info: InstanceContextInfo,
+        is_parent_active: bool,
+    ) -> None:
         """Update instance object and update UI."""
         self.instance = instance
         self._is_active = instance.is_active
         self._update_instance_values(context_info, is_parent_active)
 
-    def _validate_context(self, context_info):
+    def _validate_context(
+        self, context_info: InstanceContextInfo
+    ) -> None:
         valid = context_info.is_valid
         self._icon_widget.setVisible(valid)
         self._context_warning.setVisible(not valid)
 
     @staticmethod
     def _get_card_widget_sub_label(
-        folder_path: Optional[str],
-        task_name: Optional[str],
+        folder_path: str | None,
+        task_name: str | None,
     ) -> str:
         sublabel = ""
         if folder_path:
@@ -403,7 +415,7 @@ class InstanceCardWidget(CardWidget):
                 sublabel += f" - <i>{task_name}</i>"
         return sublabel
 
-    def _update_product_name(self):
+    def _update_product_name(self) -> None:
         variant = self.instance.variant
         product_name = self.instance.product_name
         label = self.instance.label
@@ -445,14 +457,18 @@ class InstanceCardWidget(CardWidget):
             QtCore.Qt.NoTextInteraction
         )
 
-    def _update_instance_values(self, context_info, is_parent_active):
+    def _update_instance_values(
+        self,
+        context_info: InstanceContextInfo,
+        is_parent_active: bool,
+    ) -> None:
         """Update instance data"""
         self._is_parent_active = is_parent_active
         self._update_product_name()
         self._update_checkbox_state()
         self._validate_context(context_info)
 
-    def _update_checkbox_state(self):
+    def _update_checkbox_state(self) -> None:
         parent_is_enabled = self._used_parent_active()
         self._label_widget.setEnabled(parent_is_enabled)
         self._active_checkbox.setEnabled(
@@ -479,12 +495,12 @@ class InstanceCardWidget(CardWidget):
             parent_enabled = self._is_parent_active
         return parent_enabled
 
-    def _set_expanded(self, expanded=None):
+    def _set_expanded(self, expanded: bool | None = None) -> None:
         if expanded is None:
             expanded = not self._detail_widget.isVisible()
         self._detail_widget.setVisible(expanded)
 
-    def _on_active_change(self):
+    def _on_active_change(self) -> None:
         if not self.is_checkbox_enabled():
             return
         new_value = self._active_checkbox.isChecked()
@@ -494,10 +510,10 @@ class InstanceCardWidget(CardWidget):
         self._is_active = new_value
         self.active_changed.emit(self._id, new_value)
 
-    def _on_expend_clicked(self):
+    def _on_expend_clicked(self) -> None:
         self._set_expanded()
 
-    def _is_valid_double_click(self, event):
+    def _is_valid_double_click(self, event) -> bool:
         widget = self.childAt(event.pos())
         if (
             widget is self._active_checkbox
@@ -515,7 +531,11 @@ class InstanceCardView(AbstractInstanceView):
 
     double_clicked = QtCore.Signal()
 
-    def __init__(self, controller, parent):
+    def __init__(
+        self,
+        controller: AbstractPublisherFrontend,
+        parent: QtWidgets.QWidget,
+    ) -> None:
         super().__init__(parent)
 
         self._controller: AbstractPublisherFrontend = controller
@@ -546,31 +566,33 @@ class InstanceCardView(AbstractInstanceView):
         self._content_widget = content_widget
 
         self._active_toggle_enabled: bool = True
-        self._convertors_group: Optional[BaseGroupWidget] = None
+        self._convertors_group: BaseGroupWidget | None = None
         self._convertor_widgets_by_id: dict[str, ConvertorItemCardWidget] = {}
         self._convertor_ids: list[str] = []
 
         self._group_name_by_instance_id: dict[str, str] = {}
         self._instance_ids_by_group_name: dict[str, list[str]] = (
-            collections.defaultdict(list)
+            defaultdict(list)
         )
-        self._ordered_groups = []
-        self._context_widget: Optional[ContextCardWidget] = None
+        self._ordered_groups: list[str] = []
+        self._context_widget: ContextCardWidget | None = None
         self._widgets_by_id: dict[str, InstanceCardWidget] = {}
         self._widgets_by_group: dict[str, BaseGroupWidget] = {}
 
-        self._parent_id_by_id = {}
-        self._instance_ids_by_parent_id = collections.defaultdict(set)
+        self._parent_id_by_id: dict[str, str | None] = {}
+        self._instance_ids_by_parent_id: dict[str, set[str]] = (
+            defaultdict(set)
+        )
 
-        self._explicitly_selected_instance_ids = []
-        self._explicitly_selected_groups = []
+        self._explicitly_selected_instance_ids: list[str] = []
+        self._explicitly_selected_groups: list[str] = []
 
         self.setSizePolicy(
             QtWidgets.QSizePolicy.Minimum,
             self.sizePolicy().verticalPolicy()
         )
 
-    def sizeHint(self):
+    def sizeHint(self) -> QtCore.QSize:
         """Modify sizeHint based on visibility of scroll bars."""
         # Calculate width hint by content widget and vertical scroll bar
         scroll_bar = self._scroll_area.verticalScrollBar()
@@ -589,10 +611,10 @@ class InstanceCardView(AbstractInstanceView):
 
     def _get_affected_ids(self, instance_ids: set[str]) -> set[str]:
         affected_ids = set()
-        affected_queue = collections.deque()
+        affected_queue = deque()
         affected_queue.extend(instance_ids)
         while affected_queue:
-            instance_id = affected_queue.popleft()
+            instance_id: str = affected_queue.popleft()
             if instance_id in affected_ids:
                 continue
             affected_ids.add(instance_id)
@@ -609,15 +631,15 @@ class InstanceCardView(AbstractInstanceView):
 
     def _toggle_instances(
         self,
-        new_value: Optional[bool],
-        active_id: Optional[str] = None,
+        new_value: bool | None,
+        active_id: str | None = None,
     ) -> None:
-        instance_ids = {
+        instance_ids: set[str] = {
             widget.id
             for widget in self._get_selected_instance_widgets()
             if widget.is_selected
         }
-        active_by_id = {}
+        active_by_id: dict[str, bool] = {}
         if active_id and active_id not in instance_ids:
             instance_ids = {active_id}
 
@@ -625,7 +647,7 @@ class InstanceCardView(AbstractInstanceView):
 
         affected_ids = self._get_affected_ids(instance_ids)
 
-        _queue = collections.deque()
+        _queue = deque()
         _queue.append((set(self._instance_ids_by_parent_id[None]), True))
         discarted_ids = set()
         while _queue:
@@ -670,7 +692,7 @@ class InstanceCardView(AbstractInstanceView):
         if active_by_id:
             self._controller.set_instances_active_state(active_by_id)
 
-    def keyPressEvent(self, event):
+    def keyPressEvent(self, event) -> bool:
         if event.key() == QtCore.Qt.Key_Space:
             self._toggle_instances(None)
             return True
@@ -685,7 +707,7 @@ class InstanceCardView(AbstractInstanceView):
 
         return super().keyPressEvent(event)
 
-    def _get_selected_widgets(self):
+    def _get_selected_widgets(self) -> list[CardWidget]:
         output = []
         if (
             self._context_widget is not None
@@ -711,7 +733,7 @@ class InstanceCardView(AbstractInstanceView):
             if widget.is_selected
         ]
 
-    def _get_selected_item_ids(self):
+    def _get_selected_item_ids(self) -> list[str]:
         output = []
         if (
             self._context_widget is not None
@@ -732,7 +754,7 @@ class InstanceCardView(AbstractInstanceView):
         )
         return output
 
-    def refresh(self):
+    def refresh(self) -> None:
         """Refresh instances in view based on CreatedContext."""
         self._make_sure_context_widget_exists()
 
@@ -740,12 +762,12 @@ class InstanceCardView(AbstractInstanceView):
         context_info_by_id = self._controller.get_instances_context_info()
 
         # Prepare instances by group and identifiers by group
-        instances_by_group = collections.defaultdict(list)
-        identifiers_by_group = collections.defaultdict(set)
+        instances_by_group = defaultdict(list)
+        identifiers_by_group = defaultdict(set)
         identifiers: set[str] = set()
         instances_by_id = {}
         parent_id_by_id = {}
-        instance_ids_by_parent_id = collections.defaultdict(set)
+        instance_ids_by_parent_id = defaultdict(set)
         instance_items = self._controller.get_instance_items()
         for instance in instance_items:
             group_name = instance.group_label
@@ -764,7 +786,7 @@ class InstanceCardView(AbstractInstanceView):
             instance_id: False
             for instance_id in instances_by_id
         }
-        _queue = collections.deque()
+        _queue = deque()
         _queue.append((None, True))
         while _queue:
             parent_id, is_parent_active = _queue.popleft()
@@ -800,7 +822,7 @@ class InstanceCardView(AbstractInstanceView):
             widget_idx += 1
 
         group_by_instance_id = {}
-        instance_ids_by_group_name = collections.defaultdict(list)
+        instance_ids_by_group_name = defaultdict(list)
         group_icons = {
             identifier: self._controller.get_creator_icon(identifier)
             for identifier in identifiers
@@ -880,7 +902,7 @@ class InstanceCardView(AbstractInstanceView):
         # Store instances by id and by product name
         group_widget: BaseGroupWidget = self._widgets_by_group[group_name]
         instances_by_id = {}
-        instances_by_product_name = collections.defaultdict(list)
+        instances_by_product_name = defaultdict(list)
         for instance in instances:
             instances_by_id[instance.id] = instance
             product_name = instance.product_name
@@ -925,7 +947,7 @@ class InstanceCardView(AbstractInstanceView):
 
         group_widget.set_widgets(widgets_by_id, ordered_ids)
 
-    def _make_sure_context_widget_exists(self):
+    def _make_sure_context_widget_exists(self) -> None:
         # Create context item if is not already existing
         # - this must be as first thing to do as context item should be at the
         #   top
@@ -941,7 +963,7 @@ class InstanceCardView(AbstractInstanceView):
         self.selection_changed.emit()
         self._content_layout.insertWidget(0, widget)
 
-    def _update_convertors_group(self):
+    def _update_convertors_group(self) -> None:
         convertor_items = self._controller.get_convertor_items()
         if not convertor_items and self._convertors_group is None:
             return
@@ -974,7 +996,7 @@ class InstanceCardView(AbstractInstanceView):
             self._convertors_group = group_widget
 
         # TODO create convertor widgets
-        items_by_label = collections.defaultdict(list)
+        items_by_label = defaultdict(list)
         for item in convertor_items.values():
             items_by_label[item.label].append(item)
 
@@ -1001,7 +1023,9 @@ class InstanceCardView(AbstractInstanceView):
         self._convertor_ids = convertor_ids
         self._convertor_widgets_by_id = widgets_by_id
 
-    def refresh_instance_states(self, instance_ids=None):
+    def refresh_instance_states(
+        self, instance_ids: set[str] | None = None
+    ) -> None:
         """Trigger update of instances on group widgets."""
         if instance_ids is not None:
             instance_ids = set(instance_ids)
@@ -1014,7 +1038,7 @@ class InstanceCardView(AbstractInstanceView):
 
         affected_ids = self._get_affected_ids(instance_ids)
 
-        _queue = collections.deque()
+        _queue = deque()
         _queue.append((set(self._instance_ids_by_parent_id[None]), True))
         while _queue:
             if not affected_ids:
@@ -1049,7 +1073,12 @@ class InstanceCardView(AbstractInstanceView):
     def _on_active_changed(self, instance_id: str, value: bool) -> None:
         self._toggle_instances(value, instance_id)
 
-    def _on_widget_selection(self, instance_id, group_name, selection_type):
+    def _on_widget_selection(
+        self,
+        instance_id: str,
+        group_name: str,
+        selection_type: str,
+    ) -> None:
         """Select specific item by instance id.
 
         Pass `CONTEXT_ID` as instance id and empty string as group to select
@@ -1058,22 +1087,26 @@ class InstanceCardView(AbstractInstanceView):
         if instance_id == CONTEXT_ID:
             new_widget = self._context_widget
 
+        elif group_name == CONVERTOR_ITEM_GROUP:
+            new_widget = self._convertor_widgets_by_id[instance_id]
         else:
-            if group_name == CONVERTOR_ITEM_GROUP:
-                new_widget = self._convertor_widgets_by_id[instance_id]
-            else:
-                new_widget = self._widgets_by_id[instance_id]
+            new_widget = self._widgets_by_id[instance_id]
 
         if selection_type == SelectionTypes.clear:
             self._select_item_clear(instance_id, group_name, new_widget)
         elif selection_type == SelectionTypes.extend:
             self._select_item_extend(instance_id, group_name, new_widget)
         elif selection_type == SelectionTypes.extend_to:
-            self._select_item_extend_to(instance_id, group_name, new_widget)
+            self._select_item_extend_to(instance_id, group_name)
 
         self.selection_changed.emit()
 
-    def _select_item_clear(self, instance_id, group_name, new_widget):
+    def _select_item_clear(
+        self,
+        instance_id: str,
+        group_name: str,
+        new_widget: CardWidget,
+    ) -> None:
         """Select specific item by instance id and clear previous selection.
 
         Pass `CONTEXT_ID` as instance id and empty string as group to select
@@ -1091,7 +1124,12 @@ class InstanceCardView(AbstractInstanceView):
         if new_widget is not None:
             new_widget.set_selected(True)
 
-    def _select_item_extend(self, instance_id, group_name, new_widget):
+    def _select_item_extend(
+        self,
+        instance_id: str,
+        group_name: str,
+        new_widget: CardWidget,
+    ) -> None:
         """Add/Remove single item to/from current selection.
 
         If item is already selected the selection is removed.
@@ -1134,7 +1172,9 @@ class InstanceCardView(AbstractInstanceView):
         self._explicitly_selected_groups.append(group_name)
         new_widget.set_selected(True)
 
-    def _select_item_extend_to(self, instance_id, group_name, new_widget):
+    def _select_item_extend_to(
+        self, instance_id: str, group_name: str
+    ) -> None:
         """Extend selected items to specific instance id.
 
         This method is handling Shift+click selection of widgets. Selection
@@ -1351,45 +1391,36 @@ class InstanceCardView(AbstractInstanceView):
                 for widget in sorted_widgets:
                     widget.set_selected(True)
 
-    def get_selected_items(self):
+    def get_selected_items(self) -> InstancesSelection:
         """Get selected instance ids and context."""
 
-        context_selected = (
-            self._context_widget is not None
-            and self._context_widget.is_selected
+        return InstancesSelection(
+            instance_ids={
+                widget.id
+                for widget in self._get_selected_instance_widgets()
+            },
+            context_selected=(
+                self._context_widget is not None
+                and self._context_widget.is_selected
+            ),
+            convertor_identifiers={
+                widget.identifier
+                for widget in self._get_selected_convertor_widgets()
+            },
         )
-        instances = [
-            widget.id
-            for widget in self._get_selected_instance_widgets()
-        ]
-        convertor_identifiers = [
-            widget.identifier
-            for widget in self._get_selected_convertor_widgets()
-        ]
-        return instances, context_selected, convertor_identifiers
 
-    def set_selected_items(
-        self, instance_ids, context_selected, convertor_identifiers
-    ):
-        s_instance_ids = set(instance_ids)
-        s_convertor_identifiers = set(convertor_identifiers)
-        cur_ids, cur_context, cur_convertor_identifiers = (
-            self.get_selected_items()
-        )
-        if (
-            set(cur_ids) == s_instance_ids
-            and cur_context == context_selected
-            and set(cur_convertor_identifiers) == s_convertor_identifiers
-        ):
+    def set_selected_items(self, selection: InstancesSelection) -> None:
+        current_selection = self.get_selected_items()
+        if selection == current_selection:
             return
 
         selected_groups = []
         selected_instances = []
-        if context_selected:
+        if selection.context_selected:
             selected_groups.append(CONTEXT_GROUP)
             selected_instances.append(CONTEXT_ID)
 
-        self._context_widget.set_selected(context_selected)
+        self._context_widget.set_selected(selection.context_selected)
 
         for group_name in self._ordered_groups:
             if group_name == CONTEXT_GROUP:
@@ -1412,9 +1443,11 @@ class InstanceCardView(AbstractInstanceView):
             for widget in sorted_widgets:
                 select = False
                 if is_convertor_group:
-                    is_in = widget.identifier in s_convertor_identifiers
+                    is_in = (
+                        widget.identifier in selection.convertor_identifiers
+                    )
                 else:
-                    is_in = widget.id in s_instance_ids
+                    is_in = widget.id in selection.instance_ids
                 if is_in:
                     selected_instances.append(widget.id)
                     group_selected = True
@@ -1427,7 +1460,7 @@ class InstanceCardView(AbstractInstanceView):
         self._explicitly_selected_groups = selected_groups
         self._explicitly_selected_instance_ids = selected_instances
 
-    def set_active_toggle_enabled(self, enabled):
+    def set_active_toggle_enabled(self, enabled: bool) -> None:
         if self._active_toggle_enabled is enabled:
             return
         self._active_toggle_enabled = enabled

--- a/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/card_view_widgets.py
@@ -22,7 +22,6 @@ Only one item can be selected at a time.
 from __future__ import annotations
 
 from collections import defaultdict, deque
-from enum import Enum, auto
 import re
 import typing
 

--- a/client/ayon_core/tools/publisher/widgets/create_context_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/create_context_widgets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+from typing import Any, Callable
 
 from qtpy import QtWidgets, QtCore
 
@@ -16,6 +17,12 @@ from ayon_core.tools.utils import (
 from ayon_core.tools.publisher.abstract import AbstractPublisherFrontend
 
 if typing.TYPE_CHECKING:
+    from ayon_core.tools.common_models import (
+        FolderTypeItem,
+        TaskTypeItem,
+        FolderItem,
+        TaskItem,
+    )
     from ayon_core.tools.common_models.settings import TaskSortMode
 
 
@@ -30,7 +37,7 @@ class CreateSelectionModel(object):
 
     event_source = "publisher.create.selection.model"
 
-    def __init__(self, controller: "CreateHierarchyController"):
+    def __init__(self, controller: CreateHierarchyController) -> None:
         self._controller: CreateHierarchyController = controller
 
         self._project_name = None
@@ -41,7 +48,7 @@ class CreateSelectionModel(object):
     def get_selected_project_name(self):
         return self._project_name
 
-    def set_selected_project(self, project_name):
+    def set_selected_project(self, project_name: str | None) -> None:
         if project_name == self._project_name:
             return
 
@@ -52,10 +59,10 @@ class CreateSelectionModel(object):
             self.event_source
         )
 
-    def get_selected_folder_id(self):
+    def get_selected_folder_id(self) -> str | None:
         return self._folder_id
 
-    def set_selected_folder(self, folder_id):
+    def set_selected_folder(self, folder_id: str | None) -> None:
         if folder_id == self._folder_id:
             return
 
@@ -69,13 +76,15 @@ class CreateSelectionModel(object):
             self.event_source
         )
 
-    def get_selected_task_name(self):
+    def get_selected_task_name(self) -> str | None:
         return self._task_name
 
-    def get_selected_task_id(self):
+    def get_selected_task_id(self) -> str | None:
         return self._task_id
 
-    def set_selected_task(self, task_id, task_name):
+    def set_selected_task(
+        self, task_id: str, task_name: str
+    ) -> None:
         if task_id == self._task_id:
             return
 
@@ -106,7 +115,7 @@ class CreateHierarchyController:
         controller (PublisherController): Publisher controller.
 
     """
-    def __init__(self, controller: AbstractPublisherFrontend):
+    def __init__(self, controller: AbstractPublisherFrontend) -> None:
         self._event_system = QueuedEventSystem()
         self._controller: AbstractPublisherFrontend = controller
         self._selection_model = CreateSelectionModel(self)
@@ -116,81 +125,107 @@ class CreateHierarchyController:
 
     # Events system
     @property
-    def event_system(self):
+    def event_system(self) -> QueuedEventSystem:
         return self._event_system
 
-    def emit_event(self, topic, data=None, source=None):
+    def emit_event(
+        self,
+        topic: str,
+        data: dict[str, Any] | None = None,
+        source: str | None = None,
+    ) -> None:
         """Use implemented event system to trigger event."""
 
         if data is None:
             data = {}
         self.event_system.emit(topic, data, source)
 
-    def register_event_callback(self, topic, callback):
+    def register_event_callback(self, topic: str, callback: Callable) -> None:
         self.event_system.add_callback(topic, callback)
 
-    def get_project_name(self):
+    def get_project_name(self) -> str | None:
         return self._controller.get_current_project_name()
 
     def get_task_sorting_mode(self, project_name: str | None) -> TaskSortMode:
         return self._controller.get_task_sorting_mode(project_name)
 
-    def get_folder_items(self, project_name, sender=None):
+    def get_folder_items(
+        self, project_name: str, sender: str | None = None
+    ) -> dict[str, FolderItem]:
         return self._controller.get_folder_items(project_name, sender)
 
-    def get_task_items(self, project_name, folder_id, sender=None):
+    def get_task_items(
+        self, project_name: str, folder_id: str, sender: str | None = None
+    ) -> list[TaskItem]:
         return self._controller.get_task_items(
             project_name, folder_id, sender
         )
 
-    def get_folder_type_items(self, project_name, sender=None):
+    def get_folder_type_items(
+        self, project_name: str, sender: str | None = None
+    ) -> list[FolderTypeItem]:
         return self._controller.get_folder_type_items(
             project_name, sender
         )
 
-    def get_task_type_items(self, project_name, sender=None):
+    def get_task_type_items(
+        self, project_name: str, sender: str | None = None
+    ) -> list[TaskTypeItem]:
         return self._controller.get_task_type_items(
             project_name, sender
         )
 
     # Selection model
-    def set_selected_project(self, project_name):
+    def set_selected_project(
+        self, project_name: str
+    ):
         self._selection_model.set_selected_project(project_name)
 
-    def set_selected_folder(self, folder_id):
+    def set_selected_folder(self, folder_id: str | None) -> None:
         self._selection_model.set_selected_folder(folder_id)
 
-    def set_selected_task(self, task_id, task_name):
+    def set_selected_task(self, task_id: str, task_name: str) -> None:
         self._selection_model.set_selected_task(task_id, task_name)
 
     # Expected selection
-    def get_expected_selection_data(self):
+    def get_expected_selection_data(self) -> dict[str, Any]:
         return self._expected_selection.get_expected_selection_data()
 
-    def set_expected_selection(self, project_name, folder_id, task_name):
+    def set_expected_selection(
+        self,
+        project_name: str,
+        folder_id: str | None,
+        task_name: str | None,
+    ) -> None:
         self._expected_selection.set_expected_selection(
             project_name, folder_id, task_name
         )
 
-    def expected_folder_selected(self, folder_id):
-        self._expected_selection.expected_folder_selected(folder_id)
+    def expected_folder_selected(self, folder_id: str) -> bool:
+        return self._expected_selection.expected_folder_selected(folder_id)
 
-    def expected_task_selected(self, folder_id, task_name):
-        self._expected_selection.expected_task_selected(folder_id, task_name)
+    def expected_task_selected(self, folder_id: str, task_name: str) -> bool:
+        return self._expected_selection.expected_task_selected(
+            folder_id, task_name
+        )
 
 
 class CreateContextWidget(QtWidgets.QWidget):
     folder_changed = QtCore.Signal()
     task_changed = QtCore.Signal()
 
-    def __init__(self, controller: AbstractPublisherFrontend, parent):
+    def __init__(
+        self,
+        controller: AbstractPublisherFrontend,
+        parent: QtWidgets.QWidget,
+    ) -> None:
         super().__init__(parent)
 
         self._controller: AbstractPublisherFrontend = controller
-        self._enabled = True
-        self._last_project_name = None
-        self._last_folder_id = None
-        self._last_selected_task_name = None
+        self._enabled: bool = True
+        self._last_project_name: str | None = None
+        self._last_folder_id: str | None = None
+        self._last_selected_task_name: str | None = None
 
         headers_widget = QtWidgets.QWidget(self)
 
@@ -237,34 +272,36 @@ class CreateContextWidget(QtWidgets.QWidget):
         self._tasks_widget = tasks_widget
         self._hierarchy_controller = hierarchy_controller
 
-    def get_selected_folder_id(self):
+    def get_selected_folder_id(self) -> str | None:
         return self._folders_widget.get_selected_folder_id()
 
-    def get_selected_folder_path(self):
+    def get_selected_folder_path(self) -> str | None:
         return self._folders_widget.get_selected_folder_path()
 
-    def get_selected_task_name(self):
+    def get_selected_task_name(self) -> str | None:
         return self._tasks_widget.get_selected_task_name()
 
-    def get_selected_task_type(self):
+    def get_selected_task_type(self) -> str | None:
         return self._tasks_widget.get_selected_task_type()
 
-    def update_current_context_btn(self):
+    def update_current_context_btn(self) -> None:
         # Hide set current folder if there is no one
         folder_path = self._controller.get_current_folder_path()
         self._current_context_btn.setVisible(bool(folder_path))
 
-    def set_selected_context(self, folder_id, task_name):
+    def set_selected_context(
+        self, folder_id: str | None, task_name: str | None
+    ) -> None:
         self._hierarchy_controller.set_expected_selection(
             self._controller.get_current_project_name(),
             folder_id,
             task_name
         )
 
-    def is_enabled(self):
+    def is_enabled(self) -> bool:
         return self._enabled
 
-    def set_enabled(self, enabled):
+    def set_enabled(self, enabled: bool) -> None:
         if enabled is self._enabled:
             return
 
@@ -286,7 +323,7 @@ class CreateContextWidget(QtWidgets.QWidget):
                 self._last_selected_task_name
             )
 
-    def refresh(self):
+    def refresh(self) -> None:
         self._last_project_name = self._controller.get_current_project_name()
         folder_id = self._last_folder_id
         task_name = self._last_selected_task_name
@@ -306,16 +343,16 @@ class CreateContextWidget(QtWidgets.QWidget):
             self._filters_widget.is_my_tasks_checked()
         )
 
-    def _clear_selection(self):
+    def _clear_selection(self) -> None:
         self._folders_widget.set_selected_folder(None)
 
-    def _on_folder_change(self):
+    def _on_folder_change(self) -> None:
         self.folder_changed.emit()
 
-    def _on_task_change(self):
+    def _on_task_change(self) -> None:
         self.task_changed.emit()
 
-    def _on_current_context_click(self):
+    def _on_current_context_click(self) -> None:
         folder_path = self._controller.get_current_folder_path()
         task_name = self._controller.get_current_task_name()
         folder_id = self._controller.get_folder_id_from_path(folder_path)

--- a/client/ayon_core/tools/publisher/widgets/create_widget.py
+++ b/client/ayon_core/tools/publisher/widgets/create_widget.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import re
 import collections
 import typing
-from typing import Optional, Union
+from typing import Union
 
 from qtpy import QtWidgets, QtCore, QtGui
 
@@ -47,7 +49,7 @@ class ResizeControlWidget(QtWidgets.QWidget):
 
 # TODO add creator identifier/label to details
 class CreatorShortDescWidget(QtWidgets.QWidget):
-    def __init__(self, parent=None):
+    def __init__(self, parent: QtWidgets.QWidget) -> None:
         super().__init__(parent=parent)
 
         # --- Short description widget ---
@@ -87,8 +89,8 @@ class CreatorShortDescWidget(QtWidgets.QWidget):
 
     def set_creator_item(
         self,
-        creator_item: Optional["CreatorItem"] = None,
-        product_type: Optional[str] = None,
+        creator_item: CreatorItem | None = None,
+        product_type: str | None = None,
     ) -> None:
         if not creator_item:
             self._icon_widget.set_icon_def(None)
@@ -122,7 +124,11 @@ class CreatorsProxyModel(QtCore.QSortFilterProxyModel):
 
 
 class CreateWidget(QtWidgets.QWidget):
-    def __init__(self, controller, parent=None):
+    def __init__(
+        self,
+        controller: AbstractPublisherFrontend,
+        parent: QtWidgets.QWidget,
+    ) -> None:
         super().__init__(parent)
 
         self._controller: AbstractPublisherFrontend = controller
@@ -134,7 +140,7 @@ class CreateWidget(QtWidgets.QWidget):
 
         self._prereq_available = False
 
-        name_pattern = "^[{}]*$".format(PRODUCT_NAME_ALLOWED_SYMBOLS)
+        name_pattern = f"^[{PRODUCT_NAME_ALLOWED_SYMBOLS}]*$"
         self._name_pattern = name_pattern
         self._compiled_name_pattern = re.compile(name_pattern)
 
@@ -316,28 +322,28 @@ class CreateWidget(QtWidgets.QWidget):
         self._use_current_context = True
         self._current_creator_variant_hints = []
 
-    def get_current_folder_path(self):
+    def get_current_folder_path(self) -> str | None:
         return self._controller.get_current_folder_path()
 
-    def get_current_task_name(self):
+    def get_current_task_name(self) -> str | None:
         return self._controller.get_current_task_name()
 
-    def _context_change_is_enabled(self):
+    def _context_change_is_enabled(self) -> bool:
         return self._context_widget.is_enabled()
 
-    def _get_folder_path(self):
+    def _get_folder_path(self) -> str | None:
         folder_path = None
         if self._context_change_is_enabled():
             folder_path = self._context_widget.get_selected_folder_path()
         return folder_path or None
 
-    def _get_folder_id(self):
+    def _get_folder_id(self) -> str | None:
         folder_id = None
         if self._context_widget.is_enabled():
             folder_id = self._context_widget.get_selected_folder_id()
         return folder_id
 
-    def _get_task_name(self):
+    def _get_task_name(self) -> str | None:
         task_name = None
         if self._context_change_is_enabled():
             # Don't use selection of task if folder is not set
@@ -346,19 +352,19 @@ class CreateWidget(QtWidgets.QWidget):
                 task_name = self._context_widget.get_selected_task_name()
         return task_name
 
-    def _set_context_enabled(self, enabled):
+    def _set_context_enabled(self, enabled: bool) -> None:
         check_prereq = self._context_widget.is_enabled() != enabled
         self._context_widget.set_enabled(enabled)
         if check_prereq:
             self._invalidate_prereq()
 
-    def _on_main_window_close(self):
+    def _on_main_window_close(self) -> None:
         """Publisher window was closed."""
 
         # Use current context on next refresh
         self._use_current_context = True
 
-    def refresh(self):
+    def refresh(self) -> None:
         current_folder_path = self._controller.get_current_folder_path()
         current_task_name = self._controller.get_current_task_name()
 
@@ -405,10 +411,10 @@ class CreateWidget(QtWidgets.QWidget):
 
         self._invalidate_prereq_deffered()
 
-    def _invalidate_prereq_deffered(self):
+    def _invalidate_prereq_deffered(self) -> None:
         self._prereq_timer.start()
 
-    def _invalidate_prereq(self):
+    def _invalidate_prereq(self) -> None:
         prereq_available = True
         creator_btn_tooltips = []
 
@@ -442,7 +448,7 @@ class CreateWidget(QtWidgets.QWidget):
 
         self._on_variant_change()
 
-    def _refresh_product_name(self):
+    def _refresh_product_name(self) -> None:
         folder_path = self._get_folder_path()
 
         # Skip if folder did not change
@@ -463,7 +469,7 @@ class CreateWidget(QtWidgets.QWidget):
         if product_names is None:
             self.product_name_input.setText("< Folder is not set >")
 
-    def _refresh_creators(self):
+    def _refresh_creators(self) -> None:
         # Refresh creators and add their product base types to list
         existing_items = collections.defaultdict(dict)
         for row in range(self._creators_model.rowCount()):
@@ -535,11 +541,11 @@ class CreateWidget(QtWidgets.QWidget):
 
         self._set_creator(create_item, product_type)
 
-    def _on_controler_reset(self):
+    def _on_controler_reset(self) -> None:
         # Trigger refresh only if is visible
         self.refresh()
 
-    def _pre_create_attr_changed(self, event):
+    def _pre_create_attr_changed(self, event) -> None:
         if (
             self._selected_creator_identifier is None
             or self._selected_creator_identifier not in event["identifiers"]
@@ -551,20 +557,20 @@ class CreateWidget(QtWidgets.QWidget):
             self._selected_product_type,
         )
 
-    def _on_folder_change(self):
+    def _on_folder_change(self) -> None:
         self._refresh_product_name()
         if self._context_change_is_enabled():
             self._invalidate_prereq_deffered()
 
-    def _on_task_change(self):
+    def _on_task_change(self) -> None:
         if self._context_change_is_enabled():
             self._invalidate_prereq_deffered()
 
-    def _on_thumbnail_create(self, thumbnail_path):
+    def _on_thumbnail_create(self, thumbnail_path: str) -> None:
         self._last_thumbnail_path = thumbnail_path
         self._thumbnail_widget.set_current_thumbnails([thumbnail_path])
 
-    def _on_thumbnail_clear(self):
+    def _on_thumbnail_clear(self) -> None:
         self._last_thumbnail_path = None
 
     def _on_creator_item_change(self, new_index, _old_index):
@@ -575,7 +581,9 @@ class CreateWidget(QtWidgets.QWidget):
             product_type = new_index.data(PRODUCT_TYPE_ROLE)
         self._set_creator_by_identifier(identifier, product_type)
 
-    def _set_creator_detailed_text(self, creator_item):
+    def _set_creator_detailed_text(
+        self, creator_item: CreatorItem | None
+    ) -> None:
         # TODO implement
         description = ""
         if creator_item is not None:
@@ -590,8 +598,8 @@ class CreateWidget(QtWidgets.QWidget):
 
     def _set_creator_by_identifier(
         self,
-        identifier: Union[str, None],
-        product_type: Union[str, None],
+        identifier: str | None,
+        product_type: str | None,
     ) -> None:
         creator_item = self._controller.get_creator_item_by_id(
             identifier
@@ -600,8 +608,8 @@ class CreateWidget(QtWidgets.QWidget):
 
     def _set_creator(
         self,
-        creator_item: Union["CreatorItem", None],
-        product_type: Union[str, None],
+        creator_item: CreatorItem | None,
+        product_type: str | None,
     ) -> None:
         """Set current creator item.
 
@@ -655,7 +663,7 @@ class CreateWidget(QtWidgets.QWidget):
         else:
             self._variant_widget.setText(variant_text)
 
-    def _on_variant_change(self, variant_value=None):
+    def _on_variant_change(self, variant_value: str | None = None) -> None:
         if not self._prereq_available:
             return
 
@@ -702,7 +710,9 @@ class CreateWidget(QtWidgets.QWidget):
         self._create_btn.setEnabled(True)
         self._validate_product_name(product_name, variant_value)
 
-    def _validate_product_name(self, product_name, variant_value):
+    def _validate_product_name(
+        self, product_name: str, variant_value: str
+    ) -> None:
         # Get all products of the current folder
         if self._product_names:
             existing_product_names = set(self._product_names)
@@ -749,10 +759,11 @@ class CreateWidget(QtWidgets.QWidget):
         if variant_is_valid != self._create_btn.isEnabled():
             self._create_btn.setEnabled(variant_is_valid)
 
-    def _set_variant_state_property(self, state):
+    def _set_variant_state_property(self, state: str) -> None:
+        # "" | "empty" | "exists" | "new" | "invalid"
         self._variant_widget.set_text_widget_property("state", state)
 
-    def _on_first_show(self):
+    def _on_first_show(self) -> None:
         width = self.width()
         part = int(width / 9)
         context_width = part * 3
@@ -762,18 +773,18 @@ class CreateWidget(QtWidgets.QWidget):
         rem_width -= create_sel_width
         self._creators_splitter.setSizes([create_sel_width, rem_width])
 
-    def showEvent(self, event):
+    def showEvent(self, event) -> None:
         super().showEvent(event)
         if self._first_show:
             self._first_show = False
             self._on_first_show()
 
-    def _on_creator_basics_resize(self):
+    def _on_creator_basics_resize(self) -> None:
         self._thumbnail_widget.set_height(
             self._creator_basics_widget.sizeHint().height()
         )
 
-    def _on_create(self):
+    def _on_create(self) -> None:
         indexes = self._creators_view.selectedIndexes()
         if not indexes or len(indexes) > 1:
             return

--- a/client/ayon_core/tools/publisher/widgets/create_widget.py
+++ b/client/ayon_core/tools/publisher/widgets/create_widget.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import re
 import collections
 import typing
-from typing import Union
 
 from qtpy import QtWidgets, QtCore, QtGui
 

--- a/client/ayon_core/tools/publisher/widgets/folders_dialog.py
+++ b/client/ayon_core/tools/publisher/widgets/folders_dialog.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+import typing
+from typing import Any, Callable
+
 from qtpy import QtWidgets
 
 from ayon_core.lib.events import QueuedEventSystem
@@ -7,42 +12,54 @@ from ayon_core.tools.utils import (
 )
 from ayon_core.tools.publisher.abstract import AbstractPublisherFrontend
 
+if typing.TYPE_CHECKING:
+    from ayon_core.tools.common_models import FolderItem, FolderTypeItem
+
 
 class FoldersDialogController:
     def __init__(self, controller: AbstractPublisherFrontend):
-        self._event_system = QueuedEventSystem()
+        self.event_system = QueuedEventSystem()
         self._controller: AbstractPublisherFrontend = controller
 
-    @property
-    def event_system(self):
-        return self._event_system
-
-    def emit_event(self, topic, data=None, source=None):
+    def emit_event(
+        self,
+        topic: str,
+        data: dict[str, Any] | None = None,
+        source: str | None = None,
+    ) -> None:
         """Use implemented event system to trigger event."""
 
         if data is None:
             data = {}
         self.event_system.emit(topic, data, source)
 
-    def register_event_callback(self, topic, callback):
+    def register_event_callback(self, topic: str, callback: Callable) -> None:
         self.event_system.add_callback(topic, callback)
 
-    def get_folder_items(self, project_name, sender=None):
+    def get_folder_items(
+        self, project_name: str, sender: str | None = None
+    ) -> dict[str, FolderItem]:
         return self._controller.get_folder_items(project_name, sender)
 
-    def get_folder_type_items(self, project_name, sender=None):
+    def get_folder_type_items(
+        self, project_name: str, sender: str | None = None
+    ) -> list[FolderTypeItem]:
         return self._controller.get_folder_type_items(
             project_name, sender
         )
 
-    def set_selected_folder(self, folder_id):
+    def set_selected_folder(self, folder_id: str) -> None:
         pass
 
 
 class FoldersDialog(QtWidgets.QDialog):
     """Dialog to select folder for a context of instance."""
 
-    def __init__(self, controller, parent):
+    def __init__(
+        self,
+        controller: AbstractPublisherFrontend,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Select folder")
 
@@ -83,16 +100,16 @@ class FoldersDialog(QtWidgets.QDialog):
 
         self._folders_widget = folders_widget
 
-        self._selected_folder_path = None
+        self._selected_folder_path: str | None = None
         # Soft refresh is enabled
         # - reset will happen at all cost if soft reset is enabled
         # - adds ability to call reset on multiple places without repeating
-        self._soft_reset_enabled = True
+        self._soft_reset_enabled: bool = True
 
-        self._first_show = True
+        self._first_show: bool = True
         self._default_height = 500
 
-        self._project_name = None
+        self._project_name: str | None = None
 
     def showEvent(self, event):
         """Refresh folders widget on show."""
@@ -103,7 +120,7 @@ class FoldersDialog(QtWidgets.QDialog):
         # Refresh on show
         self.reset(False)
 
-    def reset(self, force=True):
+    def reset(self, force: bool = True) -> None:
         """Reset widget."""
         if not force and not self._soft_reset_enabled:
             return
@@ -115,11 +132,11 @@ class FoldersDialog(QtWidgets.QDialog):
         self._folders_widget.set_project_name(self._project_name)
         self._on_my_tasks_change(self._filters_widget.is_my_tasks_checked())
 
-    def get_selected_folder_path(self):
+    def get_selected_folder_path(self) -> str | None:
         """Get selected folder path."""
         return self._selected_folder_path
 
-    def set_selected_folders(self, folder_paths: list[str]) -> None:
+    def set_selected_folders(self, folder_paths: set[str]) -> None:
         """Change preselected folder before showing the dialog.
 
         This also resets model and clean filter.
@@ -136,7 +153,7 @@ class FoldersDialog(QtWidgets.QDialog):
         if folder_id:
             self._folders_widget.set_selected_folder(folder_id)
 
-    def _on_first_show(self):
+    def _on_first_show(self) -> None:
         center = self.rect().center()
         size = self.size()
         size.setHeight(self._default_height)
@@ -147,18 +164,18 @@ class FoldersDialog(QtWidgets.QDialog):
         new_pos.setY(new_pos.y() - int(self.height() / 2))
         self.move(new_pos)
 
-    def _on_controller_reset(self):
+    def _on_controller_reset(self) -> None:
         # Change reset enabled so model is reset on show event
         self._soft_reset_enabled = True
 
-    def _on_filter_change(self, text):
+    def _on_filter_change(self, text: str) -> None:
         """Trigger change of filter of folders."""
         self._folders_widget.set_name_filter(text)
 
-    def _on_cancel_clicked(self):
+    def _on_cancel_clicked(self) -> None:
         self.done(0)
 
-    def _on_ok_clicked(self):
+    def _on_ok_clicked(self) -> None:
         self._selected_folder_path = (
             self._folders_widget.get_selected_folder_path()
         )

--- a/client/ayon_core/tools/publisher/widgets/help_widget.py
+++ b/client/ayon_core/tools/publisher/widgets/help_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 try:
     import commonmark
 except Exception:
@@ -11,7 +13,7 @@ from ayon_core.tools.publisher.abstract import AbstractPublisherFrontend
 class HelpButton(QtWidgets.QPushButton):
     """Button used to trigger help dialog."""
 
-    def __init__(self, parent):
+    def __init__(self, parent: QtWidgets.QWidget) -> None:
         super().__init__(parent)
         self.setObjectName("CreateDialogHelpButton")
         self.setText("?")
@@ -20,7 +22,7 @@ class HelpButton(QtWidgets.QPushButton):
 class HelpWidget(QtWidgets.QWidget):
     """Widget showing help for single functionality."""
 
-    def __init__(self, parent):
+    def __init__(self, parent: QtWidgets.QWidget) -> None:
         super().__init__(parent)
 
         # TODO add hints what to help with?
@@ -39,7 +41,7 @@ class HelpWidget(QtWidgets.QWidget):
 
         self.set_detailed_text()
 
-    def set_detailed_text(self, text=None):
+    def set_detailed_text(self, text: str | None = None) -> None:
         if not text:
             text = "We didn't prepare help for this part..."
 
@@ -58,7 +60,7 @@ class HelpDialog(QtWidgets.QDialog):
 
     def __init__(
         self, controller: AbstractPublisherFrontend, parent: QtWidgets.QWidget
-    ):
+    ) -> None:
         super().__init__(parent)
 
         self.setWindowTitle("Help dialog")
@@ -76,13 +78,13 @@ class HelpDialog(QtWidgets.QDialog):
 
         self._help_content = help_content
 
-    def _on_help_request(self, event):
+    def _on_help_request(self, event) -> None:
         message = event.get("message")
         self.set_detailed_text(message)
 
-    def set_detailed_text(self, text=None):
+    def set_detailed_text(self, text: str | None = None) -> None:
         self._help_content.set_detailed_text(text)
 
-    def showEvent(self, event):
+    def showEvent(self, event) -> None:
         super().showEvent(event)
         self.resize(self.default_width, self.default_height)

--- a/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/list_view_widgets.py
@@ -54,7 +54,7 @@ from ayon_core.tools.publisher.constants import (
     CONVERTOR_ITEM_GROUP,
 )
 
-from .widgets import AbstractInstanceView
+from .widgets import AbstractInstanceView, InstancesSelection
 
 
 class ListItemDelegate(QtWidgets.QStyledItemDelegate):
@@ -1011,7 +1011,9 @@ class InstanceListView(AbstractInstanceView):
 
         self._missing_parent_item = None
 
-    def refresh_instance_states(self, instance_ids=None):
+    def refresh_instance_states(
+        self, instance_ids: set[str] | None = None
+    ) -> None:
         """Trigger update of all instances."""
         if instance_ids is not None:
             instance_ids = set(instance_ids)
@@ -1076,14 +1078,16 @@ class InstanceListView(AbstractInstanceView):
     def set_parent_grouping(self, parent_grouping: bool) -> None:
         self._parent_grouping = parent_grouping
 
-    def _on_active_changed(self, changed_instance_id, new_value):
+    def _on_active_changed(
+        self, changed_instance_id: str, new_value: bool
+    ) -> None:
         self._toggle_active_state(new_value, changed_instance_id)
 
     def _toggle_active_state(
         self,
-        new_value: Optional[bool],
-        active_id: Optional[str] = None,
-        instance_ids: Optional[set[str]] = None,
+        new_value: bool | None,
+        active_id: str | None = None,
+        instance_ids: set[str] | None = None,
     ) -> None:
         if instance_ids is None:
             instance_ids, _, _ = self.get_selected_items()
@@ -1126,7 +1130,7 @@ class InstanceListView(AbstractInstanceView):
     def _on_selection_change(self, *_args):
         self.selection_changed.emit()
 
-    def _on_expand_toggle_request(self, group_name):
+    def _on_expand_toggle_request(self, group_name: str) -> None:
         group_item = self._group_items.get(group_name)
         if not group_item:
             return
@@ -1134,7 +1138,9 @@ class InstanceListView(AbstractInstanceView):
         new_state = not self._instance_view.isExpanded(proxy_index)
         self._instance_view.setExpanded(proxy_index, new_state)
 
-    def _on_group_toggle_request(self, group_name, state):
+    def _on_group_toggle_request(
+        self, group_name: str, state: int | QtCore.Qt.CheckState
+    ) -> None:
         state = checkstate_int_to_enum(state)
         if state == QtCore.Qt.PartiallyChecked:
             return
@@ -1164,46 +1170,34 @@ class InstanceListView(AbstractInstanceView):
             return True
         return False
 
-    def get_selected_items(self) -> tuple[list[str], bool, list[str]]:
+    def get_selected_items(self) -> InstancesSelection:
         """Get selected instance ids and context selection.
 
         Returns:
-            tuple[list[str], bool, list[str]]: Selected instance ids,
-                boolean if context is selected and selected convertor ids.
+            InstancesSelection: Selected instance ids, boolean if context is
+                selected and selected convertor ids.
 
         """
-        instance_ids = []
-        convertor_identifiers = []
-        context_selected = False
+        output = InstancesSelection()
 
         for index in self._instance_view.selectionModel().selectedIndexes():
             convertor_identifier = index.data(CONVERTER_IDENTIFIER_ROLE)
             if convertor_identifier is not None:
-                convertor_identifiers.append(convertor_identifier)
+                output.convertor_identifiers.add(convertor_identifier)
                 continue
 
             instance_id = index.data(INSTANCE_ID_ROLE)
-            if not context_selected and instance_id == CONTEXT_ID:
-                context_selected = True
+            if not output.context_selected and instance_id == CONTEXT_ID:
+                output.context_selected = True
 
             elif instance_id is not None:
-                instance_ids.append(instance_id)
+                output.instance_ids.add(instance_id)
 
-        return instance_ids, context_selected, convertor_identifiers
+        return output
 
-    def set_selected_items(
-        self, instance_ids, context_selected, convertor_identifiers
-    ):
-        s_instance_ids = set(instance_ids)
-        s_convertor_identifiers = set(convertor_identifiers)
-        cur_ids, cur_context, cur_convertor_identifiers = (
-            self.get_selected_items()
-        )
-        if (
-            set(cur_ids) == s_instance_ids
-            and cur_context == context_selected
-            and set(cur_convertor_identifiers) == s_convertor_identifiers
-        ):
+    def set_selected_items(self, selection: InstancesSelection) -> None:
+        current_selection = self.get_selected_items()
+        if selection == current_selection:
             return
 
         view = self._instance_view
@@ -1233,16 +1227,16 @@ class InstanceListView(AbstractInstanceView):
             select = False
             expand_parent = True
             if convertor_identifier is not None:
-                if convertor_identifier in s_convertor_identifiers:
+                if convertor_identifier in selection.convertor_identifiers:
                     select = True
             else:
                 instance_id = item.data(INSTANCE_ID_ROLE)
                 if instance_id == CONTEXT_ID:
-                    if context_selected:
+                    if selection.context_selected:
                         select = True
                         expand_parent = False
 
-                elif instance_id in s_instance_ids:
+                elif instance_id in selection.instance_ids:
                     select = True
 
             if not select:

--- a/client/ayon_core/tools/publisher/widgets/overview_widget.py
+++ b/client/ayon_core/tools/publisher/widgets/overview_widget.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing
 from typing import Generator
 
 from qtpy import QtWidgets, QtCore
@@ -17,6 +18,9 @@ from .widgets import (
 )
 from .create_widget import CreateWidget
 from .product_info import ProductInfoWidget
+
+if typing.TYPE_CHECKING:
+    from .widgets import InstancesSelection
 
 
 class OverviewWidget(QtWidgets.QFrame):
@@ -282,7 +286,8 @@ class OverviewWidget(QtWidgets.QFrame):
         self.create_requested.emit()
 
     def _on_delete_clicked(self):
-        instance_ids, _, _ = self.get_selected_items()
+        selection = self.get_selected_items()
+        instance_ids = selection.instance_ids
 
         # Ask user if he really wants to remove instances
         dialog = QtWidgets.QMessageBox(self)
@@ -316,24 +321,25 @@ class OverviewWidget(QtWidgets.QFrame):
         if self._refreshing_instances:
             return
 
-        instance_ids, context_selected, convertor_identifiers = (
-            self.get_selected_items()
-        )
+        selection = self.get_selected_items()
 
         # Disable delete button if nothing is selected
-        self._delete_btn.setEnabled(len(instance_ids) > 0)
+        self._delete_btn.setEnabled(len(selection.instance_ids) > 0)
         instances_by_id = self._controller.get_instance_items_by_id(
-            instance_ids
+            selection.instance_ids
         )
         instances = [
             instances_by_id[instance_id]
-            for instance_id in instance_ids
+            for instance_id in selection.instance_ids
         ]
+        # TODO find out if we can just pass in 'selection'
         self._product_attributes_widget.set_current_instances(
-            instances, context_selected, convertor_identifiers
+            instances,
+            selection.context_selected,
+            selection.convertor_identifiers,
         )
 
-    def _on_change_anim(self, value):
+    def _on_change_anim(self, value: float) -> None:
         self._create_widget.setVisible(True)
         self._product_attributes_wrap.setVisible(True)
         layout_spacing = self._product_content_layout.spacing()
@@ -364,7 +370,7 @@ class OverviewWidget(QtWidgets.QFrame):
         self._create_widget.setGeometry(create_geo)
         self._product_attributes_wrap.setGeometry(product_attrs_geo)
 
-    def _on_change_anim_finished(self):
+    def _on_change_anim_finished(self) -> None:
         self._change_visibility_for_state()
         self._product_content_layout.addWidget(self._create_widget, 7)
         self._product_content_layout.addWidget(self._product_views_widget, 3)
@@ -372,7 +378,7 @@ class OverviewWidget(QtWidgets.QFrame):
             self._product_attributes_wrap, 7
         )
 
-    def _change_visibility_for_state(self):
+    def _change_visibility_for_state(self) -> None:
         self._create_widget.setVisible(
             self._current_state == "create"
         )
@@ -380,16 +386,16 @@ class OverviewWidget(QtWidgets.QFrame):
             self._current_state == "publish"
         )
 
-    def _on_instance_context_change(self, event):
+    def _on_instance_context_change(self, event) -> None:
         self._refresh_instance_states(event["instance_ids"])
 
-    def _on_instance_requirement_changed(self, event):
+    def _on_instance_requirement_changed(self, event) -> None:
         self._refresh_instance_states(event["instance_ids"])
 
-    def _on_instance_parent_changed(self, event):
+    def _on_instance_parent_changed(self, event) -> None:
         self._refresh_instance_states(event["instance_ids"])
 
-    def _refresh_instance_states(self, instance_ids):
+    def _refresh_instance_states(self, instance_ids: set[str]) -> None:
         current_view = self._get_current_view()
         for view in self._iter_views():
             if view is current_view:
@@ -399,14 +405,14 @@ class OverviewWidget(QtWidgets.QFrame):
 
         current_view.refresh_instance_states(instance_ids)
 
-    def _on_convert_requested(self):
+    def _on_convert_requested(self) -> None:
         self.convert_requested.emit()
 
-    def get_selected_items(self):
+    def get_selected_items(self) -> InstancesSelection:
         """Selected items in current view widget.
 
         Returns:
-            tuple[list[str], bool, list[str]]: Selected items. List of
+            InstancesSelection: Selected items. List of
                 instance ids, context is selected, list of selected legacy
                 convertor plugins.
         """
@@ -414,18 +420,18 @@ class OverviewWidget(QtWidgets.QFrame):
         view = self._get_current_view()
         return view.get_selected_items()
 
-    def get_selected_legacy_convertors(self):
+    def get_selected_legacy_convertors(self) -> set[str]:
         """Selected legacy convertor identifiers.
 
         Returns:
-            list[str]: Selected legacy convertor identifiers.
+            set[str]: Selected legacy convertor identifiers.
                 Example: ['io.ayon.creators.houdini.legacy']
         """
 
-        _, _, convertor_identifiers = self.get_selected_items()
-        return convertor_identifiers
+        selection = self.get_selected_items()
+        return selection.convertor_identifiers
 
-    def _change_view_type(self):
+    def _change_view_type(self) -> None:
         old_view = self._get_current_view()
 
         idx = self._product_views_layout.currentIndex()
@@ -438,12 +444,8 @@ class OverviewWidget(QtWidgets.QFrame):
         else:
             new_view.refresh_instance_states()
 
-        instance_ids, context_selected, convertor_identifiers = (
-            old_view.get_selected_items()
-        )
-        new_view.set_selected_items(
-            instance_ids, context_selected, convertor_identifiers
-        )
+        new_view.set_selected_items(old_view.get_selected_items())
+
         view_type = "list"
         if new_view is self._product_list_view_grouped:
             view_type = "card"
@@ -480,7 +482,7 @@ class OverviewWidget(QtWidgets.QFrame):
             "Current widget is not instance of 'AbstractInstanceView'"
         )
 
-    def _refresh_instances(self):
+    def _refresh_instances(self) -> None:
         if self._refreshing_instances:
             return
 
@@ -503,7 +505,7 @@ class OverviewWidget(QtWidgets.QFrame):
         # Trigger update geometry
         view.updateGeometry()
 
-    def _on_publish_start(self):
+    def _on_publish_start(self) -> None:
         """Publish started."""
 
         self._create_btn.setEnabled(False)
@@ -511,13 +513,13 @@ class OverviewWidget(QtWidgets.QFrame):
         for view in self._iter_views():
             view.set_active_toggle_enabled(False)
 
-    def _on_controller_reset_start(self):
+    def _on_controller_reset_start(self) -> None:
         """Controller reset started."""
 
         for view in self._iter_views():
             view.set_active_toggle_enabled(True)
 
-    def _on_publish_reset(self):
+    def _on_publish_reset(self) -> None:
         """Context in controller has been reseted."""
 
         self._create_btn.setEnabled(True)
@@ -526,10 +528,10 @@ class OverviewWidget(QtWidgets.QFrame):
             self._controller.is_host_valid()
         )
 
-    def _on_create_model_reset(self):
+    def _on_create_model_reset(self) -> None:
         self._refresh_instances()
 
-    def _on_instances_added(self):
+    def _on_instances_added(self) -> None:
         view = self._get_current_view()
         is_card_view = False
         count = 0
@@ -544,5 +546,5 @@ class OverviewWidget(QtWidgets.QFrame):
             if new_count > count and new_count >= 10:
                 self._change_view_type()
 
-    def _on_instances_removed(self):
+    def _on_instances_removed(self) -> None:
         self._refresh_instances()

--- a/client/ayon_core/tools/publisher/widgets/precreate_widget.py
+++ b/client/ayon_core/tools/publisher/widgets/precreate_widget.py
@@ -1,18 +1,29 @@
 from __future__ import annotations
 
+from typing import Any
+
 from qtpy import QtWidgets, QtCore
 
 from ayon_core.lib import AbstractAttrDef, ButtonDef, UILabelDef
-
-from ayon_core.tools.attribute_defs import create_widget_for_attr_def
+from ayon_core.tools.attribute_defs import (
+    BaseAttrDefWidget,
+    create_widget_for_attr_def,
+)
+from ayon_core.tools.publisher.abstract import AbstractPublisherFrontend
+from ayon_core.tools.publisher.constants import (
+    INPUTS_LAYOUT_HSPACING,
+    INPUTS_LAYOUT_VSPACING,
+)
 
 from .utils import PreCreateButtonCallback
 
-from ..constants import INPUTS_LAYOUT_HSPACING, INPUTS_LAYOUT_VSPACING
-
 
 class PreCreateWidget(QtWidgets.QWidget):
-    def __init__(self, controller, parent):
+    def __init__(
+        self,
+        controller: AbstractPublisherFrontend,
+        parent: QtWidgets.QWidget,
+    ) -> None:
         super().__init__(parent)
 
         # Precreate attribute defininitions of Creator
@@ -86,7 +97,11 @@ class PreCreateWidget(QtWidgets.QWidget):
 
 
 class AttributesWidget(QtWidgets.QWidget):
-    def __init__(self, controller, parent=None):
+    def __init__(
+        self,
+        controller: AbstractPublisherFrontend,
+        parent: QtWidgets.QWidget,
+    ) -> None:
         super().__init__(parent)
 
         layout = QtWidgets.QGridLayout(self)
@@ -96,11 +111,11 @@ class AttributesWidget(QtWidgets.QWidget):
         layout.setColumnStretch(0, 0)
         layout.setColumnStretch(1, 1)
 
-        self._controller = controller
-        self._layout = layout
-        self._widgets = []
+        self._controller: AbstractPublisherFrontend = controller
+        self._layout: QtWidgets.QGridLayout = layout
+        self._widgets: list[BaseAttrDefWidget] = []
 
-    def current_value(self):
+    def current_value(self) -> dict[str, Any]:
         output = {}
         for widget in self._widgets:
             attr_def = widget.attr_def
@@ -108,7 +123,7 @@ class AttributesWidget(QtWidgets.QWidget):
                 output[attr_def.key] = widget.current_value()
         return output
 
-    def clear_attr_defs(self):
+    def clear_attr_defs(self) -> None:
         while self._layout.count():
             item = self._layout.takeAt(0)
             widget = item.widget()

--- a/client/ayon_core/tools/publisher/widgets/product_context.py
+++ b/client/ayon_core/tools/publisher/widgets/product_context.py
@@ -29,7 +29,11 @@ from .tasks_model import TasksModel
 from .widgets import ClickableLineEdit, MultipleItemWidget
 
 if typing.TYPE_CHECKING:
+    from typing import Literal
+
     from ayon_core.tools.publisher.abstract import InstanceItem
+
+    StyleState = Literal["", "invalid"]
 
 
 class FoldersFields(BaseClickableFrame):
@@ -82,12 +86,20 @@ class FoldersFields(BaseClickableFrame):
         self._name_input = name_input
         self._icon_btn = icon_btn
 
-        self._origin_value = []
-        self._origin_selection = []
-        self._selected_items = []
+        self._origin_value = set()
+        self._origin_selection = set()
+        self._selected_items = set()
         self._has_value_changed = False
         self._is_valid = True
         self._multiselection_text = None
+
+    def set_multiselection_text(self, text: str) -> None:
+        """Change text for multiselection of different folders.
+
+        When there are selected multiple instances at once and they don't have
+        same folder in context.
+        """
+        self._multiselection_text = text
 
     def _on_dialog_finish(self, result):
         if not result:
@@ -97,7 +109,7 @@ class FoldersFields(BaseClickableFrame):
         if folder_path is None:
             return
 
-        self._selected_items = [folder_path]
+        self._selected_items = {folder_path}
         self._has_value_changed = (
             self._origin_value != self._selected_items
         )
@@ -110,41 +122,33 @@ class FoldersFields(BaseClickableFrame):
         self._dialog.set_selected_folders(self._selected_items)
         self._dialog.open()
 
-    def set_multiselection_text(self, text):
-        """Change text for multiselection of different folders.
-
-        When there are selected multiple instances at once and they don't have
-        same folder in context.
-        """
-        self._multiselection_text = text
-
-    def _set_is_valid(self, valid):
+    def _set_is_valid(self, valid: bool) -> None:
         if valid == self._is_valid:
             return
         self._is_valid = valid
-        state = ""
+        state: StyleState = ""
         if not valid:
             state = "invalid"
         self._set_state_property(state)
 
-    def _set_state_property(self, state):
+    def _set_state_property(self, state: StyleState) -> None:
         set_style_property(self, "state", state)
         set_style_property(self._name_input, "state", state)
         set_style_property(self._icon_btn, "state", state)
 
-    def is_valid(self):
+    def is_valid(self) -> bool:
         """Is folder valid."""
         return self._is_valid
 
-    def has_value_changed(self):
+    def has_value_changed(self) -> bool:
         """Value of folder has changed."""
         return self._has_value_changed
 
-    def get_selected_items(self):
+    def get_selected_items(self) -> set[str]:
         """Selected folder paths."""
-        return list(self._selected_items)
+        return set(self._selected_items)
 
-    def set_text(self, text):
+    def set_text(self, text: str) -> None:
         """Set text in text field.
 
         Does not change selected items (folders).
@@ -152,22 +156,24 @@ class FoldersFields(BaseClickableFrame):
         self._name_input.setText(text)
         self._name_input.end(False)
 
-    def set_selected_items(self, folder_paths=None):
+    def set_selected_items(
+        self, folder_paths: set[str] | None = None
+    ) -> None:
         """Set folder paths for selection of instances.
 
         Passed folder paths are validated and if there are 2 or more different
         folder paths then multiselection text is shown.
 
         Args:
-            folder_paths (list, tuple, set, NoneType): List of folder paths.
+            folder_paths (set[str] | None): Set of folder paths.
 
         """
         if folder_paths is None:
-            folder_paths = []
+            folder_paths = set()
 
         self._has_value_changed = False
-        self._origin_value = list(folder_paths)
-        self._selected_items = list(folder_paths)
+        self._origin_value = set(folder_paths)
+        self._selected_items = set(folder_paths)
         is_valid = self._controller.are_folder_paths_valid(folder_paths)
         if not folder_paths:
             self.set_text("")
@@ -183,11 +189,11 @@ class FoldersFields(BaseClickableFrame):
 
         self._set_is_valid(is_valid)
 
-    def reset_to_origin(self):
+    def reset_to_origin(self) -> None:
         """Change to folder paths set with last `set_selected_items` call."""
         self.set_selected_items(self._origin_value)
 
-    def confirm_value(self):
+    def confirm_value(self) -> None:
         self._origin_value = copy.deepcopy(self._selected_items)
         self._has_value_changed = False
 
@@ -356,7 +362,7 @@ class TasksCombobox(QtWidgets.QComboBox):
         """
         return list(self._selected_items)
 
-    def set_folder_paths(self, folder_paths):
+    def set_folder_paths(self, folder_paths: set[str]) -> None:
         """Set folder paths for which should show tasks."""
         self._ignore_index_change = True
 

--- a/client/ayon_core/tools/publisher/widgets/tabs_widget.py
+++ b/client/ayon_core/tools/publisher/widgets/tabs_widget.py
@@ -1,31 +1,36 @@
+from __future__ import annotations
+
 from qtpy import QtWidgets, QtCore
+
 from ayon_core.tools.utils import set_style_property
 
 
 class PublisherTabBtn(QtWidgets.QPushButton):
     tab_clicked = QtCore.Signal(str)
 
-    def __init__(self, identifier, label, parent):
+    def __init__(
+        self, identifier: str, label: str, parent: QtWidgets.QWidget
+    ) -> None:
         super().__init__(label, parent)
-        self._identifier = identifier
-        self._active = False
+        self._identifier: str = identifier
+        self._active: bool = False
 
         self.clicked.connect(self._on_click)
 
-    def _on_click(self):
+    def _on_click(self) -> None:
         self.tab_clicked.emit(self.identifier)
 
     @property
-    def identifier(self):
+    def identifier(self) -> str:
         return self._identifier
 
-    def activate(self):
+    def activate(self) -> None:
         if self._active:
             return
         self._active = True
         set_style_property(self, "active", "1")
 
-    def deactivate(self):
+    def deactivate(self) -> None:
         if not self._active:
             return
         self._active = False
@@ -35,7 +40,7 @@ class PublisherTabBtn(QtWidgets.QPushButton):
 class PublisherTabsWidget(QtWidgets.QFrame):
     tab_changed = QtCore.Signal(str, str)
 
-    def __init__(self, parent=None):
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
         super().__init__(parent)
 
         btns_widget = QtWidgets.QWidget(self)
@@ -50,18 +55,18 @@ class PublisherTabsWidget(QtWidgets.QFrame):
 
         self._btns_layout = btns_layout
 
-        self._current_identifier = None
-        self._buttons_by_identifier = {}
+        self._current_identifier: str | None = None
+        self._buttons_by_identifier: dict[str, PublisherTabBtn] = {}
 
-    def is_current_tab(self, identifier):
-        if isinstance(identifier, int):
-            identifier = self.get_tab_by_index(identifier)
-
-        if isinstance(identifier, PublisherTabBtn):
-            identifier = identifier.identifier
+    def is_current_tab(self, identifier: str) -> bool:
+        # if isinstance(identifier, int):
+        #     identifier = self.get_tab_by_index(identifier)
+        #
+        # if isinstance(identifier, PublisherTabBtn):
+        #     identifier = identifier.identifier
         return self._current_identifier == identifier
 
-    def add_tab(self, label, identifier):
+    def add_tab(self, label: str, identifier: str) -> PublisherTabBtn:
         button = PublisherTabBtn(identifier, label, self)
         button.tab_clicked.connect(self._on_tab_click)
         self._btns_layout.addWidget(button, 0)
@@ -71,13 +76,15 @@ class PublisherTabsWidget(QtWidgets.QFrame):
             self.set_current_tab(identifier)
         return button
 
-    def get_tab_by_index(self, index):
+    def get_tab_by_index(self, index: int) -> PublisherTabBtn | None:
         if 0 >= index < self._btns_layout.count():
             item = self._btns_layout.itemAt(index)
             return item.widget()
         return None
 
-    def set_current_tab(self, identifier):
+    def set_current_tab(
+        self, identifier: str | int | PublisherTabBtn
+    ) -> None:
         if isinstance(identifier, int):
             identifier = self.get_tab_by_index(identifier)
 
@@ -100,8 +107,8 @@ class PublisherTabsWidget(QtWidgets.QFrame):
         new_btn.activate()
         self.tab_changed.emit(old_identifier, identifier)
 
-    def current_tab(self):
+    def current_tab(self) -> str | None:
         return self._current_identifier
 
-    def _on_tab_click(self, identifier):
+    def _on_tab_click(self, identifier: str) -> None:
         self.set_current_tab(identifier)

--- a/client/ayon_core/tools/publisher/widgets/tabs_widget.py
+++ b/client/ayon_core/tools/publisher/widgets/tabs_widget.py
@@ -1,18 +1,26 @@
 from __future__ import annotations
 
+import typing
+
 from qtpy import QtWidgets, QtCore
 
 from ayon_core.tools.utils import set_style_property
+
+if typing.TYPE_CHECKING:
+    from .typing import TabIdentifier
 
 
 class PublisherTabBtn(QtWidgets.QPushButton):
     tab_clicked = QtCore.Signal(str)
 
     def __init__(
-        self, identifier: str, label: str, parent: QtWidgets.QWidget
+        self,
+        identifier: TabIdentifier,
+        label: str,
+        parent: QtWidgets.QWidget,
     ) -> None:
         super().__init__(label, parent)
-        self._identifier: str = identifier
+        self._identifier: TabIdentifier = identifier
         self._active: bool = False
 
         self.clicked.connect(self._on_click)
@@ -21,7 +29,7 @@ class PublisherTabBtn(QtWidgets.QPushButton):
         self.tab_clicked.emit(self.identifier)
 
     @property
-    def identifier(self) -> str:
+    def identifier(self) -> TabIdentifier:
         return self._identifier
 
     def activate(self) -> None:
@@ -55,18 +63,15 @@ class PublisherTabsWidget(QtWidgets.QFrame):
 
         self._btns_layout = btns_layout
 
-        self._current_identifier: str | None = None
+        self._current_identifier: TabIdentifier | None = None
         self._buttons_by_identifier: dict[str, PublisherTabBtn] = {}
 
-    def is_current_tab(self, identifier: str) -> bool:
-        # if isinstance(identifier, int):
-        #     identifier = self.get_tab_by_index(identifier)
-        #
-        # if isinstance(identifier, PublisherTabBtn):
-        #     identifier = identifier.identifier
+    def is_current_tab(self, identifier: TabIdentifier) -> bool:
         return self._current_identifier == identifier
 
-    def add_tab(self, label: str, identifier: str) -> PublisherTabBtn:
+    def add_tab(
+        self, label: str, identifier: TabIdentifier
+    ) -> PublisherTabBtn:
         button = PublisherTabBtn(identifier, label, self)
         button.tab_clicked.connect(self._on_tab_click)
         self._btns_layout.addWidget(button, 0)
@@ -76,21 +81,7 @@ class PublisherTabsWidget(QtWidgets.QFrame):
             self.set_current_tab(identifier)
         return button
 
-    def get_tab_by_index(self, index: int) -> PublisherTabBtn | None:
-        if 0 >= index < self._btns_layout.count():
-            item = self._btns_layout.itemAt(index)
-            return item.widget()
-        return None
-
-    def set_current_tab(
-        self, identifier: str | int | PublisherTabBtn
-    ) -> None:
-        if isinstance(identifier, int):
-            identifier = self.get_tab_by_index(identifier)
-
-        if isinstance(identifier, PublisherTabBtn):
-            identifier = identifier.identifier
-
+    def set_current_tab(self, identifier: TabIdentifier) -> None:
         if identifier == self._current_identifier:
             return
 
@@ -107,8 +98,8 @@ class PublisherTabsWidget(QtWidgets.QFrame):
         new_btn.activate()
         self.tab_changed.emit(old_identifier, identifier)
 
-    def current_tab(self) -> str | None:
+    def current_tab(self) -> TabIdentifier | None:
         return self._current_identifier
 
-    def _on_tab_click(self, identifier: str) -> None:
+    def _on_tab_click(self, identifier: TabIdentifier) -> None:
         self.set_current_tab(identifier)

--- a/client/ayon_core/tools/publisher/widgets/tasks_model.py
+++ b/client/ayon_core/tools/publisher/widgets/tasks_model.py
@@ -1,11 +1,20 @@
-from typing import Optional
+from __future__ import annotations
+
+import typing
 
 from qtpy import QtCore, QtGui
 
-from ayon_core.lib.icon_definitions import MaterialSymbolsIcon, AwesomeFontIcon
+from ayon_core.lib.icon_definitions import (
+    MaterialSymbolsIcon,
+    AwesomeFontIcon,
+)
 from ayon_core.style import get_default_entity_icon_color
 from ayon_core.tools.utils import get_qt_icon
 from ayon_core.tools.publisher.abstract import AbstractPublisherFrontend
+
+if typing.TYPE_CHECKING:
+    from ayon_core.tools.common_models import TaskTypeItem, TaskItem
+
 
 TASK_NAME_ROLE = QtCore.Qt.UserRole + 1
 TASK_TYPE_ROLE = QtCore.Qt.UserRole + 2
@@ -30,31 +39,33 @@ class TasksModel(QtGui.QStandardItemModel):
     def __init__(
         self,
         controller: AbstractPublisherFrontend,
-        allow_empty_task: Optional[bool] = False
-    ):
+        allow_empty_task: bool = False
+    ) -> None:
         super().__init__()
 
-        self._allow_empty_task = allow_empty_task
+        self._allow_empty_task: bool = allow_empty_task
         self._controller: AbstractPublisherFrontend = controller
-        self._items_by_name = {}
-        self._folder_paths = []
-        self._task_names_by_folder_path = {}
+        self._items_by_name: dict[str, QtGui.QStandardItem] = {}
+        self._folder_paths: set[str] = set()
+        self._task_names_by_folder_path: dict[str, set[str]] = {}
 
-    def set_folder_paths(self, folder_paths):
+    def set_folder_paths(self, folder_paths: set[str]) -> None:
         """Set folders context."""
         self._folder_paths = folder_paths
         self.reset()
 
     @staticmethod
-    def get_intersection_of_tasks(task_names_by_folder_path):
+    def get_intersection_of_tasks(
+        task_names_by_folder_path: dict[str, set[str]]
+    ) -> set[str]:
         """Calculate intersection of task names from passed data.
 
         Example:
         ```
         # Passed `task_names_by_folder_path`
         {
-            "/folder_1": ["compositing", "animation"],
-            "/folder_2": ["compositing", "editorial"]
+            "/folder_1": {"compositing", "animation"},
+            "/folder_2": {"compositing", "editorial"}
         }
         ```
         Result:
@@ -65,6 +76,7 @@ class TasksModel(QtGui.QStandardItemModel):
 
         Args:
             task_names_by_folder_path (dict): Task names in iterable by parent.
+
         """
         tasks = None
         for task_names in task_names_by_folder_path.values():
@@ -75,9 +87,12 @@ class TasksModel(QtGui.QStandardItemModel):
 
             if not tasks:
                 break
+
         return tasks or set()
 
-    def is_task_name_valid(self, folder_path, task_name):
+    def is_task_name_valid(
+        self, folder_path: str, task_name: str | None
+    ) -> bool:
         """Is task name available for folder.
 
         Todos:
@@ -85,8 +100,8 @@ class TasksModel(QtGui.QStandardItemModel):
 
         Args:
             folder_path (str): Fodler path where should look for task.
-            task_name (str): Name of task which should be available in folder
-                tasks.
+            task_name (str | None): Name of task which should be available
+                in folder tasks.
         """
         if folder_path not in self._task_names_by_folder_path:
             return False
@@ -99,7 +114,7 @@ class TasksModel(QtGui.QStandardItemModel):
             return True
         return False
 
-    def reset(self):
+    def reset(self) -> None:
         """Update model by current context."""
         if not self._folder_paths:
             self._items_by_name = {}
@@ -108,13 +123,13 @@ class TasksModel(QtGui.QStandardItemModel):
             root_item.removeRows(0, self.rowCount())
             return
 
-        task_items_by_folder_path = (
+        task_items_by_folder_path: dict[str, list[TaskItem]] = (
             self._controller.get_task_items_by_folder_paths(
                 self._folder_paths
             )
         )
 
-        task_names_by_folder_path = {
+        task_names_by_folder_path: dict[str, set[str]] = {
             folder_path: {item.name for item in task_items}
             for folder_path, task_items in task_items_by_folder_path.items()
         }
@@ -146,7 +161,7 @@ class TasksModel(QtGui.QStandardItemModel):
                 self._controller.get_current_project_name()
             )
         }
-        type_item_by_task_name = {}
+        type_item_by_task_name: dict[str, TaskTypeItem] = {}
         for task_items in task_items_by_folder_path.values():
             for task_item in task_items:
                 task_name = task_item.name
@@ -171,11 +186,15 @@ class TasksModel(QtGui.QStandardItemModel):
             if not task_name:
                 continue
 
-            icon = icon_name = icon_color = None
-            task_type_item = type_item_by_task_name.get(task_name)
+            task_type_item: TaskTypeItem | None = type_item_by_task_name.get(
+                task_name
+            )
+            icon_name = icon_color = None
             if task_type_item is not None:
                 icon_name = task_type_item.icon
                 icon_color = task_type_item.color
+
+            icon = None
             if icon_name:
                 if not icon_color:
                     icon_color = get_default_entity_icon_color()

--- a/client/ayon_core/tools/publisher/widgets/typing.py
+++ b/client/ayon_core/tools/publisher/widgets/typing.py
@@ -1,0 +1,3 @@
+from typing import Literal
+
+TabIdentifier = Literal["create", "publish", "details", "report"]

--- a/client/ayon_core/tools/publisher/widgets/widgets.py
+++ b/client/ayon_core/tools/publisher/widgets/widgets.py
@@ -1,5 +1,8 @@
-import os
+from __future__ import annotations
+
+from dataclasses import dataclass, field
 import functools
+import os
 
 from qtpy import QtWidgets, QtCore, QtGui
 import qtawesome
@@ -21,6 +24,13 @@ from .icons import (
 )
 
 FA_PREFIXES = ["", "fa.", "fa5.", "fa5b.", "fa5s.", "ei.", "mdi."]
+
+
+@dataclass
+class InstancesSelection:
+    instance_ids: set[str] = field(default_factory=set)
+    context_selected: bool = False
+    convertor_identifiers: set[str] = field(default_factory=set)
 
 
 def parse_icon_def(
@@ -335,13 +345,13 @@ class AbstractInstanceView(QtWidgets.QWidget):
         """
         self.refreshed = refreshed
 
-    def refresh(self):
+    def refresh(self) -> None:
         """Refresh instances in the view from current `CreatedContext`."""
-        raise NotImplementedError((
-            "{} Method 'refresh' is not implemented."
-        ).format(self.__class__.__name__))
+        raise NotImplementedError(
+            f"{self.__class__.__name__} Method 'refresh' is not implemented."
+        )
 
-    def has_items(self):
+    def has_items(self) -> bool:
         """View has at least one item.
 
         This is more a question for controller but is called from widget
@@ -349,53 +359,55 @@ class AbstractInstanceView(QtWidgets.QWidget):
 
         Returns:
             bool: There is at least one instance or conversion item.
+
         """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} Method 'has_items'"
+            " is not implemented."
+        )
 
-        raise NotImplementedError((
-            "{} Method 'has_items' is not implemented."
-        ).format(self.__class__.__name__))
-
-    def get_selected_items(self):
+    def get_selected_items(self) -> InstancesSelection:
         """Selected instances required for callbacks.
 
         Example: When delete button is clicked to know what should be deleted.
+
         """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} Method 'get_selected_items'"
+            " is not implemented."
+        )
 
-        raise NotImplementedError((
-            "{} Method 'get_selected_items' is not implemented."
-        ).format(self.__class__.__name__))
-
-    def set_selected_items(
-        self, instance_ids, context_selected, convertor_identifiers
-    ):
+    def set_selected_items(self, selection: InstancesSelection) -> None:
         """Change selection for instances and context.
 
         Used to applying selection from one view to other.
 
         Args:
-            instance_ids (List[str]): Selected instance ids.
-            context_selected (bool): Context is selected.
-            convertor_identifiers (List[str]): Selected convertor identifiers.
+            selection (InstancesSelection): Selected instances and context.
 
         """
-        raise NotImplementedError((
-            "{} Method 'set_selected_items' is not implemented."
-        ).format(self.__class__.__name__))
+        raise NotImplementedError(
+            f"{self.__class__.__name__} Method 'set_selected_items'"
+            " is not implemented."
+        )
 
-    def set_active_toggle_enabled(self, enabled):
+    def set_active_toggle_enabled(self, enabled: bool) -> None:
         """Instances are disabled for changing enabled state.
 
         Active state should stay the same until is "unset".
 
         Args:
             enabled (bool): Instance state can be changed.
+
         """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} Method 'set_active_toggle_enabled'"
+            " is not implemented."
+        )
 
-        raise NotImplementedError((
-            "{} Method 'set_active_toggle_enabled' is not implemented."
-        ).format(self.__class__.__name__))
-
-    def refresh_instance_states(self, instance_ids=None):
+    def refresh_instance_states(
+        self, instance_ids: set[str] | None = None
+    ) -> None:
         """Refresh instance states.
 
         Args:

--- a/client/ayon_core/tools/publisher/window.py
+++ b/client/ayon_core/tools/publisher/window.py
@@ -5,7 +5,8 @@ import json
 import time
 import collections
 import copy
-from typing import Optional
+import typing
+from typing import Optional, Any
 
 from qtpy import QtWidgets, QtCore, QtGui
 
@@ -44,6 +45,11 @@ from .widgets import (
 
     CreateNextPageOverlay,
 )
+
+if typing.TYPE_CHECKING:
+    from typing import Literal
+
+    TabIdentifier = Literal["create", "publish", "details", "report"]
 
 
 class PublisherWindow(QtWidgets.QDialog):
@@ -428,7 +434,9 @@ class PublisherWindow(QtWidgets.QDialog):
         """Kept for compatibility with traypublisher."""
         return self._controller
 
-    def show_and_publish(self, comment=None):
+    def show_and_publish(
+        self, comment: str | None = None
+    ) -> None:
         """Show the window and start publishing.
 
         The method will reset controller and start the publishing afterwards.
@@ -439,7 +447,7 @@ class PublisherWindow(QtWidgets.QDialog):
                 simplified.
 
         Args:
-            comment (Optional[str]): Comment to be set to publish.
+            comment (str | None): Comment to be set to publish.
                 If is set to 'None' a comment is not changed at all.
         """
 
@@ -455,7 +463,7 @@ class PublisherWindow(QtWidgets.QDialog):
         #   comment to controller
         self._on_publish_clicked()
 
-    def set_comment(self, comment):
+    def set_comment(self, comment: str) -> None:
         """Change comment text.
 
         Todos:
@@ -463,11 +471,11 @@ class PublisherWindow(QtWidgets.QDialog):
 
         Args:
             comment (str): Comment text.
-        """
 
+        """
         self._comment_input.setText(comment)
 
-    def make_sure_is_visible(self):
+    def make_sure_is_visible(self) -> None:
         if self._window_is_visible:
             self.setWindowState(QtCore.Qt.WindowActive)
         else:
@@ -477,7 +485,7 @@ class PublisherWindow(QtWidgets.QDialog):
         self.activateWindow()
         self.showNormal()
 
-    def showEvent(self, event):
+    def showEvent(self, event) -> None:
         self._window_is_visible = True
         super().showEvent(event)
         if self._first_show:
@@ -486,12 +494,12 @@ class PublisherWindow(QtWidgets.QDialog):
 
         self._show_timer.start()
 
-    def resizeEvent(self, event):
+    def resizeEvent(self, event) -> None:
         super().resizeEvent(event)
         self._update_publish_frame_rect()
         self._update_create_overlay_size()
 
-    def closeEvent(self, event):
+    def closeEvent(self, event) -> None:
         self._window_is_visible = False
         self._uninstall_app_event_listener()
         # TODO capture changes and ask user if wants to save changes on close
@@ -505,30 +513,30 @@ class PublisherWindow(QtWidgets.QDialog):
         self._controller.emit_event("main.window.closed", {}, "window")
         super().closeEvent(event)
 
-    def leaveEvent(self, event):
+    def leaveEvent(self, event) -> None:
         super().leaveEvent(event)
         self._update_create_overlay_visibility()
 
-    def eventFilter(self, obj, event):
+    def eventFilter(self, obj, event) -> None:
         if event.type() == QtCore.QEvent.MouseMove:
             self._update_create_overlay_visibility(event.globalPos())
         return super().eventFilter(obj, event)
 
-    def _install_app_event_listener(self):
+    def _install_app_event_listener(self) -> None:
         if self._app_event_listener_installed:
             return
         self._app_event_listener_installed = True
         app = QtWidgets.QApplication.instance()
         app.installEventFilter(self)
 
-    def _uninstall_app_event_listener(self):
+    def _uninstall_app_event_listener(self) -> None:
         if not self._app_event_listener_installed:
             return
         self._app_event_listener_installed = False
         app = QtWidgets.QApplication.instance()
         app.removeEventFilter(self)
 
-    def keyPressEvent(self, event):
+    def keyPressEvent(self, event) -> None:
         if event.key() in {
             # Ignore escape button to close window
             QtCore.Qt.Key_Escape,
@@ -569,7 +577,7 @@ class PublisherWindow(QtWidgets.QDialog):
 
         super().keyPressEvent(event)
 
-    def _on_overlay_message(self, event):
+    def _on_overlay_message(self, event) -> None:
         self._overlay_object.add_message(
             event["message"],
             event.get("message_type")
@@ -581,7 +589,7 @@ class PublisherWindow(QtWidgets.QDialog):
         center_window(self)
         self._reset_on_show = self._reset_on_first_show
 
-    def _on_show_timer(self):
+    def _on_show_timer(self) -> None:
         # Add 1 to counter until hits 2
         if self._show_counter < 3:
             self._show_counter += 1
@@ -602,7 +610,7 @@ class PublisherWindow(QtWidgets.QDialog):
             self._reset_on_show = False
             self.reset()
 
-    def _checks_before_save(self, explicit_save):
+    def _checks_before_save(self, explicit_save: bool) -> bool:
         """Save of changes may trigger some issues.
 
         Check if context did change and ask user if he is really sure the
@@ -640,7 +648,7 @@ class PublisherWindow(QtWidgets.QDialog):
         )
         return result == QtWidgets.QMessageBox.Save
 
-    def _save_changes(self, explicit_save):
+    def _save_changes(self, explicit_save: bool) -> bool:
         """Save changes of Creation part.
 
         All possible triggers of save changes were moved to main window (here),
@@ -656,32 +664,32 @@ class PublisherWindow(QtWidgets.QDialog):
 
         Returns:
             bool: Save happened successfully.
-        """
 
+        """
         if not self._checks_before_save(explicit_save):
             return False
         return self._controller.save_changes()
 
-    def reset(self):
+    def reset(self) -> None:
         self._controller.reset()
 
-    def set_context_label(self, label):
+    def set_context_label(self, label: str) -> None:
         self._context_label.setText(label)
 
-    def set_tab_on_reset(self, tab):
+    def set_tab_on_reset(self, tab: TabIdentifier) -> None:
         """Define tab that will be selected on window show.
 
         This is single use method, when publisher window is showed the value is
             unset and not used on next show.
 
         Args:
-            tab (Union[int, Literal[create, publish, details, report]]: Index
-                or name of tab which will be selected on show (after reset).
+            tab (TabIdentifier): Identifier of tab which will be selected
+                on show (after reset).
         """
 
         self._tab_on_reset = tab
 
-    def set_current_tab(self, tab):
+    def set_current_tab(self, tab: TabIdentifier) -> None:
         if tab == "create":
             self._go_to_create_tab()
         elif tab == "publish":
@@ -711,7 +719,7 @@ class PublisherWindow(QtWidgets.QDialog):
 
         self._publish_details_widget.set_report(report)
 
-    def _on_help_click(self):
+    def _on_help_click(self) -> None:
         if self._help_dialog.isVisible():
             return
 
@@ -733,11 +741,13 @@ class PublisherWindow(QtWidgets.QDialog):
             self._help_dialog.width(), self._help_dialog.height()
         )
 
-    def _on_create_overlay_button_click(self):
+    def _on_create_overlay_button_click(self) -> None:
         self._create_overlay_button.set_under_mouse(False)
         self._go_to_publish_tab()
 
-    def _on_tab_change(self, old_tab, new_tab):
+    def _on_tab_change(
+        self, old_tab: TabIdentifier, new_tab: TabIdentifier
+    ) -> None:
         if old_tab == "details":
             self._publish_details_widget.set_active(False)
 
@@ -775,13 +785,13 @@ class PublisherWindow(QtWidgets.QDialog):
             self._uninstall_app_event_listener()
         self._create_overlay_button.set_visible(is_create)
 
-    def _on_context_or_active_change(self):
+    def _on_context_or_active_change(self) -> None:
         self._validate_create_instances()
 
-    def _on_create_request(self):
+    def _on_create_request(self) -> None:
         self._go_to_create_tab()
 
-    def _on_convert_requested(self):
+    def _on_convert_requested(self) -> None:
         if not self._save_changes(False):
             return
         convertor_identifiers = (
@@ -789,13 +799,13 @@ class PublisherWindow(QtWidgets.QDialog):
         )
         self._controller.trigger_convertor_items(convertor_identifiers)
 
-    def _set_current_tab(self, identifier):
+    def _set_current_tab(self, identifier: TabIdentifier) -> None:
         self._tabs_widget.set_current_tab(identifier)
 
-    def _is_current_tab(self, identifier):
+    def _is_current_tab(self, identifier: TabIdentifier) -> bool:
         return self._tabs_widget.is_current_tab(identifier)
 
-    def _go_to_create_tab(self):
+    def _go_to_create_tab(self) -> None:
         if self._create_tab.isEnabled():
             self._set_current_tab("create")
             return
@@ -805,59 +815,59 @@ class PublisherWindow(QtWidgets.QDialog):
             message_type="info"
         )
 
-    def _go_to_publish_tab(self):
+    def _go_to_publish_tab(self) -> None:
         self._set_current_tab("publish")
 
-    def _go_to_report_tab(self):
+    def _go_to_report_tab(self) -> None:
         self._set_current_tab("report")
 
-    def _go_to_details_tab(self):
+    def _go_to_details_tab(self) -> None:
         self._set_current_tab("details")
 
-    def _is_on_create_tab(self):
+    def _is_on_create_tab(self) -> bool:
         return self._is_current_tab("create")
 
-    def _is_on_publish_tab(self):
+    def _is_on_publish_tab(self) -> bool:
         return self._is_current_tab("publish")
 
-    def _is_on_report_tab(self):
+    def _is_on_report_tab(self) -> bool:
         return self._is_current_tab("report")
 
-    def _is_on_details_tab(self):
+    def _is_on_details_tab(self) -> bool:
         return self._is_current_tab("details")
 
-    def _set_publish_overlay_visibility(self, visible):
+    def _set_publish_overlay_visibility(self, visible: bool) -> None:
         if visible:
             widget = self._publish_overlay
         else:
             widget = self._under_publish_widget
         self._under_publish_stack_layout.setCurrentWidget(widget)
 
-    def _set_publish_visibility(self, visible):
+    def _set_publish_visibility(self, visible: bool) -> None:
         if visible is self._publish_frame_visible:
             return
         self._publish_frame_visible = visible
         self._publish_frame.setVisible(visible)
         self._update_publish_frame_rect()
 
-    def _on_save_clicked(self):
+    def _on_save_clicked(self) -> None:
         self._save_changes(True)
 
-    def _on_reset_clicked(self):
+    def _on_reset_clicked(self) -> None:
         self.reset()
 
-    def _on_stop_clicked(self):
+    def _on_stop_clicked(self) -> None:
         self._controller.stop_publish()
 
-    def _set_publish_comment(self):
+    def _set_publish_comment(self) -> None:
         self._controller.set_comment(self._comment_input.text())
 
-    def _on_validate_clicked(self):
+    def _on_validate_clicked(self) -> None:
         if self._validate_comment() and self._save_changes(False):
             self._set_publish_comment()
             self._controller.validate()
 
-    def _on_publish_clicked(self):
+    def _on_publish_clicked(self) -> None:
         if self._validate_comment() and self._save_changes(False):
             self._set_publish_comment()
             self._controller.publish()
@@ -879,7 +889,7 @@ class PublisherWindow(QtWidgets.QDialog):
             return False
         return True
 
-    def _invalidate_comment_field(self):
+    def _invalidate_comment_field(self) -> None:
         self._comment_invalid_timer.start()
         self._comment_input.setStyleSheet("border-color: #DD2020")
         # Set focus so user can start typing and is pointed towards the field
@@ -888,7 +898,7 @@ class PublisherWindow(QtWidgets.QDialog):
             len(self._comment_input.text())
         )
 
-    def _on_comment_invalid_timeout(self):
+    def _on_comment_invalid_timeout(self) -> None:
         # Reset style
         self._comment_input.setStyleSheet("")
 
@@ -929,7 +939,7 @@ class PublisherWindow(QtWidgets.QDialog):
         self._validate_btn.setEnabled(enabled)
         self._publish_btn.setEnabled(enabled)
 
-    def _on_publish_reset(self):
+    def _on_publish_reset(self) -> None:
         self._create_tab.setEnabled(True)
         self._set_comment_input_visiblity(True)
         self._set_publish_overlay_visibility(False)
@@ -940,7 +950,7 @@ class PublisherWindow(QtWidgets.QDialog):
         self._set_blocked(blocked)
         self._update_publish_details_widget(report=report)
 
-    def _on_controller_reset(self):
+    def _on_controller_reset(self) -> None:
         self._update_publish_details_widget(force=True)
         self._first_reset, first_reset = False, self._first_reset
         if self._tab_on_reset is not None:
@@ -962,7 +972,7 @@ class PublisherWindow(QtWidgets.QDialog):
             #       specific tabs.
             self._go_to_publish_tab()
 
-    def _on_publish_start(self):
+    def _on_publish_start(self) -> None:
         self._create_tab.setEnabled(False)
 
         self._reset_btn.setEnabled(False)
@@ -979,14 +989,14 @@ class PublisherWindow(QtWidgets.QDialog):
         if self._is_on_create_tab():
             self._go_to_publish_tab()
 
-    def _on_publish_validated(self):
+    def _on_publish_validated(self) -> None:
         self._validate_btn.setEnabled(False)
 
-    def _on_publish_finished(self, event):
+    def _on_publish_finished(self, event) -> None:
         # Successful publish, remove comment from UI
         self._comment_input.setText("")
 
-    def _on_publish_stop(self):
+    def _on_publish_stop(self) -> None:
         self._set_publish_overlay_visibility(False)
         self._reset_btn.setEnabled(True)
         self._stop_btn.setEnabled(False)
@@ -1005,7 +1015,7 @@ class PublisherWindow(QtWidgets.QDialog):
 
         self._update_publish_details_widget()
 
-    def _validate_create_instances(self):
+    def _validate_create_instances(self) -> None:
         if not self._controller.is_host_valid():
             self._set_create_context_valid(True)
             return
@@ -1030,21 +1040,21 @@ class PublisherWindow(QtWidgets.QDialog):
 
         self._set_create_context_valid(bool(all_valid))
 
-    def _on_create_model_reset(self):
+    def _on_create_model_reset(self) -> None:
         self._validate_create_instances()
 
         context_title = self._controller.get_context_title()
         self.set_context_label(context_title)
         self._update_publish_details_widget()
 
-    def _event_callback_validate_instances(self, _event):
+    def _event_callback_validate_instances(self, _event) -> None:
         self._validate_create_instances()
 
-    def _set_comment_input_visiblity(self, visible):
+    def _set_comment_input_visiblity(self, visible: bool) -> None:
         self._comment_input.setVisible(visible)
         self._footer_spacer.setVisible(not visible)
 
-    def _update_publish_frame_rect(self):
+    def _update_publish_frame_rect(self) -> None:
         if not self._publish_frame_visible:
             return
 
@@ -1060,13 +1070,18 @@ class PublisherWindow(QtWidgets.QDialog):
             0, window_size.height() - height
         )
 
-    def add_error_message_dialog(self, title, failed_info, message_start=None):
+    def add_error_message_dialog(
+        self,
+        title: str,
+        failed_info: list[dict[str, Any]],
+        message_start: str | None = None,
+    ) -> None:
         self._error_messages_to_show.append(
             (title, failed_info, message_start)
         )
         self._errors_dialog_message_timer.start()
 
-    def _on_errors_message_timeout(self):
+    def _on_errors_message_timeout(self) -> None:
         if not self._error_messages_to_show:
             self._errors_dialog_message_timer.stop()
             return
@@ -1079,7 +1094,7 @@ class PublisherWindow(QtWidgets.QDialog):
         dialog.exec_()
         dialog.deleteLater()
 
-    def _on_creator_error(self, event):
+    def _on_creator_error(self, event) -> None:
         new_failed_info = []
         for item in event["failed_info"]:
             new_item = copy.deepcopy(item)
@@ -1092,7 +1107,7 @@ class PublisherWindow(QtWidgets.QDialog):
              "Creator:"
         )
 
-    def _on_convertor_error(self, event):
+    def _on_convertor_error(self, event) -> None:
         new_failed_info = []
         for item in event["failed_info"]:
             new_item = copy.deepcopy(item)
@@ -1102,7 +1117,7 @@ class PublisherWindow(QtWidgets.QDialog):
             event["title"], new_failed_info, "Convertor:"
         )
 
-    def _on_action_error(self, event):
+    def _on_action_error(self, event) -> None:
         self.add_error_message_dialog(
             event["title"],
             [{
@@ -1114,7 +1129,7 @@ class PublisherWindow(QtWidgets.QDialog):
             "Action:"
         )
 
-    def _update_create_overlay_size(self):
+    def _update_create_overlay_size(self) -> None:
         metrics = self._create_overlay_button.fontMetrics()
         height = int(metrics.height())
         width = int(height * 0.7)
@@ -1132,7 +1147,9 @@ class PublisherWindow(QtWidgets.QDialog):
             width, height
         )
 
-    def _update_create_overlay_visibility(self, global_pos=None):
+    def _update_create_overlay_visibility(
+        self, global_pos: QtCore.QPoint | None = None
+    ) -> None:
         if global_pos is None:
             global_pos = QtGui.QCursor.pos()
 
@@ -1144,7 +1161,7 @@ class PublisherWindow(QtWidgets.QDialog):
             under_mouse = widget_x < global_pos.x()
         self._create_overlay_button.set_under_mouse(under_mouse)
 
-    def _copy_report(self):
+    def _copy_report(self) -> None:
         data = self._controller.get_publish_report_data()
         report_string = json.dumps(data, indent=4)
 
@@ -1158,7 +1175,7 @@ class PublisherWindow(QtWidgets.QDialog):
             CardMessageTypes.info
         )
 
-    def _export_report(self):
+    def _export_report(self) -> None:
         default_filename = "publish-report-{}".format(
             time.strftime("%y%m%d-%H-%M")
         )
@@ -1205,26 +1222,23 @@ class ErrorsMessageBox(ErrorMessageBox):
     def _create_top_widget(self, parent_widget):
         return None
 
-    def _get_report_data(self):
+    def _get_report_data(self) -> None:
         output = []
         for info in self._failed_info:
             item_label = info.get("label")
             item_identifier = info["identifier"]
             if item_label:
-                report_message = "{} ({})".format(
-                    item_label, item_identifier)
+                report_message = f"{item_label} ({item_identifier})"
             else:
-                report_message = "{}".format(item_identifier)
+                report_message = str(item_identifier)
 
             if self._message_start:
-                report_message = "{} {}".format(
-                    self._message_start, report_message
-                )
+                report_message = f"{self._message_start} {report_message}"
 
-            report_message += "\n\nError: {}".format(info["message"])
+            report_message += f"\n\nError: {info['message']}"
             formatted_traceback = info.get("traceback")
             if formatted_traceback:
-                report_message += "\n\n{}".format(formatted_traceback)
+                report_message += f"\n\n{formatted_traceback}"
             output.append(report_message)
         return output
 

--- a/client/ayon_core/tools/publisher/window.py
+++ b/client/ayon_core/tools/publisher/window.py
@@ -1217,9 +1217,6 @@ class ErrorsMessageBox(ErrorMessageBox):
         footer_layout = self._footer_widget.layout()
         footer_layout.setContentsMargins(5, 5, 5, 5)
 
-    def _create_top_widget(self, parent_widget):
-        return None
-
     def _get_report_data(self) -> list[str]:
         output = []
         for info in self._failed_info:

--- a/client/ayon_core/tools/publisher/window.py
+++ b/client/ayon_core/tools/publisher/window.py
@@ -515,7 +515,7 @@ class PublisherWindow(QtWidgets.QDialog):
         super().leaveEvent(event)
         self._update_create_overlay_visibility()
 
-    def eventFilter(self, obj, event) -> None:
+    def eventFilter(self, obj, event) -> bool:
         if event.type() == QtCore.QEvent.MouseMove:
             self._update_create_overlay_visibility(event.globalPos())
         return super().eventFilter(obj, event)
@@ -1220,7 +1220,7 @@ class ErrorsMessageBox(ErrorMessageBox):
     def _create_top_widget(self, parent_widget):
         return None
 
-    def _get_report_data(self) -> None:
+    def _get_report_data(self) -> list[str]:
         output = []
         for info in self._failed_info:
             item_label = info.get("label")

--- a/client/ayon_core/tools/publisher/window.py
+++ b/client/ayon_core/tools/publisher/window.py
@@ -47,9 +47,7 @@ from .widgets import (
 )
 
 if typing.TYPE_CHECKING:
-    from typing import Literal
-
-    TabIdentifier = Literal["create", "publish", "details", "report"]
+    from .widgets.typing import TabIdentifier
 
 
 class PublisherWindow(QtWidgets.QDialog):
@@ -685,8 +683,8 @@ class PublisherWindow(QtWidgets.QDialog):
         Args:
             tab (TabIdentifier): Identifier of tab which will be selected
                 on show (after reset).
-        """
 
+        """
         self._tab_on_reset = tab
 
     def set_current_tab(self, tab: TabIdentifier) -> None:


### PR DESCRIPTION
## Changelog Description
Added some type hints to publisher UI.

## Additional info
Added type hints to publisher UI to get some idea what is actually passed where. It is not 100% accurate and perfect but it is better than current state. Enhanced passing selection information between views using `InstancesSelection` and added base type for attribute definition widgets.

Except for the selection and one small change in `emit_card_message` nothing changed related to logic.

## Testing notes:
1. Publisher UI does work in any host (with python 3.9 or higher).
