### PR TITLE
YN-1000 - Fix audio offset ffmpeg filter on extract_review.

### DIFF
--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -1304,21 +1304,24 @@ class ExtractReview(pyblish.api.InstancePlugin):
             return audio_in_args, audio_filters, audio_out_args
 
         for audio in audio_inputs:
-            offset_seconds = audio.get("offset") or 0
+            offset_seconds = audio.get("offset", 0)
+            # Delay audio start to match its timeline position.
             if offset_seconds > 0:
+                # "all=1" applies to every channel (mono, stereo, 5.1…).
                 delay_ms = int(round(offset_seconds * 1000))
-                audio_filters.append("adelay={}|{}".format(delay_ms, delay_ms))
-
+                audio_filters.append(
+                    "adelay={}:all=1".format(delay_ms)
+                )
+            # Crop audio file input.
             elif offset_seconds < 0:
                 audio_in_args.append(
                     "-ss {}".format(abs(offset_seconds))
                 )
 
-            # Audio duration is offset from `-ss`
-            audio_duration = duration_seconds + offset_seconds
-
-            # Set audio duration
-            audio_in_args.append("-to {:0.10f}".format(audio_duration))
+            # Audio duration
+            audio_in_args.append(
+                "-to {:0.10f}".format(duration_seconds - offset_seconds)
+            )
 
             # Ignore video data from audio input
             audio_in_args.append("-vn")

--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -1304,6 +1304,9 @@ class ExtractReview(pyblish.api.InstancePlugin):
             return audio_in_args, audio_filters, audio_out_args
 
         for audio in audio_inputs:
+            # 'offset' was set only by maya addon and it used frame offset
+            #     instead of seconds offset. To prevent issues the value is
+            #     ignored and logged as skipped.
             if audio.get("offset"):
                 self.log.warning(
                     "Ignored deprecated audio input attribute 'offset'. "

--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -1338,6 +1338,23 @@ class ExtractReview(pyblish.api.InstancePlugin):
             audio_out_args.append("-filter_complex amerge")
             audio_out_args.append("-ac {}".format(len(audio_inputs)))
 
+        # Resample audio to ensure block duration from AAC
+        # encoder never exceeds one video frame duration.
+        # Pick the lowest video standard rate satisfying this constraint.
+        # For non-AAC codecs, this has no negative effect.
+
+        # TODO: Replace with once https://trac.ffmpeg.org/ticket/11668 is fixed
+        # audio_filters.append("apad")
+        # audio_out_args.append("-shortest")
+
+        standard_audio_rates = (48000, 96000, 192000)
+        min_audio_rate = 1024 * temp_data.fps  # 1 AAC block = 1024 samples
+        sample_rate = next(
+            (rate for rate in standard_audio_rates if rate > min_audio_rate),
+            standard_audio_rates[-1]
+        )
+        audio_out_args.append("-ar {}".format(sample_rate))
+
         return audio_in_args, audio_filters, audio_out_args
 
     def get_letterbox_filters(

--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -1304,7 +1304,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
             return audio_in_args, audio_filters, audio_out_args
 
         for audio in audio_inputs:
-            if not audio.get("offset"):
+            if audio.get("offset"):
                 self.log.warning(
                     "Ignored deprecated audio input attribute 'offset'. "
                     "Use 'offset_in_seconds' instead."

--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -1304,15 +1304,14 @@ class ExtractReview(pyblish.api.InstancePlugin):
             return audio_in_args, audio_filters, audio_out_args
 
         for audio in audio_inputs:
-            offset_seconds = 0
+            offset_seconds = audio.get("offset") or 0
             if offset_seconds > 0:
-                audio_in_args.append(
-                    "-ss {}".format(offset_seconds)
-                )
+                delay_ms = int(round(offset_seconds * 1000))
+                audio_filters.append("adelay={}|{}".format(delay_ms, delay_ms))
 
             elif offset_seconds < 0:
                 audio_in_args.append(
-                    "-itsoffset {}".format(abs(offset_seconds))
+                    "-ss {}".format(abs(offset_seconds))
                 )
 
             # Audio duration is offset from `-ss`

--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -1359,7 +1359,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
             (rate for rate in standard_audio_rates if rate > min_audio_rate),
             standard_audio_rates[-1]
         )
-        audio_out_args.append("-ar {}".format(sample_rate))
+        audio_out_args.append(f"-ar {sample_rate}")
 
         return audio_in_args, audio_filters, audio_out_args
 

--- a/client/ayon_core/plugins/publish/extract_review.py
+++ b/client/ayon_core/plugins/publish/extract_review.py
@@ -1304,7 +1304,13 @@ class ExtractReview(pyblish.api.InstancePlugin):
             return audio_in_args, audio_filters, audio_out_args
 
         for audio in audio_inputs:
-            offset_seconds = audio.get("offset", 0)
+            if not audio.get("offset"):
+                self.log.warning(
+                    "Ignored deprecated audio input attribute 'offset'. "
+                    "Use 'offset_in_seconds' instead."
+                )
+
+            offset_seconds = audio.get("offset_in_seconds", 0)
             # Delay audio start to match its timeline position.
             if offset_seconds > 0:
                 # "all=1" applies to every channel (mono, stereo, 5.1…).


### PR DESCRIPTION
## Changelog Description

Changes:
* [x] Fix dead code for audio offset in `extract_review` plugins
* [x] Fix positive audio offset using [`adelay` filter](https://stackoverflow.com/questions/52446539/how-to-add-offset-or-delay-to-audio-file-with-ffmpeg) instead of `-itsoffset` which is for video 


## Testing notes:
1. Create a review instance with an audio offset (positive or negative)
2. Ensure the audio track of the resulting review media match audio offset.
