### PR TITLE
Integrate Hero version with traits: Skip if no published representations or hero versions are disabled.

### DIFF
--- a/client/ayon_core/plugins/publish/integrate_hero_version_with_traits.py
+++ b/client/ayon_core/plugins/publish/integrate_hero_version_with_traits.py
@@ -97,6 +97,20 @@ class IntegrateHeroVersionTraits(
 
     use_hardlinks = False
 
+    @classmethod
+    def apply_settings(cls, settings):
+        # Inherit settings from IntegrateHeroVersion so that essentially
+        # the enabled state is shared between the two plugins.
+        integrate_hero_settings = settings["publish"]["IntegrateHeroVersion"]
+        for option, value in integrate_hero_settings.items():
+            cls.log.debug(
+                "Plugin %s - Attr: %s -> %s",
+                cls.__name__,
+                option,
+                value,
+            )
+            setattr(cls, option, value)
+
     def process(self, instance: pyblish.api.Instance) -> None:
         """Integrate Hero version with representation traits.
 

--- a/client/ayon_core/plugins/publish/integrate_hero_version_with_traits.py
+++ b/client/ayon_core/plugins/publish/integrate_hero_version_with_traits.py
@@ -107,6 +107,13 @@ class IntegrateHeroVersionTraits(
         if not self.is_active(instance.data):
             return
 
+        if not instance.data.get("published_representations"):
+            self.log.debug(
+                "Instance has no published representations. "
+                "Skipping hero version with traits integration."
+            )
+            return
+
         if not has_trait_representations(instance):
             self.log.debug(
                 f"Instance '{instance.name}' has no representations with "

--- a/client/ayon_core/plugins/publish/integrate_hero_version_with_traits.py
+++ b/client/ayon_core/plugins/publish/integrate_hero_version_with_traits.py
@@ -101,7 +101,9 @@ class IntegrateHeroVersionTraits(
     def apply_settings(cls, settings):
         # Inherit settings from IntegrateHeroVersion so that essentially
         # the enabled state is shared between the two plugins.
-        integrate_hero_settings = settings["publish"]["IntegrateHeroVersion"]
+        integrate_hero_settings = (
+            settings["core"]["publish"]["IntegrateHeroVersion"]
+        )
         for option, value in integrate_hero_settings.items():
             cls.log.debug(
                 "Plugin %s - Attr: %s -> %s",


### PR DESCRIPTION
## Changelog

Skip hero version integrate with traits if there are no published representations, e.g. instance has `integrate=False`.
Plus in settings share them with IntegrateHeroVersion

## Additional info

Now the integrator can actually be disabled.

Fix #2007 

In the future I think we should consolidate it into one plug-in, but let the single plug-in decide which of the two hero version integrations to trigger. For now this is the easiest hotfix.

## Testing notes:

1. Integrate Hero version with traits can be disabled and should be skipped completely (via `IntegrateHeroVersion` settings)
2. Integrate Hero version with traits should skip instances without publishes, e.g. if a pointcache is marked to be processed on the farm.