### PR TITLE
Optimization: use `str.format_map(data)` over `str.format(**data)`

### DIFF
--- a/client/ayon_core/lib/env_tools.py
+++ b/client/ayon_core/lib/env_tools.py
@@ -230,7 +230,7 @@ def _partial_format(
         output = value
         for match in re.findall(r_token, value):
             try:
-                output = re.sub(match, match.format(**data), output)
+                output = re.sub(match, match.format_map(data), output)
             except (KeyError, ValueError, IndexError):
                 continue
     return output

--- a/client/ayon_core/lib/path_templates.py
+++ b/client/ayon_core/lib/path_templates.py
@@ -760,7 +760,7 @@ class FormattingPart:
             parent_fill_data[used_keys[-1]] = value
 
         template = f"{{{field_name}{self._format_spec}{self._conversion}}}"
-        formatted_value = template.format(**root_fill_data)
+        formatted_value = template.format_map(root_fill_data)
         used_key = key
         if keys_to_value is not None:
             used_key = self.keys_to_template_base(keys_to_value)

--- a/client/ayon_core/lib/path_templates.py
+++ b/client/ayon_core/lib/path_templates.py
@@ -191,6 +191,19 @@ class StringTemplate:
             invalid_types
         )
 
+    def format_map(self, data: dict[str, Any]) -> "TemplateResult":
+        """Format the template using a mapping of replacement values.
+
+        This mirrors :meth:`str.format_map`.
+
+        Args:
+            data (dict): Containing keys to be filled into the template.
+
+        Returns:
+            TemplateResult: Filled or partially filled template.
+        """
+        return self.format(data)
+
     def format_strict(self, data: dict[str, Any]) -> "TemplateResult":
         result = self.format(data)
         result.validate()

--- a/client/ayon_core/pipeline/anatomy/anatomy.py
+++ b/client/ayon_core/pipeline/anatomy/anatomy.py
@@ -237,7 +237,7 @@ class BaseAnatomy(object):
         if not root_templates:
             return None
 
-        return root_templates[0].format(**{"root": self.roots})
+        return root_templates[0].format_map({"root": self.roots})
 
     def root_names_from_templates(self, templates):
         """Extract root names form anatomy templates.
@@ -287,7 +287,7 @@ class BaseAnatomy(object):
             str: formatted path
         """
         # NOTE does not care if there are different keys than "root"
-        return template_path.format(**{"root": self.roots})
+        return template_path.format_map({"root": self.roots})
 
     @classmethod
     def fill_root_with_path(cls, rootless_path, root_path):
@@ -359,7 +359,7 @@ class BaseAnatomy(object):
             )
 
         data = self.root_environmets_fill_data(template)
-        return rootless_path.format(**data)
+        return rootless_path.format_map(data)
 
     def _project_entity_to_anatomy_data(self, project_entity):
         """Convert project document to anatomy data.

--- a/client/ayon_core/pipeline/anatomy/anatomy.py
+++ b/client/ayon_core/pipeline/anatomy/anatomy.py
@@ -237,7 +237,7 @@ class BaseAnatomy(object):
         if not root_templates:
             return None
 
-        return root_templates[0].format_map({"root": self.roots})
+        return root_templates[0].format(root=self.roots)
 
     def root_names_from_templates(self, templates):
         """Extract root names form anatomy templates.
@@ -287,7 +287,7 @@ class BaseAnatomy(object):
             str: formatted path
         """
         # NOTE does not care if there are different keys than "root"
-        return template_path.format_map({"root": self.roots})
+        return template_path.format(root=self.roots)
 
     @classmethod
     def fill_root_with_path(cls, rootless_path, root_path):

--- a/client/ayon_core/pipeline/anatomy/roots.py
+++ b/client/ayon_core/pipeline/anatomy/roots.py
@@ -190,7 +190,7 @@ class AnatomyRoot(FormatObject):
         else:
             fill_data = {self.name: self.value}
 
-        return template.format(**{"root": fill_data})
+        return template.format_map({"root": fill_data})
 
     def find_root_template_from_path(self, path):
         """Replaces known root value with formattable key in path.
@@ -329,7 +329,7 @@ class AnatomyRoots:
             raise ValueError("Roots are not set. Can't find path.")
 
         if "{root" in path:
-            path = path.format(**{"root": roots})
+            path = path.format_map({"root": roots})
             # If `dst_platform` is not specified then return else continue.
             if not dst_platform:
                 return path

--- a/client/ayon_core/pipeline/anatomy/roots.py
+++ b/client/ayon_core/pipeline/anatomy/roots.py
@@ -190,7 +190,7 @@ class AnatomyRoot(FormatObject):
         else:
             fill_data = {self.name: self.value}
 
-        return template.format_map({"root": fill_data})
+        return template.format(root=fill_data)
 
     def find_root_template_from_path(self, path):
         """Replaces known root value with formattable key in path.
@@ -329,7 +329,7 @@ class AnatomyRoots:
             raise ValueError("Roots are not set. Can't find path.")
 
         if "{root" in path:
-            path = path.format_map({"root": roots})
+            path = path.format(root=roots)
             # If `dst_platform` is not specified then return else continue.
             if not dst_platform:
                 return path

--- a/client/ayon_core/pipeline/context_tools.py
+++ b/client/ayon_core/pipeline/context_tools.py
@@ -228,7 +228,7 @@ def install_ayon_plugins(project_name=None, host_name=None):
         ) or []
         for path in project_plugins:
             try:
-                path = str(path.format(**os.environ))
+                path = str(path.format_map(os.environ))
             except KeyError:
                 pass
 

--- a/client/ayon_core/pipeline/project_folders.py
+++ b/client/ayon_core/pipeline/project_folders.py
@@ -55,7 +55,7 @@ def fill_paths(path_list: list[str], anatomy: Anatomy):
     filled_paths = []
 
     for path in path_list:
-        new_path = path.format(**format_data)
+        new_path = path.format_map(format_data)
         filled_paths.append(new_path)
 
     return filled_paths

--- a/client/ayon_core/pipeline/publish/publish_plugins.py
+++ b/client/ayon_core/pipeline/publish/publish_plugins.py
@@ -118,10 +118,10 @@ class PublishXmlValidationError(PublishValidationError):
             formatting_data = {}
         result = load_help_content_from_plugin(plugin, help_filename)
         content_obj = result["errors"][key]
-        description = content_obj.description.format(**formatting_data)
+        description = content_obj.description.format_map(formatting_data)
         detail = content_obj.detail
         if detail:
-            detail = detail.format(**formatting_data)
+            detail = detail.format_map(formatting_data)
         super().__init__(
             message,
             content_obj.title,

--- a/client/ayon_core/plugins/publish/extract_burnin.py
+++ b/client/ayon_core/plugins/publish/extract_burnin.py
@@ -447,7 +447,7 @@ class ExtractBurnin(publish.Extractor):
             font_filepath = font_filepath.get(sys_name)
 
         if font_filepath and isinstance(font_filepath, str):
-            font_filepath = font_filepath.format(**os.environ)
+            font_filepath = font_filepath.format_map(os.environ)
             if not os.path.exists(font_filepath):
                 font_filepath = None
 

--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -797,7 +797,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
             if not value:
                 continue
             try:
-                value = value.format(**fill_data)
+                value = value.format_map(fill_data)
             except Exception:
                 self.log.warning(
                     "Failed to format ffmpeg argument: {}".format(value),

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -344,7 +344,7 @@ class CollectUSDLayerContributions(pyblish.api.InstancePlugin,
             "contribution_variant_set_name",
             "contribution_variant"
         ]:
-            attr_values[key] = attr_values[key].format(**data)
+            attr_values[key] = attr_values[key].format_map(data)
 
         # Define contribution
         in_layer_order: int = attr_values.get("contribution_in_layer_order", 0)

--- a/client/ayon_core/scripts/otio_burnin.py
+++ b/client/ayon_core/scripts/otio_burnin.py
@@ -513,7 +513,7 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
             for value, new_values in zip(values, new_listed_keys):
                 sub_value[last_item_key] = value
                 try:
-                    value = key.format(**sub_value)
+                    value = key.format_map(sub_value)
                 except (TypeError, KeyError, ValueError):
                     value = MISSING_KEY_VALUE
                 new_values[key] = value
@@ -790,7 +790,7 @@ def prepare_fill_values(burnin_template, data):
                     "values": key_value,
                     "keys": keys}
             else:
-                fill_values[orig_key] = orig_key.format(**data)
+                fill_values[orig_key] = orig_key.format_map(data)
         except (KeyError, TypeError):
             missing_keys.add(orig_key)
             continue
@@ -989,7 +989,7 @@ def burnins_from_data(
             args = [align, frame_start, frame_end, source_timecode]
             if not value.startswith(SOURCE_TIMECODE_KEY):
                 value_items = value.split(SOURCE_TIMECODE_KEY)
-                text = value_items[0].format(**data)
+                text = value_items[0].format_map(data)
                 args.append(text)
 
             burnin.add_timecode(*args)
@@ -999,13 +999,13 @@ def burnins_from_data(
             args = [align, frame_start, frame_end, frame_start_tc]
             if not value.startswith(TIMECODE_KEY):
                 value_items = value.split(TIMECODE_KEY)
-                text = value_items[0].format(**data)
+                text = value_items[0].format_map(data)
                 args.append(text)
 
             burnin.add_timecode(*args)
             continue
 
-        text = value.format(**data)
+        text = value.format_map(data)
 
         burnin.add_text(text, align, frame_start, frame_end)
 

--- a/client/ayon_core/scripts/slates/slate_base/items.py
+++ b/client/ayon_core/scripts/slates/slate_base/items.py
@@ -41,7 +41,7 @@ class ItemImage(BaseItem):
 
     def fill_data_format(self):
         if re.match(self.fill_data_regex, self.image_path):
-            self.image_path = self.image_path.format(**self.fill_data)
+            self.image_path = self.image_path.format_map(self.fill_data)
 
     def draw(self, image, drawer):
         source_image = Image.open(os.path.normpath(self.image_path))
@@ -101,7 +101,7 @@ class ItemPlaceHolder(BaseItem):
 
     def fill_data_format(self):
         if re.match(self.fill_data_regex, self.image_path):
-            self.image_path = self.image_path.format(**self.fill_data)
+            self.image_path = self.image_path.format_map(self.fill_data)
 
     def draw(self, image, drawer):
         bg_color = self.style["bg-color"]
@@ -503,7 +503,7 @@ class TableField(BaseItem):
     def fill_data_format(self):
         value = self.value
         if re.match(self.fill_data_regex, value):
-            value = value.format(**self.fill_data)
+            value = value.format_map(self.fill_data)
 
         self.orig_value = value
 

--- a/client/ayon_core/scripts/slates/slate_base/main_frame.py
+++ b/client/ayon_core/scripts/slates/slate_base/main_frame.py
@@ -23,7 +23,7 @@ class MainFrame(BaseObj):
 
     def fill_data_format(self):
         if re.match(self.fill_data_regex, self.dst_path):
-            self.dst_path = self.dst_path.format(**self.fill_data)
+            self.dst_path = self.dst_path.format_map(self.fill_data)
 
     @property
     def fill_data(self):

--- a/client/ayon_core/tools/push_to_project/control.py
+++ b/client/ayon_core/tools/push_to_project/control.py
@@ -361,8 +361,8 @@ class PushToContextController:
             "task": task_name
         })
         try:
-            product_s = template_s.format(**fill_data)
-            product_e = template_e.format(**fill_data)
+            product_s = template_s.format_map(fill_data)
+            product_e = template_e.format_map(fill_data)
         except Exception as exc:
             print("Failed format", exc)
             return ""

--- a/tests/client/ayon_core/pipeline/traits/test_publishing.py
+++ b/tests/client/ayon_core/pipeline/traits/test_publishing.py
@@ -38,7 +38,7 @@ class _DummyPathTemplate(str):
 
     def format_strict(self, data: dict) -> _DummyFormattedTemplate:
         return _DummyFormattedTemplate(
-            self.format(**data),
+            self.format_map(data),
             {
                 key: value
                 for key, value in data.items()


### PR DESCRIPTION
## Changelog Description

Optimization: use `str.format_map(data)` over `str.format(**data)`

## Additional info

Double check whether we're only doing these to `str` and not to any of our custom "template" classes that do not inherit from `str`.

Here's some numbers:
```
=== Small dict (2 keys) ===
format(**data)   : 0.4824s for 1,000,000 calls  (482.4 ns/call)
format_map(data) : 0.3197s for 1,000,000 calls  (319.7 ns/call)

=== Large dict (52 keys) ===
format(**data)   : 0.8103s for 1,000,000 calls  (810.3 ns/call)
format_map(data) : 0.4332s for 1,000,000 calls  (433.2 ns/call)

=== Repeat runs for consistency (large dict) ===
format(**data)    run0: 0.7982s for 1,000,000 calls  (798.2 ns/call)
format_map(data)  run0: 0.4288s for 1,000,000 calls  (428.8 ns/call)
format(**data)    run1: 0.8166s for 1,000,000 calls  (816.6 ns/call)
format_map(data)  run1: 0.4307s for 1,000,000 calls  (430.7 ns/call)
format(**data)    run2: 0.8488s for 1,000,000 calls  (848.8 ns/call)
format_map(data)  run2: 0.4439s for 1,000,000 calls  (443.9 ns/call)
```
We're talking very small differences. Do note that for small dict the old way seems that it's technically slightly faster.
However, it should also use less memory, less garbage collection, etc. so there's other benefits too.

However, given this ☝️ we may want to not swap the `{root` ones because it has a single key. So those are now written as `format(root=...)` to avoid even having to create the `dict`, etc.

## Testing notes:

1. Test general pipeline usage.
2. Test publishing.
3. Test extract review with burnins.
