### PR TITLE
new: add host as a key in get_product_name

### DIFF
--- a/client/ayon_core/pipeline/create/product_name.py
+++ b/client/ayon_core/pipeline/create/product_name.py
@@ -168,7 +168,9 @@ def _get_product_name_old(
             "type": product_type,
             "basetype": product_base_type or product_type,
         },
-        "host": host_name,
+        "host": {
+            "name": host_name,
+        },
     }
 
     if dynamic_data:
@@ -471,7 +473,9 @@ def get_product_name(
             "type": product_type,
             "basetype": product_base_type,
         },
-        "host": host_name,
+        "host": {
+            "name": host_name,
+        },
     }
     if folder_entity:
         fill_pairs["folder"] = {

--- a/client/ayon_core/pipeline/create/product_name.py
+++ b/client/ayon_core/pipeline/create/product_name.py
@@ -167,7 +167,8 @@ def _get_product_name_old(
         "product": {
             "type": product_type,
             "basetype": product_base_type or product_type,
-        }
+        },
+        "host": host_name,
     }
 
     if dynamic_data:
@@ -469,7 +470,8 @@ def get_product_name(
         "product": {
             "type": product_type,
             "basetype": product_base_type,
-        }
+        },
+        "host": host_name,
     }
     if folder_entity:
         fill_pairs["folder"] = {


### PR DESCRIPTION
## Changelog Description
added `{host}` as a key to be available in `get_product_name`

Add for example `{host[name]}` key to the product name template.

## Additional info

It felt strange beeing able to filter profiles by host, but then to not be able to have host as an option in the template itself.
In our case it lead to the creation of multiple profiles for each host:
```json
[
    {
      "product_base_types": ["workfile"],
      "host_names": ["nuke"],
      "template": "{product[type]}{Task[name]}Nuke"
    },
    {
      "product_base_types": ["workfile"],
      "host_names": ["houdini"],
      "template": "{product[type]}{Task[name]}Houdini"
    },
    {
      "product_base_types": ["workfile"],
      "host_names": ["maya"],
      "template": "{product[type]}{Task[name]}Maya"
    },
    {
      "product_base_types": ["workfile"],
      "host_names": ["substancepainter"],
      "template": "{product[type]}{Task[name]}SubstancePainter"
    },
    {
      "product_base_types": ["workfile"],
      "host_names": ["zbrush"],
      "template": "{product[type]}{Task[name]}ZBrush"
    }
  ]
```

With this change this can be consolidated into a single profile:
```json
[
    {
      "product_base_types": ["workfile"],
      "host_names": [],
      "template": "{product[type]}{Task[name]}{Host[name]}"
    }
]
```

## `str` vs. `dict`

I wasn't 100%  sure weather use the string `{host}` or dict `{host[name]}`  variant

I'e went with the dict version as it feels more in line with how the `product` and `task` entities are represented and keeps the door open for other attributes in the future. (`{host[label]}` or similar in the future for `SubstancePainter` or `ZBrush`)

`{host}` is nice and short and does the job perfectly well right now, but i'm worried we end up having to implement a similar check as the `{task}` -> `{task[name]}` conversion to migrate templates if we ever decide to change it


## Testing notes:
1. add `{host[name]}` or `{Host[name]}` to a product name template
2. confirm in the creator or any other tool that the host name is added
