### PR TITLE
Publish report viewer: Show timestamp in logs

### DIFF
--- a/client/ayon_core/tools/publisher/publish_report_viewer/widgets.py
+++ b/client/ayon_core/tools/publisher/publish_report_viewer/widgets.py
@@ -317,6 +317,98 @@ class ZoomPlainText(QtWidgets.QTextEdit):
             self._scheduled_scalings += 1
 
 
+class _LogFiller:
+    _color_mapping = (
+        ("TRACEBACK", QtGui.QColor(255, 74, 74)),
+        ("CRITICAL", QtGui.QColor(255, 79, 117)),
+        ("ERROR", QtGui.QColor(255, 77, 88)),
+        ("WARNING", QtGui.QColor(255, 186, 102)),
+        ("INFO", QtGui.QColor(102, 171, 255)),
+        ("DEBUG", QtGui.QColor(127, 140, 141)),
+        ("", QtGui.QColor(127, 140, 141)),
+        ("NOTSET", QtGui.QColor(127, 140, 141)),
+    )
+
+    def __init__(
+        self,
+        output_widget: QtWidgets.QTextEdit,
+        logs: list[ReportLog],
+        show_timestamp: bool,
+    ) -> None:
+        self.output_widget = output_widget
+        self.show_timestamp = show_timestamp
+        self.logs = logs
+        self.first_line = True
+        self.cursor = None
+        default_format = QtGui.QTextCharFormat(
+            self.output_widget.currentCharFormat()
+        )
+        prefix_fmts = {}
+        for key, color in self._color_mapping:
+            fmt = QtGui.QTextCharFormat(default_format)
+            fmt.setForeground(color)
+            prefix_fmts[key] = fmt
+
+        self.default_fmt = default_format
+        self.prefix_fmts = prefix_fmts
+
+    def _add_entry(
+        self, message: str, timestamp: str = "", log_level: str = ""
+    ) -> None:
+        if not self.first_line:
+            self.cursor.insertBlock()
+        self.first_line = False
+        if timestamp or log_level:
+            fmt = self.prefix_fmts.get(log_level, self.default_fmt)
+            self.cursor.insertText(
+                f"{timestamp}{log_level}: ", fmt
+            )
+        self.cursor.insertText(message, self.default_fmt)
+
+    def fill(self) -> None:
+        self.output_widget.clear()
+        # Create copy of a document to avoid live updates in UI
+        src_doc = self.output_widget.document()
+        document = QtGui.QTextDocument()
+        document.setDefaultStyleSheet(src_doc.defaultStyleSheet())
+        document.setDefaultFont(src_doc.defaultFont())
+        document.setDefaultTextOption(
+            QtGui.QTextOption(src_doc.defaultTextOption())
+        )
+        self.cursor = QtGui.QTextCursor(document)
+
+        for log in self.logs:
+            timestamp = ""
+            if self.show_timestamp and log.created is not None:
+                timestamp = (
+                    arrow
+                    .get(log.created)
+                    .to("local")
+                    .format("YYYY/MM/DD HH:mm:ss ")
+                )
+
+            if log.type == "record":
+                self._add_entry(log.message, timestamp, log.levelname)
+                exc_info = log.exc_info
+                if exc_info:
+                    self._add_entry(exc_info)
+
+            elif log.type == "error":
+                self._add_entry(
+                    log.traceback, timestamp, "TRACEBACK"
+                )
+
+            else:
+                print(log.type)
+
+        self.cursor.select(QtGui.QTextCursor.Document)
+        fmt = QtGui.QTextBlockFormat()
+        fmt.setLeftMargin(20)
+        fmt.setTextIndent(-20)
+        self.cursor.mergeBlockFormat(fmt)
+        self.output_widget.setDocument(document)
+
+
 class DetailsWidget(QtWidgets.QWidget):
     def __init__(self, parent: QtWidgets.QWidget) -> None:
         super().__init__(parent)
@@ -399,58 +491,11 @@ class DetailsWidget(QtWidgets.QWidget):
             )
         ]
 
-        self._set_logs(filtered_logs)
-
-    def _set_logs(self, logs: list[ReportLog]) -> None:
         show_timestamp = self._timestamp_check.isChecked()
-
-        self._output_widget.clear()
-        # Create copy of a document to avoid live updates in UI
-        document = self._output_widget.document().clone()
-        cursor = QtGui.QTextCursor(document)
-        default_fmt = self._output_widget.currentCharFormat()
-        prefix_fmt = QtGui.QTextCharFormat(default_fmt)
-        prefix_fmt.setForeground(QtGui.QColor("#7F8C8D"))
-
-        def _add_entry(idx, entry_prefix, entry):
-            if idx > 0:
-                cursor.insertBlock()
-            if entry_prefix:
-                cursor.insertText(entry_prefix, prefix_fmt)
-            cursor.insertText(entry, default_fmt)
-
-        for idx, log in enumerate(logs):
-            timestamp = ""
-            if show_timestamp and log.created is not None:
-                timestamp = (
-                    arrow
-                    .get(log.created)
-                    .to("local")
-                    .format("YYYY/MM/DD HH:mm:ss ")
-                )
-
-            if log.type == "record":
-                _add_entry(idx, f"{timestamp}{log.levelname}: ", log.message)
-                exc_info = log.exc_info
-                if exc_info:
-                    _add_entry(idx, f"{timestamp}", exc_info)
-
-            elif log.type == "error":
-                _add_entry(idx, f"{timestamp}TRACEBACK:\n", log.traceback)
-
-            else:
-                print(log.type)
-
-        cursor.select(QtGui.QTextCursor.Document)
-        fmt = QtGui.QTextBlockFormat()
-        if show_timestamp:
-            fmt.setLeftMargin(20)
-            fmt.setTextIndent(-20)
-        else:
-            fmt.setLeftMargin(0)
-            fmt.setTextIndent(0)
-        cursor.mergeBlockFormat(fmt)
-        self._output_widget.setDocument(document)
+        filler = _LogFiller(
+            self._output_widget, filtered_logs, show_timestamp
+        )
+        filler.fill()
 
 
 class PluginDetailsWidget(QtWidgets.QWidget):

--- a/client/ayon_core/tools/publisher/publish_report_viewer/widgets.py
+++ b/client/ayon_core/tools/publisher/publish_report_viewer/widgets.py
@@ -404,8 +404,22 @@ class DetailsWidget(QtWidgets.QWidget):
     def _set_logs(self, logs: list[ReportLog]) -> None:
         show_timestamp = self._timestamp_check.isChecked()
 
-        lines = []
-        for log in logs:
+        self._output_widget.clear()
+        # Create copy of a document to avoid live updates in UI
+        document = self._output_widget.document().clone()
+        cursor = QtGui.QTextCursor(document)
+        default_fmt = self._output_widget.currentCharFormat()
+        prefix_fmt = QtGui.QTextCharFormat(default_fmt)
+        prefix_fmt.setForeground(QtGui.QColor("#7F8C8D"))
+
+        def _add_entry(idx, entry_prefix, entry):
+            if idx > 0:
+                cursor.insertBlock()
+            if entry_prefix:
+                cursor.insertText(entry_prefix, prefix_fmt)
+            cursor.insertText(entry, default_fmt)
+
+        for idx, log in enumerate(logs):
             timestamp = ""
             if show_timestamp and log.created is not None:
                 timestamp = (
@@ -416,19 +430,27 @@ class DetailsWidget(QtWidgets.QWidget):
                 )
 
             if log.type == "record":
-                lines.append(f"{timestamp}{log.levelname}: {log.message}")
+                _add_entry(idx, f"{timestamp}{log.levelname}: ", log.message)
                 exc_info = log.exc_info
                 if exc_info:
-                    lines.append(f"{timestamp}{exc_info}")
+                    _add_entry(idx, f"{timestamp}", exc_info)
 
             elif log.type == "error":
-                lines.append(f"{timestamp}TRACEBACK:\n{log.traceback}")
+                _add_entry(idx, f"{timestamp}TRACEBACK:\n", log.traceback)
 
             else:
                 print(log.type)
 
-        text = "\n".join(lines)
-        self._output_widget.setPlainText(text)
+        cursor.select(QtGui.QTextCursor.Document)
+        fmt = QtGui.QTextBlockFormat()
+        if show_timestamp:
+            fmt.setLeftMargin(20)
+            fmt.setTextIndent(-20)
+        else:
+            fmt.setLeftMargin(0)
+            fmt.setTextIndent(0)
+        cursor.mergeBlockFormat(fmt)
+        self._output_widget.setDocument(document)
 
 
 class PluginDetailsWidget(QtWidgets.QWidget):

--- a/client/ayon_core/tools/publisher/publish_report_viewer/widgets.py
+++ b/client/ayon_core/tools/publisher/publish_report_viewer/widgets.py
@@ -404,20 +404,8 @@ class DetailsWidget(QtWidgets.QWidget):
     def _set_logs(self, logs: list[ReportLog]) -> None:
         show_timestamp = self._timestamp_check.isChecked()
 
-        self._output_widget.clear()
-        cursor = QtGui.QTextCursor(self._output_widget.document())
-        default_fmt = self._output_widget.currentCharFormat()
-        prefix_fmt = QtGui.QTextCharFormat(default_fmt)
-        prefix_fmt.setForeground(QtGui.QColor("#7F8C8D"))
-
-        def _add_entry(idx, entry_prefix, entry):
-            if idx > 0:
-                cursor.insertBlock()
-            if entry_prefix:
-                cursor.insertText(entry_prefix, prefix_fmt)
-            cursor.insertText(entry, default_fmt)
-
-        for idx, log in enumerate(logs):
+        lines = []
+        for log in logs:
             timestamp = ""
             if show_timestamp and log.created is not None:
                 timestamp = (
@@ -428,26 +416,19 @@ class DetailsWidget(QtWidgets.QWidget):
                 )
 
             if log.type == "record":
-                _add_entry(idx, f"{timestamp}{log.levelname}: ", log.message)
+                lines.append(f"{timestamp}{log.levelname}: {log.message}")
                 exc_info = log.exc_info
                 if exc_info:
-                    _add_entry(idx + 1, "", exc_info)
+                    lines.append(f"{timestamp}{exc_info}")
 
             elif log.type == "error":
-                _add_entry(idx, f"{timestamp}TRACEBACK: ", log.traceback)
+                lines.append(f"{timestamp}TRACEBACK:\n{log.traceback}")
 
             else:
                 print(log.type)
 
-        cursor.select(QtGui.QTextCursor.Document)
-        fmt = QtGui.QTextBlockFormat()
-        if show_timestamp:
-            fmt.setLeftMargin(20)
-            fmt.setTextIndent(-20)
-        else:
-            fmt.setLeftMargin(0)
-            fmt.setTextIndent(0)
-        cursor.mergeBlockFormat(fmt)
+        text = "\n".join(lines)
+        self._output_widget.setPlainText(text)
 
 
 class PluginDetailsWidget(QtWidgets.QWidget):

--- a/client/ayon_core/tools/publisher/publish_report_viewer/widgets.py
+++ b/client/ayon_core/tools/publisher/publish_report_viewer/widgets.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from math import ceil
+import typing
+
+import arrow
 from qtpy import QtWidgets, QtCore, QtGui
 
 from ayon_core.lib.icon_definitions import MaterialSymbolsIcon
@@ -12,10 +15,7 @@ from ayon_core.tools.utils import (
     paint_image_with_color,
     get_qt_icon,
 )
-from ayon_core.pipeline.publish.report import (
-    PublishReport,
-    PublishPluginReportInfo,
-)
+from ayon_core.pipeline.publish.report import PublishReport
 from ayon_core.resources import get_image_path
 from ayon_core.style import get_objected_colors
 
@@ -30,6 +30,12 @@ from .model import (
     PluginsModel,
     PluginProxyModel
 )
+
+if typing.TYPE_CHECKING:
+    from ayon_core.pipeline.publish.report import (
+        ReportLog,
+        PublishPluginReportInfo,
+    )
 
 FILEPATH_ROLE = QtCore.Qt.UserRole + 1
 TRACEBACK_ROLE = QtCore.Qt.UserRole + 2
@@ -323,6 +329,7 @@ class DetailsWidget(QtWidgets.QWidget):
         layout.addWidget(output_widget)
 
         self._is_active: bool = True
+        self._show_timestamp: bool = True
         self._need_refresh: bool = False
         self._output_widget: ZoomPlainText = output_widget
         self._report_item: PublishReport | None = None
@@ -373,11 +380,20 @@ class DetailsWidget(QtWidgets.QWidget):
 
         self._set_logs(filtered_logs)
 
-    def _set_logs(self, logs):
+    def _set_logs(self, logs: list[ReportLog]) -> None:
         lines = []
         for log in logs:
+            timestamp = ""
+            if self._show_timestamp and log.created is not None:
+                timestamp = (
+                    arrow
+                    .get(log.created)
+                    .to("local")
+                    .format("YYYY/MM/DD HH:mm:ss ")
+                )
+
             if log.type == "record":
-                message = f"{log.levelname}: {log.message}"
+                message = f"{timestamp}{log.levelname}: {log.message}"
 
                 lines.append(message)
                 exc_info = log.exc_info
@@ -385,7 +401,7 @@ class DetailsWidget(QtWidgets.QWidget):
                     lines.append(exc_info)
 
             elif log.type == "error":
-                lines.append(log.traceback)
+                lines.append(f"{timestamp} TRACEBACK:\n{log.traceback}")
 
             else:
                 print(log.type)

--- a/client/ayon_core/tools/publisher/publish_report_viewer/widgets.py
+++ b/client/ayon_core/tools/publisher/publish_report_viewer/widgets.py
@@ -321,21 +321,41 @@ class DetailsWidget(QtWidgets.QWidget):
     def __init__(self, parent: QtWidgets.QWidget) -> None:
         super().__init__(parent)
 
+        header_widget = QtWidgets.QWidget(self)
+
+        timestamp_check = NiceCheckbox(parent=header_widget)
+        timestamp_check.setChecked(True)
+        timestamp_label = QtWidgets.QLabel("Show timestamps", header_widget)
+
+        header_layout = QtWidgets.QHBoxLayout(header_widget)
+        header_layout.setContentsMargins(5, 5, 5, 5)
+        header_layout.addWidget(timestamp_check, 0)
+        header_layout.addWidget(timestamp_label, 0)
+        header_layout.addStretch(1)
+
         output_widget = ZoomPlainText(self)
         output_widget.setObjectName("PublishLogConsole")
         output_widget.setTextInteractionFlags(QtCore.Qt.TextBrowserInteraction)
 
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(output_widget)
+        layout.setSpacing(0)
+        layout.addWidget(header_widget, 0)
+        layout.addWidget(output_widget, 1)
+
+        timestamp_check.stateChanged.connect(self._on_timestamp_check)
 
         self._is_active: bool = True
-        self._show_timestamp: bool = True
         self._need_refresh: bool = False
+
+        self._timestamp_check = timestamp_check
         self._output_widget: ZoomPlainText = output_widget
         self._report_item: PublishReport | None = None
         self._instance_filter: set[str] = set()
         self._plugin_filter: set[str] = set()
+
+    def _on_timestamp_check(self):
+        self._update_logs()
 
     def clear(self) -> None:
         self._output_widget.setPlainText("")
@@ -382,6 +402,8 @@ class DetailsWidget(QtWidgets.QWidget):
         self._set_logs(filtered_logs)
 
     def _set_logs(self, logs: list[ReportLog]) -> None:
+        show_timestamp = self._timestamp_check.isChecked()
+
         self._output_widget.clear()
         cursor = QtGui.QTextCursor(self._output_widget.document())
         default_fmt = self._output_widget.currentCharFormat()
@@ -397,7 +419,7 @@ class DetailsWidget(QtWidgets.QWidget):
 
         for idx, log in enumerate(logs):
             timestamp = ""
-            if self._show_timestamp and log.created is not None:
+            if show_timestamp and log.created is not None:
                 timestamp = (
                     arrow
                     .get(log.created)
@@ -419,7 +441,7 @@ class DetailsWidget(QtWidgets.QWidget):
 
         cursor.select(QtGui.QTextCursor.Document)
         fmt = QtGui.QTextBlockFormat()
-        if self._show_timestamp:
+        if show_timestamp:
             fmt.setLeftMargin(20)
             fmt.setTextIndent(-20)
         else:

--- a/client/ayon_core/tools/publisher/publish_report_viewer/widgets.py
+++ b/client/ayon_core/tools/publisher/publish_report_viewer/widgets.py
@@ -382,8 +382,20 @@ class DetailsWidget(QtWidgets.QWidget):
         self._set_logs(filtered_logs)
 
     def _set_logs(self, logs: list[ReportLog]) -> None:
-        lines = []
-        for log in logs:
+        self._output_widget.clear()
+        cursor = QtGui.QTextCursor(self._output_widget.document())
+        default_fmt = self._output_widget.currentCharFormat()
+        prefix_fmt = QtGui.QTextCharFormat(default_fmt)
+        prefix_fmt.setForeground(QtGui.QColor("#7F8C8D"))
+
+        def _add_entry(idx, entry_prefix, entry):
+            if idx > 0:
+                cursor.insertBlock()
+            if entry_prefix:
+                cursor.insertText(entry_prefix, prefix_fmt)
+            cursor.insertText(entry, default_fmt)
+
+        for idx, log in enumerate(logs):
             timestamp = ""
             if self._show_timestamp and log.created is not None:
                 timestamp = (
@@ -394,28 +406,26 @@ class DetailsWidget(QtWidgets.QWidget):
                 )
 
             if log.type == "record":
-                message = f"{timestamp}{log.levelname}: {log.message}"
-
-                lines.append(message)
+                _add_entry(idx, f"{timestamp}{log.levelname}: ", log.message)
                 exc_info = log.exc_info
                 if exc_info:
-                    lines.append(exc_info)
+                    _add_entry(idx + 1, "", exc_info)
 
             elif log.type == "error":
-                lines.append(f"{timestamp}TRACEBACK:\n{log.traceback}")
+                _add_entry(idx, f"{timestamp}TRACEBACK: ", log.traceback)
 
             else:
                 print(log.type)
 
-        text = "\n".join(lines)
-        self._output_widget.setPlainText(text)
+        cursor.select(QtGui.QTextCursor.Document)
+        fmt = QtGui.QTextBlockFormat()
         if self._show_timestamp:
-            cursor = QtGui.QTextCursor(self._output_widget.document())
-            cursor.select(QtGui.QTextCursor.Document)
-            fmt = QtGui.QTextBlockFormat()
             fmt.setLeftMargin(20)
             fmt.setTextIndent(-20)
-            cursor.mergeBlockFormat(fmt)
+        else:
+            fmt.setLeftMargin(0)
+            fmt.setTextIndent(0)
+        cursor.mergeBlockFormat(fmt)
 
 
 class PluginDetailsWidget(QtWidgets.QWidget):

--- a/client/ayon_core/tools/publisher/publish_report_viewer/widgets.py
+++ b/client/ayon_core/tools/publisher/publish_report_viewer/widgets.py
@@ -240,12 +240,13 @@ class PluginLoadReportWidget(QtWidgets.QWidget):
         self._widgets_by_filepath[filepath] = (widget, index)
 
 
-class ZoomPlainText(QtWidgets.QPlainTextEdit):
+class ZoomPlainText(QtWidgets.QTextEdit):
     min_point_size = 1.0
     max_point_size = 200.0
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.setAcceptRichText(False)
 
         anim_timer = QtCore.QTimer()
         anim_timer.setInterval(20)
@@ -401,13 +402,20 @@ class DetailsWidget(QtWidgets.QWidget):
                     lines.append(exc_info)
 
             elif log.type == "error":
-                lines.append(f"{timestamp} TRACEBACK:\n{log.traceback}")
+                lines.append(f"{timestamp}TRACEBACK:\n{log.traceback}")
 
             else:
                 print(log.type)
 
         text = "\n".join(lines)
         self._output_widget.setPlainText(text)
+        if self._show_timestamp:
+            cursor = QtGui.QTextCursor(self._output_widget.document())
+            cursor.select(QtGui.QTextCursor.Document)
+            fmt = QtGui.QTextBlockFormat()
+            fmt.setLeftMargin(20)
+            fmt.setTextIndent(-20)
+            cursor.mergeBlockFormat(fmt)
 
 
 class PluginDetailsWidget(QtWidgets.QWidget):


### PR DESCRIPTION
## Changelog Description
Publish report viewer does show timestamps in logs.

## Additional info
Use timestamp from logs to show it in UI.

### Screenshot
<img width="510" height="490" alt="image" src="https://github.com/user-attachments/assets/f3fa0c73-9a37-45c6-afa4-cbbae7f13bb6" />

## Testing notes:
The timestamp is not available on older reports so you might need to create new one.
1. Open publish report viewer.
2. Select a report.
3. In logs make sure `Show timestamp` is enabled.
4. Logs should show timestamps.
5. Disabling the checkbox should hide them.

I didn't try this on super long report with a tons of logs, it might be good idea to find out (e.g. from editorial) and test the performance.