### PR TITLE
Tests: mark visual tests optional

### DIFF
--- a/.github/workflows/pr_unittests.yaml
+++ b/.github/workflows/pr_unittests.yaml
@@ -34,4 +34,4 @@ jobs:
       - name: Run tests
         env:
           QT_QPA_PLATFORM: offscreen
-        run: ./tools/manage.sh run-tests
+        run: ./tools/manage.sh run-tests --optional

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ poetry.lock
 
 # ignore mkdocs build
 site/
+
+# handle test images from tests
+test_images

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ mypy_path = "$MYPY_CONFIG_FILE_DIR/client"
 [tool.pytest.ini_options]
 log_cli = true
 log_cli_level = "INFO"
-addopts = "-ra -q"
+addopts = "-ra -q -m 'not optional'"
 testpaths = [
     "client/ayon_core/tests",
     "tests/client/ayon_core/ui",
@@ -82,4 +82,5 @@ markers = [
     "cli: CLI tests",
     "slow: Slow tests",
     "server: Tests that require a running AYON server",
+    "optional: Tests excluded from the default test run",
 ]

--- a/tests/client/ayon_core/ui/test_visual.py
+++ b/tests/client/ayon_core/ui/test_visual.py
@@ -24,6 +24,9 @@ from visual_utils import capture_widget
 from widget_test import WidgetTest
 
 
+pytestmark = pytest.mark.optional
+
+
 def _collect_widget_test_classes() -> list[Type[WidgetTest]]:
     """Import all test_*.py modules under tests/components/ and return
     WidgetTest subclasses."""

--- a/tools/manage.ps1
+++ b/tools/manage.ps1
@@ -221,7 +221,7 @@ function Run-Tests {
         $TestMarker
     )
     & uv sync --extra test
-    & uv $RunArgs
+    & uv $RunArgs @TestArguments
 }
 
 function Write-Help {

--- a/tools/manage.ps1
+++ b/tools/manage.ps1
@@ -207,9 +207,21 @@ function Run-From-Code {
 }
 
 function Run-Tests {
-    $RunArgs = @( "run", "pytest", "$($RepoRoot)/tests", "-m",  "not server")
+    param(
+        [string[]]$TestArguments
+    )
+
+    $TestMarker = "not server and not optional"
+    if ($TestArguments -contains "--optional" -or $TestArguments -contains "-optional") {
+        $TestMarker = "not server"
+    }
+
+    $RunArgs = @(
+        "run", "pytest", "$($RepoRoot)/tests", "-m",
+        $TestMarker
+    )
     & uv sync --extra test
-    & uv $RunArgs @arguments
+    & uv $RunArgs
 }
 
 function Write-Help {
@@ -228,7 +240,7 @@ function Write-Help {
     Write-Info -Text "  ruff-fix                      ", "Run Ruff fix for the repository" -Color White, Cyan
     Write-Info -Text "  codespell                     ", "Run codespell check for the repository" -Color White, Cyan
     Write-Info -Text "  run                           ", "Run a uv command in the repository environment" -Color White, Cyan
-    Write-Info -Text "  run-tests                     ", "Run ayon-core tests" -Color White, Cyan
+    Write-Info -Text "  run-tests --optional          ", "Run ayon-core tests including optional tests" -Color White, Cyan
     Write-Host ""
 }
 
@@ -255,7 +267,7 @@ function Resolve-Function {
         Run-From-Code
     } elseif ($FunctionName -eq "runtests") {
         Set-Cwd
-        Run-Tests
+        Run-Tests -TestArguments $Arguments
     } else {
         Write-Host "Unknown function ""$FunctionName"""
         Write-Help

--- a/tools/manage.sh
+++ b/tools/manage.sh
@@ -144,7 +144,7 @@ default_help() {
   echo -e "  ${BWhite}ruff-fix${RST}        ${BCyan}Run Ruff fix for the repository${RST}"
   echo -e "  ${BWhite}codespell${RST}       ${BCyan}Run codespell check for the repository${RST}"
   echo -e "  ${BWhite}run${RST}             ${BCyan}Run a uv command in the repository environment${RST}"
-  echo -e "  ${BWhite}run-tests${RST}       ${BCyan}Run ayon-core tests${RST}"
+  echo -e "  ${BWhite}run-tests --optional${RST} ${BCyan}Run ayon-core tests including optional tests${RST}"
   echo ""
 }
 
@@ -172,8 +172,12 @@ run_command () {
 run_tests () {
   echo -e "${BIGreen}>>>${RST} Running tests..."
   shift;  # will remove first arg ("run-tests") from the "$@"
+  local test_marker="not server and not optional"
+  if [ "$1" = "--optional" ]; then
+    test_marker="not server"
+  fi
   uv sync --extra test
-  uv run pytest ./tests -m "not server"
+  uv run pytest ./tests -m "$test_marker"
 }
 
 main () {

--- a/tools/manage.sh
+++ b/tools/manage.sh
@@ -144,6 +144,7 @@ default_help() {
   echo -e "  ${BWhite}ruff-fix${RST}        ${BCyan}Run Ruff fix for the repository${RST}"
   echo -e "  ${BWhite}codespell${RST}       ${BCyan}Run codespell check for the repository${RST}"
   echo -e "  ${BWhite}run${RST}             ${BCyan}Run a uv command in the repository environment${RST}"
+  echo -e "  ${BWhite}run-tests${RST}       ${BCyan}Run ayon-core tests (optional tests excluded)${RST}"
   echo -e "  ${BWhite}run-tests --optional${RST} ${BCyan}Run ayon-core tests including optional tests${RST}"
   echo ""
 }


### PR DESCRIPTION
## Changelog Description
Make visual test optional except on GH Action.

## Additional info
Running test locally will produce inconsistent errors about pixel deviation tolerances. Running them on Github Actions is more consistent and produce no errors as of now. Until we can figure out why the testing differences are so big on individual machines, we'll mark those tests optional.

BREAKING CHANGE: UI visual tests are not running by default, you need to add optional tests using `--optional` argument.

## Testing notes:

Running tests using `./tools/manage.sh run-tests` should deselect failing visual tests.
Running tests using `./tools/manage.sh run-tests --optional` should a run visual tests.
CI Action on Github should run them too.
