### PR TITLE
Use enum instead of bool for USD contribution variant

### DIFF
--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -835,12 +835,10 @@ class ExtractUSDLayerContribution(publish.Extractor):
                 # Set default variant selection
                 variant_set_name = contribution.variant_set_name
                 variant_name = contribution.variant_name
-                if (
-                    contribution.variant_default_policy
-                    == "always"
+                policy = contribution.variant_default_policy
+                if (policy == "always"
                     or (
-                        contribution.variant_default_policy
-                        == "if_missing"
+                        policy == "if_missing"
                         and variant_set_name not in prim_spec.variantSelections
                     )
                 ):

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -361,16 +361,6 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
             variant_default_policy = attr_values.get(
                 "contribution_variant_default_policy"
             )
-            if variant_default_policy is None:
-                # Support data created before the boolean was replaced by the
-                # policy enum.
-                variant_default_policy = (
-                    "always"
-                    if attr_values.get(
-                        "contribution_variant_is_default", False
-                    )
-                    else "if_not_set"
-                )
 
             contribution = VariantContribution(
                 instance=instance,

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -358,9 +358,8 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
         # Define contribution
         in_layer_order: int = attr_values.get("contribution_in_layer_order", 0)
         if attr_values["contribution_apply_as_variant"]:
-            variant_default_policy = attr_values.get(
-                "contribution_variant_default_policy"
-            )
+            variant_default_policy = attr_values[
+                "contribution_variant_default_policy"]
 
             contribution = VariantContribution(
                 instance=instance,

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -4,7 +4,7 @@ import os
 import platform
 from collections import defaultdict
 from operator import attrgetter
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Literal
 
 import pyblish.api
 try:
@@ -74,7 +74,9 @@ class VariantContribution(_BaseContribution):
     # Variant
     variant_set_name: str
     variant_name: str
-    variant_default_policy: str  # Policy controlling variant selection opinion
+    variant_default_policy: Literal[
+        "if_not_set", "always", "never"
+    ]  # Policy controlling variant selection opinion
 
 
 CONTRIBUTION_VARIANT_DEFAULT_POLICY = {

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -362,13 +362,13 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
             if variant_default_policy is None:
                 # Support data created before the boolean was replaced by the
                 # policy enum.
-                variant_default_policy = CONTRIBUTION_VARIANT_DEFAULT_POLICY[
+                variant_default_policy = (
                     "always"
                     if attr_values.get(
                         "contribution_variant_is_default", False
                     )
                     else "if_missing"
-                ]
+                )
 
             contribution = VariantContribution(
                 instance=instance,
@@ -567,18 +567,16 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
+                    "if_missing",
             }
         elif "contribution_variant_default_policy" not in profile:
             # Support profiles created before the boolean was replaced by the
             # policy enum.
             profile = profile.copy()
             profile["contribution_variant_default_policy"] = (
-                CONTRIBUTION_VARIANT_DEFAULT_POLICY[
-                    "always"
-                    if profile.get("contribution_variant_is_default", False)
-                    else "if_missing"
-                ]
+                "always"
+                if profile.get("contribution_variant_is_default", False)
+                else "if_missing"
             )
 
         # Define defaults
@@ -706,10 +704,10 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                     f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['always']}', "
                     "the final result depends on their contribution order."
                 ),
-                items=list(CONTRIBUTION_VARIANT_DEFAULT_POLICY.values()),
+                items=CONTRIBUTION_VARIANT_DEFAULT_POLICY,
                 default=profile.get(
                     "contribution_variant_default_policy",
-                    CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
+                    "if_missing",
                 ),
                 visible=variant_visible,
             ),
@@ -839,10 +837,10 @@ class ExtractUSDLayerContribution(publish.Extractor):
                 variant_name = contribution.variant_name
                 if (
                     contribution.variant_default_policy
-                    == CONTRIBUTION_VARIANT_DEFAULT_POLICY["always"]
+                    == "always"
                     or (
                         contribution.variant_default_policy
-                        == CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"]
+                        == "if_missing"
                         and variant_set_name not in prim_spec.variantSelections
                     )
                 ):

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -575,6 +575,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
         publish_attributes = instance["publish_attributes"].get(
             cls.__name__, {})
 
+        # Convert legacy attribute value
         if "contribution_variant_is_default" in publish_attributes:
             contribution_variant_is_default = publish_attributes.pop(
                 "contribution_variant_is_default"

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -819,7 +819,8 @@ class ExtractUSDLayerContribution(publish.Extractor):
                 variant_set_name = contribution.variant_set_name
                 variant_name = contribution.variant_name
                 policy = contribution.variant_default_policy
-                if (policy == "always"
+                if (
+                    policy == "always"
                     or (
                         policy == "if_not_set"
                         and variant_set_name not in prim_spec.variantSelections

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -74,7 +74,14 @@ class VariantContribution(_BaseContribution):
     # Variant
     variant_set_name: str
     variant_name: str
-    variant_is_default: bool  # Whether to author variant selection opinion
+    variant_default_policy: str  # Policy controlling variant selection opinion
+
+
+CONTRIBUTION_VARIANT_DEFAULT_POLICY = {
+    "if_missing": "Set as default if no current default",
+    "always": "Set as default",
+    "never": "Do not set"
+}
 
 
 def get_representation_path_in_publish_context(
@@ -349,13 +356,25 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
         # Define contribution
         in_layer_order: int = attr_values.get("contribution_in_layer_order", 0)
         if attr_values["contribution_apply_as_variant"]:
+            variant_default_policy = attr_values.get(
+                "contribution_variant_default_policy"
+            )
+            if variant_default_policy is None:
+                # Support data created before the boolean was replaced by the
+                # policy enum.
+                variant_default_policy = CONTRIBUTION_VARIANT_DEFAULT_POLICY[
+                    "always"
+                    if attr_values.get("contribution_variant_is_default", False)
+                    else "if_missing"
+                ]
+
             contribution = VariantContribution(
                 instance=instance,
                 layer_id=attr_values["contribution_layer"],
                 target_product=attr_values["contribution_target_product"],
                 variant_set_name=attr_values["contribution_variant_set_name"],
                 variant_name=attr_values["contribution_variant"],
-                variant_is_default=attr_values["contribution_variant_is_default"],  # noqa: E501
+                variant_default_policy=variant_default_policy,
                 order=in_layer_order
             )
         else:
@@ -536,6 +555,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
             "task_names": create_context.get_current_task_name()
         }
         profile = filter_profiles(cls.profiles, filtering_criteria)
+
         if not profile:
             profile = {
                 "contribution_enabled": True,
@@ -544,8 +564,20 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                 "contribution_apply_as_variant": False,
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
-                "contribution_variant_is_default": False,
+                "contribution_variant_default_policy":
+                    CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
             }
+        elif "contribution_variant_default_policy" not in profile:
+            # Support profiles created before the boolean was replaced by the
+            # policy enum.
+            profile = profile.copy()
+            profile["contribution_variant_default_policy"] = (
+                CONTRIBUTION_VARIANT_DEFAULT_POLICY[
+                    "always"
+                    if profile.get("contribution_variant_is_default", False)
+                    else "if_missing"
+                ]
+            )
 
         # Define defaults
         default_target_product: str = profile["contribution_target_product"]
@@ -654,18 +686,27 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                     label="Variant Name",
                     default=profile["contribution_variant"],
                     visible=variant_visible),
-            BoolDef("contribution_variant_is_default",
-                    label="Set as default variant selection",
-                    tooltip=(
-                        "Whether to set this instance's variant name as the "
-                        "default selected variant name for the variant set.\n"
-                        "It is always expected to be enabled for only one "
-                        "variant name in the variant set.\n"
-                        "The behavior is unpredictable if multiple instances "
-                        "for the same variant set have this enabled."
-                    ),
-                    default=profile["contribution_variant_is_default"],
-                    visible=variant_visible),
+            EnumDef(
+                "contribution_variant_default_policy",
+                label="Set as default variant selection",
+                tooltip=(
+                    "Controls whether this contribution's variant name is "
+                    "authored as the selected default for the variant set.\n"
+                    "'Do not set' leaves the variant selection unchanged.\n"
+                    "'Set as default if no current default' sets it only when "
+                    "the variant set has no default selection yet.\n"
+                    "'Set as default' always sets it as the default and may "
+                    "override a selection authored by another contribution.\n"
+                    "When multiple contributions use 'Set as default', "
+                    "the final result depends on their contribution order."
+                ),
+                items=CONTRIBUTION_VARIANT_DEFAULT_POLICY.values(),
+                default=profile.get(
+                    "contribution_variant_default_policy",
+                    CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
+                ),
+                visible=variant_visible,
+            ),
             UISeparatorDef("usd_container_settings3"),
         ]
 
@@ -790,8 +831,15 @@ class ExtractUSDLayerContribution(publish.Extractor):
                 # Set default variant selection
                 variant_set_name = contribution.variant_set_name
                 variant_name = contribution.variant_name
-                if contribution.variant_is_default or \
-                        variant_set_name not in prim_spec.variantSelections:
+                if (
+                    contribution.variant_default_policy
+                    == CONTRIBUTION_VARIANT_DEFAULT_POLICY["always"]
+                    or (
+                        contribution.variant_default_policy
+                        == CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"]
+                        and variant_set_name not in prim_spec.variantSelections
+                    )
+                ):
                     prim_spec.variantSelections[variant_set_name] = variant_name  # noqa: E501
 
             elif isinstance(contribution, SublayerContribution):

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -561,15 +561,6 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                 "contribution_variant_default_policy":
                     "if_not_set",
             }
-        elif "contribution_variant_default_policy" not in profile:
-            # Support profiles created before the boolean was replaced by the
-            # policy enum.
-            profile = profile.copy()
-            profile["contribution_variant_default_policy"] = (
-                "always"
-                if profile.get("contribution_variant_is_default", False)
-                else "if_not_set"
-            )
 
         # Define defaults
         default_target_product: str = profile["contribution_target_product"]

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -706,7 +706,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                     f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['always']}', "
                     "the final result depends on their contribution order."
                 ),
-                items=CONTRIBUTION_VARIANT_DEFAULT_POLICY.values(),
+                items=list(CONTRIBUTION_VARIANT_DEFAULT_POLICY.values()),
                 default=profile.get(
                     "contribution_variant_default_policy",
                     CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -574,6 +574,16 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
         # Attributes logic
         publish_attributes = instance["publish_attributes"].get(
             cls.__name__, {})
+            if "contribution_variant_is_default" in publish_attributes:
+                contribution_variant_is_default = publish_attributes.pop(
+                    "contribution_variant_is_default"
+                )
+
+                publish_attributes["contribution_variant_default_policy"] = (
+                    "always"
+                    if contribution_variant_is_default
+                    else "if_not_set"
+                )
 
         visible = publish_attributes.get("contribution_enabled", True)
         variant_visible = visible and publish_attributes.get(

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -78,7 +78,7 @@ class VariantContribution(_BaseContribution):
 
 
 CONTRIBUTION_VARIANT_DEFAULT_POLICY = {
-    "if_missing": "Set as default if no current default",
+    "if_not_set": "Set as default if no current default",
     "always": "Set as default",
     "never": "Do not set"
 }
@@ -367,7 +367,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                     if attr_values.get(
                         "contribution_variant_is_default", False
                     )
-                    else "if_missing"
+                    else "if_not_set"
                 )
 
             contribution = VariantContribution(
@@ -567,7 +567,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    "if_missing",
+                    "if_not_set",
             }
         elif "contribution_variant_default_policy" not in profile:
             # Support profiles created before the boolean was replaced by the
@@ -576,7 +576,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
             profile["contribution_variant_default_policy"] = (
                 "always"
                 if profile.get("contribution_variant_is_default", False)
-                else "if_missing"
+                else "if_not_set"
             )
 
         # Define defaults
@@ -694,7 +694,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                     "authored as the selected default for the variant set.\n"
                     f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['never']}' leaves "
                     "the variant selection unchanged.\n"
-                    f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['if_missing']}' "
+                    f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['if_not_set']}' "
                     "sets it only when "
                     "the variant set has no default selection yet.\n"
                     f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['always']}' always"
@@ -707,7 +707,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                 items=CONTRIBUTION_VARIANT_DEFAULT_POLICY,
                 default=profile.get(
                     "contribution_variant_default_policy",
-                    "if_missing",
+                    "if_not_set",
                 ),
                 visible=variant_visible,
             ),
@@ -838,7 +838,7 @@ class ExtractUSDLayerContribution(publish.Extractor):
                 policy = contribution.variant_default_policy
                 if (policy == "always"
                     or (
-                        policy == "if_missing"
+                        policy == "if_not_set"
                         and variant_set_name not in prim_spec.variantSelections
                     )
                 ):

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -364,7 +364,9 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                 # policy enum.
                 variant_default_policy = CONTRIBUTION_VARIANT_DEFAULT_POLICY[
                     "always"
-                    if attr_values.get("contribution_variant_is_default", False)
+                    if attr_values.get(
+                        "contribution_variant_is_default", False
+                    )
                     else "if_missing"
                 ]
 
@@ -697,8 +699,8 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                     f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['if_missing']}' "
                     "sets it only when "
                     "the variant set has no default selection yet.\n"
-                    f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['always']}' always "
-                    "sets it as the default and may "
+                    f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['always']}' always"
+                    " sets it as the default and may "
                     "override a selection authored by another contribution.\n"
                     f"When multiple contributions use "
                     f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['always']}', "

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -692,12 +692,16 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
                 tooltip=(
                     "Controls whether this contribution's variant name is "
                     "authored as the selected default for the variant set.\n"
-                    "'Do not set' leaves the variant selection unchanged.\n"
-                    "'Set as default if no current default' sets it only when "
+                    f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['never']}' leaves "
+                    "the variant selection unchanged.\n"
+                    f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['if_missing']}' "
+                    "sets it only when "
                     "the variant set has no default selection yet.\n"
-                    "'Set as default' always sets it as the default and may "
+                    f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['always']}' always "
+                    "sets it as the default and may "
                     "override a selection authored by another contribution.\n"
-                    "When multiple contributions use 'Set as default', "
+                    f"When multiple contributions use "
+                    f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['always']}', "
                     "the final result depends on their contribution order."
                 ),
                 items=CONTRIBUTION_VARIANT_DEFAULT_POLICY.values(),

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -574,16 +574,17 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
         # Attributes logic
         publish_attributes = instance["publish_attributes"].get(
             cls.__name__, {})
-            if "contribution_variant_is_default" in publish_attributes:
-                contribution_variant_is_default = publish_attributes.pop(
-                    "contribution_variant_is_default"
-                )
 
-                publish_attributes["contribution_variant_default_policy"] = (
-                    "always"
-                    if contribution_variant_is_default
-                    else "if_not_set"
-                )
+        if "contribution_variant_is_default" in publish_attributes:
+            contribution_variant_is_default = publish_attributes.pop(
+                "contribution_variant_is_default"
+            )
+
+            publish_attributes["contribution_variant_default_policy"] = (
+                "always"
+                if contribution_variant_is_default
+                else "if_not_set"
+            )
 
         visible = publish_attributes.get("contribution_enabled", True)
         variant_visible = visible and publish_attributes.get(

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -305,7 +305,7 @@ def _convert_usd_contribution_variant_default_policy(overrides):
 
         is_default = profile.pop("contribution_variant_is_default")
         profile["contribution_variant_default_policy"] = (
-            "always" if is_default else "if_missing"
+            "always" if is_default else "if_not_set"
         )
 
 

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -293,8 +293,10 @@ def _convert_usd_contribution_variant_default_policy(overrides):
         overrides
         .get("publish", {})
         .get("CollectUSDLayerContributions", {})
-        .get("profiles", [])
+        .get("profiles")
     )
+    if not profiles:
+        return
 
     for profile in profiles:
         if "contribution_variant_default_policy" in profile:

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -5,10 +5,7 @@ from typing import Any
 
 from semver import VersionInfo
 
-from .publish_plugins import (
-    CONTRIBUTION_VARIANT_DEFAULT_POLICY,
-    DEFAULT_PUBLISH_VALUES,
-)
+from .publish_plugins import DEFAULT_PUBLISH_VALUES
 
 PRODUCT_NAME_REPL_REGEX = re.compile(r"[^<>{}\[\]a-zA-Z0-9_.]")
 
@@ -308,9 +305,7 @@ def _convert_usd_contribution_variant_default_policy(overrides):
 
         is_default = profile.pop("contribution_variant_is_default")
         profile["contribution_variant_default_policy"] = (
-            CONTRIBUTION_VARIANT_DEFAULT_POLICY[
-                "always" if is_default else "if_missing"
-            ]
+            "always" if is_default else "if_missing"
         )
 
 

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -316,7 +316,7 @@ def _convert_publish_plugins(overrides):
         return
     _convert_validate_version_0_3_3(overrides["publish"])
     _convert_oiio_transcode_0_4_5(overrides["publish"])
-    _convert_usd_contribution_variant_default_policy(overrides)
+    _convert_usd_contribution_variant_default_policy_1_9_11(overrides)
 
 
 def _convert_extract_thumbnail(overrides, version: VersionInfo):

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -287,7 +287,7 @@ def _convert_oiio_transcode_0_4_5(publish_overrides):
             }
 
 
-def _convert_usd_contribution_variant_default_policy(overrides):
+def _convert_usd_contribution_variant_default_policy_1_9_11(overrides):
     """Convert the USD contribution default boolean to a policy enum."""
     profiles = (
         overrides

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -5,7 +5,10 @@ from typing import Any
 
 from semver import VersionInfo
 
-from .publish_plugins import DEFAULT_PUBLISH_VALUES
+from .publish_plugins import (
+    CONTRIBUTION_VARIANT_DEFAULT_POLICY,
+    DEFAULT_PUBLISH_VALUES,
+)
 
 PRODUCT_NAME_REPL_REGEX = re.compile(r"[^<>{}\[\]a-zA-Z0-9_.]")
 
@@ -287,11 +290,36 @@ def _convert_oiio_transcode_0_4_5(publish_overrides):
             }
 
 
+def _convert_usd_contribution_variant_default_policy(overrides):
+    """Convert the USD contribution default boolean to a policy enum."""
+    profiles = (
+        overrides
+        .get("publish", {})
+        .get("CollectUSDLayerContributions", {})
+        .get("profiles", [])
+    )
+
+    for profile in profiles:
+        if "contribution_variant_default_policy" in profile:
+            continue
+
+        if "contribution_variant_is_default" not in profile:
+            continue
+
+        is_default = profile.pop("contribution_variant_is_default")
+        profile["contribution_variant_default_policy"] = (
+            CONTRIBUTION_VARIANT_DEFAULT_POLICY[
+                "always" if is_default else "if_missing"
+            ]
+        )
+
+
 def _convert_publish_plugins(overrides):
     if "publish" not in overrides:
         return
     _convert_validate_version_0_3_3(overrides["publish"])
     _convert_oiio_transcode_0_4_5(overrides["publish"])
+    _convert_usd_contribution_variant_default_policy(overrides)
 
 
 def _convert_extract_thumbnail(overrides, version: VersionInfo):

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -26,6 +26,21 @@ except ImportError:
     StatusesEnumResolver = None
 
 
+CONTRIBUTION_VARIANT_DEFAULT_POLICY = {
+    "if_missing": "Set as default if no current default",
+    "always": "Set as default",
+    "never": "Do not set",
+}
+
+
+def contribution_variant_default_policy_enum():
+    """Return the available variant default policies for the settings UI."""
+    return [
+        {"value": label, "label": label}
+        for label in CONTRIBUTION_VARIANT_DEFAULT_POLICY.values()
+    ]
+
+
 async def _get_anatomy(project_name: str | None = None) -> Anatomy:
     if project_name:
         return await get_project_anatomy(project_name)
@@ -262,14 +277,18 @@ class CollectUSDLayerContributionsProfileModel(BaseSettingsModel):
         ),
     )
     contribution_variant_default_policy: str = SettingsField(
-        "Set as default if no current default",
+        CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
         title="Set as default variant selection",
+        enum_resolver=contribution_variant_default_policy_enum,
         description=(
             "Controls whether this contribution's variant name is authored "
-            "as the selected default for the variant set. Use 'Do not set' "
-            "to leave the variant selection unchanged, 'Set as default if "
-            "no current default' to set it only when no selection exists, "
-            "or 'Set as default' to always override the current selection."
+            "as the selected default for the variant set. Use "
+            f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['never']}' to leave the "
+            "variant selection unchanged, "
+            f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['if_missing']}' to set "
+            "it only when no selection exists, or "
+            f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['always']}' to always "
+            "override the current selection."
         ),
     )
 
@@ -1656,7 +1675,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    "Set as default if no current default",
+                    CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
             },
             {
                 "product_base_types": ["look"],
@@ -1669,7 +1688,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    "Set as default if no current default",
+                    CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
             },
             {
                 "product_base_types": ["groom"],
@@ -1682,7 +1701,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    "Set as default if no current default",
+                    CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
             },
             {
                 "product_base_types": ["rig"],
@@ -1695,7 +1714,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    "Set as default if no current default",
+                    CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
             },
             {
                 "product_base_types": ["usd"],
@@ -1708,7 +1727,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    "Set as default if no current default",
+                    CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
             },
         ]
     },

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -27,7 +27,7 @@ except ImportError:
 
 
 CONTRIBUTION_VARIANT_DEFAULT_POLICY = {
-    "if_missing": "Set as default if no current default",
+    "if_not_set": "Set as default if no current default",
     "always": "Set as default",
     "never": "Do not set",
 }
@@ -277,7 +277,7 @@ class CollectUSDLayerContributionsProfileModel(BaseSettingsModel):
         ),
     )
     contribution_variant_default_policy: str = SettingsField(
-        "if_missing",
+        "if_not_set",
         title="Set as default variant selection",
         enum_resolver=contribution_variant_default_policy_enum,
         description=(
@@ -285,7 +285,7 @@ class CollectUSDLayerContributionsProfileModel(BaseSettingsModel):
             "as the selected default for the variant set. Use "
             f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['never']}' to leave the "
             "variant selection unchanged, "
-            f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['if_missing']}' to set "
+            f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['if_not_set']}' to set "
             "it only when no selection exists, or "
             f"'{CONTRIBUTION_VARIANT_DEFAULT_POLICY['always']}' to always "
             "override the current selection."
@@ -1675,7 +1675,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    "if_missing",
+                    "if_not_set",
             },
             {
                 "product_base_types": ["look"],
@@ -1688,7 +1688,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    "if_missing",
+                    "if_not_set",
             },
             {
                 "product_base_types": ["groom"],
@@ -1701,7 +1701,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    "if_missing",
+                    "if_not_set",
             },
             {
                 "product_base_types": ["rig"],
@@ -1714,7 +1714,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    "if_missing",
+                    "if_not_set",
             },
             {
                 "product_base_types": ["usd"],
@@ -1727,7 +1727,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    "if_missing",
+                    "if_not_set",
             },
         ]
     },

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -261,16 +261,15 @@ class CollectUSDLayerContributionsProfileModel(BaseSettingsModel):
             "The default variant name for instances matching this profile."
         ),
     )
-    contribution_variant_is_default: bool = SettingsField(
-        False,
+    contribution_variant_default_policy: str = SettingsField(
+        "Set as default if no current default",
         title="Set as default variant selection",
         description=(
-            "Whether to set this instance's variant name as the "
-            "default selected variant name for the variant set.\n"
-            "It is always expected to be enabled for only one "
-            "variant name in the variant set.\n"
-            "The behavior is unpredictable if multiple instances "
-            "for the same variant set have this enabled."
+            "Controls whether this contribution's variant name is authored "
+            "as the selected default for the variant set. Use 'Do not set' "
+            "to leave the variant selection unchanged, 'Set as default if "
+            "no current default' to set it only when no selection exists, "
+            "or 'Set as default' to always override the current selection."
         ),
     )
 
@@ -1656,7 +1655,8 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_apply_as_variant": True,
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
-                "contribution_variant_is_default": False,
+                "contribution_variant_default_policy":
+                    "Set as default if no current default",
             },
             {
                 "product_base_types": ["look"],
@@ -1668,7 +1668,8 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_apply_as_variant": True,
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
-                "contribution_variant_is_default": False,
+                "contribution_variant_default_policy":
+                    "Set as default if no current default",
             },
             {
                 "product_base_types": ["groom"],
@@ -1680,7 +1681,8 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_apply_as_variant": True,
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
-                "contribution_variant_is_default": False,
+                "contribution_variant_default_policy":
+                    "Set as default if no current default",
             },
             {
                 "product_base_types": ["rig"],
@@ -1692,7 +1694,8 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_apply_as_variant": True,
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
-                "contribution_variant_is_default": False,
+                "contribution_variant_default_policy":
+                    "Set as default if no current default",
             },
             {
                 "product_base_types": ["usd"],
@@ -1704,7 +1707,8 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_apply_as_variant": False,
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
-                "contribution_variant_is_default": False,
+                "contribution_variant_default_policy":
+                    "Set as default if no current default",
             },
         ]
     },

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -36,8 +36,8 @@ CONTRIBUTION_VARIANT_DEFAULT_POLICY = {
 def contribution_variant_default_policy_enum():
     """Return the available variant default policies for the settings UI."""
     return [
-        {"value": label, "label": label}
-        for label in CONTRIBUTION_VARIANT_DEFAULT_POLICY.values()
+        {"value": value, "label": label}
+        for value, label in CONTRIBUTION_VARIANT_DEFAULT_POLICY.items()
     ]
 
 
@@ -277,7 +277,7 @@ class CollectUSDLayerContributionsProfileModel(BaseSettingsModel):
         ),
     )
     contribution_variant_default_policy: str = SettingsField(
-        CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
+        "if_missing",
         title="Set as default variant selection",
         enum_resolver=contribution_variant_default_policy_enum,
         description=(
@@ -1675,7 +1675,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
+                    "if_missing",
             },
             {
                 "product_base_types": ["look"],
@@ -1688,7 +1688,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
+                    "if_missing",
             },
             {
                 "product_base_types": ["groom"],
@@ -1701,7 +1701,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
+                    "if_missing",
             },
             {
                 "product_base_types": ["rig"],
@@ -1714,7 +1714,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
+                    "if_missing",
             },
             {
                 "product_base_types": ["usd"],
@@ -1727,7 +1727,7 @@ DEFAULT_PUBLISH_VALUES = {
                 "contribution_variant_set_name": "{layer}",
                 "contribution_variant": "{variant}",
                 "contribution_variant_default_policy":
-                    CONTRIBUTION_VARIANT_DEFAULT_POLICY["if_missing"],
+                    "if_missing",
             },
         ]
     },


### PR DESCRIPTION
## Changelog Description
This PR is adding an option to `Set as default variant selection` during the publishing. Before there was only toggle that has this behaviour:
     - `True` : Always set the variant as default
     - `False` : Set as the default only if there is no default
     
So it wasn't possible to `Don't set the variant as default if the default is not set yet`. The current implementation is adding this option and maps also the previous values to the new enum. 

## Additional info
The conversion is done this way to keep the behaviour of the previous implementation the same:
1. `False` -> `Set as default if no current default`
2. `True` -> `Set as default`

The new option is `Do not set`, which really doesn't set the default even if there is no default yet.

## Testing notes:
1. test publish with all possible choices in `Set as default variant selection` and check if it matches the settings
2. test conversion from older settings:
    - `False` -> `Set as default if no current default`
    - `True` -> `Set as default`

