### PR TITLE
FFmpeg: Use `-/filter` for ffmpeg-9.x+

### DIFF
--- a/client/ayon_core/lib/__init__.py
+++ b/client/ayon_core/lib/__init__.py
@@ -35,7 +35,7 @@ from .vendor_bin_utils import (
     get_ffmpeg_supported_options,
     get_ffmpeg_tool_path,
     get_ffmpeg_tool_args,
-    is_ffmpeg_supported_option,
+    is_ffmpeg_option_supported,
     is_oiio_supported,
 )
 
@@ -200,7 +200,7 @@ __all__ = [
     "get_ffmpeg_supported_options",
     "get_ffmpeg_tool_path",
     "get_ffmpeg_tool_args",
-    "is_ffmpeg_supported_option",
+    "is_ffmpeg_option_supported",
     "is_oiio_supported",
 
     "IconBase",

--- a/client/ayon_core/lib/__init__.py
+++ b/client/ayon_core/lib/__init__.py
@@ -197,8 +197,10 @@ __all__ = [
     "find_executable",
     "get_oiio_tools_path",
     "get_oiio_tool_args",
+    "get_ffmpeg_supported_options",
     "get_ffmpeg_tool_path",
     "get_ffmpeg_tool_args",
+    "is_ffmpeg_supported_option",
     "is_oiio_supported",
 
     "IconBase",

--- a/client/ayon_core/lib/__init__.py
+++ b/client/ayon_core/lib/__init__.py
@@ -32,8 +32,10 @@ from .vendor_bin_utils import (
     find_executable,
     get_oiio_tools_path,
     get_oiio_tool_args,
+    get_ffmpeg_supported_options,
     get_ffmpeg_tool_path,
     get_ffmpeg_tool_args,
+    is_ffmpeg_supported_option,
     is_oiio_supported,
 )
 

--- a/client/ayon_core/lib/vendor_bin_utils.py
+++ b/client/ayon_core/lib/vendor_bin_utils.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import logging
 import platform
@@ -463,6 +464,48 @@ def get_ffmpeg_tool_args(tool_name, *extra_args):
     raise ToolNotFoundError(
         "FFmpeg '{}' tool not found.".format(tool_name)
     )
+
+
+@functools.lru_cache
+def get_ffmpeg_supported_options(mode: str = "long") -> set[str]:
+    """Get all the options supported by the current FFmpeg version.
+
+    Args:
+        mode: Which version of the help message to parse
+            Can be "long", "full" or "" (for short)
+            Default is "long"
+
+    Returns:
+        set[str]: All the options supported by the current FFmpeg version.
+
+    """
+    ffmpeg = get_ffmpeg_tool_path("ffmpeg")
+    result = subprocess.run(
+        [ffmpeg, "-h", mode],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+
+    options: set[str] = set()
+    for line in result.stdout.splitlines():
+        option = line.lstrip()
+        if not option.startswith("-"):
+            continue
+        option = option.split(" ", maxsplit=1)[0]  # remove description
+        option = option.split("[", maxsplit=1)[0]  # remove stream_specifier
+        if not option:
+            continue
+
+        options.add(option)
+
+    return options
+
+
+def is_ffmpeg_supported_option(option: str) -> bool:
+    """True if the current version of ffmpeg supports the given option."""
+    return option in get_ffmpeg_supported_options()
 
 
 def is_oiio_supported():

--- a/client/ayon_core/lib/vendor_bin_utils.py
+++ b/client/ayon_core/lib/vendor_bin_utils.py
@@ -479,9 +479,8 @@ def get_ffmpeg_supported_options(mode: str = "long") -> set[str]:
         set[str]: All the options supported by the current FFmpeg version.
 
     """
-    ffmpeg = get_ffmpeg_tool_path("ffmpeg")
     result = subprocess.run(
-        [ffmpeg, "-h", mode],
+        get_ffmpeg_tool_args("ffmpeg", "-h", mode),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,

--- a/client/ayon_core/lib/vendor_bin_utils.py
+++ b/client/ayon_core/lib/vendor_bin_utils.py
@@ -495,6 +495,7 @@ def get_ffmpeg_supported_options(mode: str = "long") -> set[str]:
             continue
         option = option.split(" ", maxsplit=1)[0]  # remove description
         option = option.split("[", maxsplit=1)[0]  # remove stream_specifier
+        option = option.lstrip("-")
         if not option:
             continue
 

--- a/client/ayon_core/lib/vendor_bin_utils.py
+++ b/client/ayon_core/lib/vendor_bin_utils.py
@@ -503,7 +503,7 @@ def get_ffmpeg_supported_options(mode: str = "long") -> set[str]:
     return options
 
 
-def is_ffmpeg_supported_option(option: str) -> bool:
+def is_ffmpeg_option_supported(option: str) -> bool:
     """True if the current version of ffmpeg supports the given option."""
     return option in get_ffmpeg_supported_options()
 

--- a/client/ayon_core/plugins/publish/extract_otio_audio_tracks.py
+++ b/client/ayon_core/plugins/publish/extract_otio_audio_tracks.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pyblish
 from ayon_core.lib import get_ffmpeg_tool_args, run_subprocess
+from ayon_core.lib.vendor_bin_utils import is_ffmpeg_supported_option
 
 
 def get_audio_instances(context):
@@ -398,11 +399,12 @@ class ExtractOtioAudioTracks(pyblish.api.ContextPlugin):
 
         args = get_ffmpeg_tool_args("ffmpeg")
         args.extend(input_args)
-        args.extend([
-            "-filter_complex_script", filters_tmp_filepath,
-            "-map", "[a]"
-        ])
-        args.append(audio_temp_fpath)
+
+        if is_ffmpeg_supported_option("filter_complex_script"):
+            args.extend(["-filter_complex_script", filters_tmp_filepath])
+        else:
+            args.extend(["-/filter_complex", filters_tmp_filepath])
+        args.extend(["-map", "[a]", audio_temp_fpath])
 
         # run subprocess
         self.log.debug("Executing: {}".format(args))

--- a/client/ayon_core/plugins/publish/extract_otio_audio_tracks.py
+++ b/client/ayon_core/plugins/publish/extract_otio_audio_tracks.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pyblish
 from ayon_core.lib import get_ffmpeg_tool_args, run_subprocess
-from ayon_core.lib.vendor_bin_utils import is_ffmpeg_supported_option
+from ayon_core.lib.vendor_bin_utils import is_ffmpeg_option_supported
 
 
 def get_audio_instances(context):
@@ -400,7 +400,7 @@ class ExtractOtioAudioTracks(pyblish.api.ContextPlugin):
         args = get_ffmpeg_tool_args("ffmpeg")
         args.extend(input_args)
 
-        if is_ffmpeg_supported_option("filter_complex_script"):
+        if is_ffmpeg_option_supported("filter_complex_script"):
             args.extend(["-filter_complex_script", filters_tmp_filepath])
         else:
             args.extend(["-/filter_complex", filters_tmp_filepath])

--- a/client/ayon_core/scripts/otio_burnin.py
+++ b/client/ayon_core/scripts/otio_burnin.py
@@ -27,7 +27,7 @@ from ayon_core.lib import (
     get_ffmpeg_codec_args,
     get_ffmpeg_format_args,
     convert_ffprobe_fps_value,
-    is_ffmpeg_supported_option,
+    is_ffmpeg_option_supported,
     StringTemplate,
 )
 
@@ -649,7 +649,7 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
                 filters_path = temp.name
 
             # "-filter_script" was removed in FFmpeg 9 in favor of "-/filter"
-            if is_ffmpeg_supported_option("filter_script"):
+            if is_ffmpeg_option_supported("filter_script"):
                 filters = f'-filter_script:v "{filters_path}"'
             else:
                 filters = f'-/filter:v "{filters_path}"'

--- a/client/ayon_core/scripts/otio_burnin.py
+++ b/client/ayon_core/scripts/otio_burnin.py
@@ -650,7 +650,7 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
                 filters_path = temp.name
 
             # "-filter_script" was removed in FFmpeg 9 in favor of "-/filter"
-            if is_ffmpeg_supported_option("-filter_script"):
+            if is_ffmpeg_supported_option("filter_script"):
                 filters = f'-filter_script:v "{filters_path}"'
             else:
                 filters = f'-/filter:v "{filters_path}"'

--- a/client/ayon_core/scripts/otio_burnin.py
+++ b/client/ayon_core/scripts/otio_burnin.py
@@ -78,11 +78,11 @@ def get_supported_ffmpeg_options(mode: str = "long") -> set[str]:
     options: set[str] = set()
     for line in result.stdout.splitlines():
         option = line.lstrip()
+        if not option.startswith("-"):
+            continue
         option = option.split(" ", maxsplit=1)[0]  # remove description
         option = option.split("[", maxsplit=1)[0]  # remove stream_specifier
         if not option:
-            continue
-        if not option.startswith("-"):
             continue
 
         options.add(option)

--- a/client/ayon_core/scripts/otio_burnin.py
+++ b/client/ayon_core/scripts/otio_burnin.py
@@ -28,6 +28,7 @@ from ayon_core.lib import (
     get_ffmpeg_codec_args,
     get_ffmpeg_format_args,
     convert_ffprobe_fps_value,
+    is_ffmpeg_supported_option,
     StringTemplate,
 )
 
@@ -47,51 +48,6 @@ CURRENT_FRAME_KEY = "{current_frame}"
 CURRENT_FRAME_SPLITTER = "_-_CURRENT_FRAME_-_"
 TIMECODE_KEY = "{timecode}"
 SOURCE_TIMECODE_KEY = "{source_timecode}"
-
-
-@functools.lru_cache
-def get_supported_ffmpeg_options(mode: str = "long") -> set[str]:
-    """Get all the options supported by the current FFmpeg version.
-
-    Args:
-        mode: Which version of the help message to parse
-            Can be "long", "full" or "" (for short)
-            Default is "long"
-
-    Returns:
-        set[str]: All the options supported by the current FFmpeg version.
-
-    """
-    result = subprocess.run(
-        [
-            *FFMPEG_EXE_ARGS,
-            "-h",
-            mode,
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        check=False,
-    )
-
-    options: set[str] = set()
-    for line in result.stdout.splitlines():
-        option = line.lstrip()
-        if not option.startswith("-"):
-            continue
-        option = option.split(" ", maxsplit=1)[0]  # remove description
-        option = option.split("[", maxsplit=1)[0]  # remove stream_specifier
-        if not option:
-            continue
-
-        options.add(option)
-
-    return options
-
-
-def ffmpeg_supports_option(option: str) -> bool:
-    """True if the current version of ffmpeg supports the given option."""
-    return option in get_supported_ffmpeg_options()
 
 
 def _get_text_width_fonttools(
@@ -694,7 +650,7 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
                 filters_path = temp.name
 
             # "-filter_script" was removed in FFmpeg 9 in favor of "-/filter"
-            if ffmpeg_supports_option("-filter_script"):
+            if is_ffmpeg_supported_option("-filter_script"):
                 filters = f'-filter_script:v "{filters_path}"'
             else:
                 filters = f'-/filter:v "{filters_path}"'

--- a/client/ayon_core/scripts/otio_burnin.py
+++ b/client/ayon_core/scripts/otio_burnin.py
@@ -65,7 +65,6 @@ def get_supported_ffmpeg_options(mode: str = "long") -> set[str]:
     result = subprocess.run(
         [
             *FFMPEG_EXE_ARGS,
-            "-hide_banner",
             "-h",
             mode,
         ],

--- a/client/ayon_core/scripts/otio_burnin.py
+++ b/client/ayon_core/scripts/otio_burnin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import math
 import os
 import string
@@ -46,6 +47,52 @@ CURRENT_FRAME_KEY = "{current_frame}"
 CURRENT_FRAME_SPLITTER = "_-_CURRENT_FRAME_-_"
 TIMECODE_KEY = "{timecode}"
 SOURCE_TIMECODE_KEY = "{source_timecode}"
+
+
+@functools.lru_cache
+def get_supported_ffmpeg_options(mode: str = "long") -> set[str]:
+    """Get all the options supported by the current FFmpeg version.
+
+    Args:
+        mode: Which version of the help message to parse
+            Can be "long", "full" or "" (for short)
+            Default is "long"
+
+    Returns:
+        set[str]: All the options supported by the current FFmpeg version.
+
+    """
+    result = subprocess.run(
+        [
+            *FFMPEG_EXE_ARGS,
+            "-hide_banner",
+            "-h",
+            mode,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+
+    options: set[str] = set()
+    for line in result.stdout.splitlines():
+        option = line.lstrip()
+        option = option.split(" ", maxsplit=1)[0]  # remove description
+        option = option.split("[", maxsplit=1)[0]  # remove stream_specifier
+        if not option:
+            continue
+        if not option.startswith("-"):
+            continue
+
+        options.add(option)
+
+    return options
+
+
+def ffmpeg_supports_option(option: str) -> bool:
+    """True if the current version of ffmpeg supports the given option."""
+    return option in get_supported_ffmpeg_options()
 
 
 def _get_text_width_fonttools(
@@ -646,7 +693,13 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
             ) as temp:
                 temp.write(filter_string)
                 filters_path = temp.name
-            filters = '-filter_script:v "{}"'.format(filters_path)
+
+            # "-filter_script" was removed in FFmpeg 9 in favor of "-/filter"
+            if ffmpeg_supports_option("-filter_script"):
+                filters = f'-filter_script:v "{filters_path}"'
+            else:
+                filters = f'-/filter:v "{filters_path}"'
+
             print("Filters:", filter_string)
             self.cleanup_paths.append(filters_path)
 

--- a/client/ayon_core/scripts/otio_burnin.py
+++ b/client/ayon_core/scripts/otio_burnin.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 import math
 import os
 import string


### PR DESCRIPTION
## Changelog Description
use `-/filter` for ffmpeg 9.x

## Additional info
`-filter_script` has been removed in ffmpeg 9.x. ([relevant commit](https://github.com/FFmpeg/FFmpeg/commit/07407fff6142f14dcb21b8a06d0d15db0e31135e#diff-b646b1a71ed55a47856727c59940ee9579254bdf1db57c33f2d229516beb3fc4L1800-L1804)) 
It was marked as deprecated for a while.

I've added a check and decided to support both, since `-/filter` is apparently only supported as of ffmpeg 7.x.
Removing it would break things for anyone running ffmpeg 1.x - 5.x


## Testing notes:
1. install ffmpeg 9.x
2. try to publish a product that uses otio_burnin
