### PR TITLE
Publish: Capture more logs

### DIFF
--- a/client/ayon_core/lib/log.py
+++ b/client/ayon_core/lib/log.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import os
-import sys
+import copy
 import getpass
 import logging
+import os
 import platform
 import socket
+import sys
 import time
 import threading
-import copy
 import warnings
 
 from . import Terminal

--- a/client/ayon_core/lib/log.py
+++ b/client/ayon_core/lib/log.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 import getpass
@@ -113,6 +115,7 @@ class Logger:
 
     # Logging level - AYON_LOG_LEVEL
     log_level = None
+    logger_names: set[str] = set()
 
     # Data same for all record documents
     process_data = None
@@ -124,7 +127,10 @@ class Logger:
         if not cls.initialized:
             cls.initialize()
 
-        logger = logging.getLogger(name or "__main__")
+        if not name:
+            name = "__main__"
+        cls.logger_names.add(name)
+        logger = logging.getLogger(name)
 
         logger.setLevel(cls.log_level)
 

--- a/client/ayon_core/lib/log.py
+++ b/client/ayon_core/lib/log.py
@@ -112,10 +112,10 @@ class Logger:
     # Is static class initialized
     initialized = False
     _init_lock = threading.Lock()
+    _root_logger = None
 
     # Logging level - AYON_LOG_LEVEL
     log_level = None
-    logger_names: set[str] = set()
 
     # Data same for all record documents
     process_data = None
@@ -127,26 +127,17 @@ class Logger:
         if not cls.initialized:
             cls.initialize()
 
-        if not name:
-            name = "__main__"
-        cls.logger_names.add(name)
-        logger = logging.getLogger(name)
-
+        logger = logging.getLogger(name or "__main__")
         logger.setLevel(cls.log_level)
-
-        add_console_handler = True
-
-        for handler in logger.handlers:
-            if isinstance(handler, LogStreamHandler):
-                add_console_handler = False
-
-        if add_console_handler:
-            logger.addHandler(cls._get_console_handler())
-
-        # Do not propagate logs to root logger
-        logger.propagate = False
+        logger.parent = cls._root_logger
 
         return logger
+
+    @classmethod
+    def get_root_logger(cls) -> logging.Logger:
+        if not cls.initialized:
+            cls.initialize()
+        return cls._root_logger
 
     @classmethod
     def _get_console_handler(cls):
@@ -184,6 +175,11 @@ class Logger:
             else:
                 log_level = 20
         cls.log_level = int(log_level)
+        root_logger = logging.getLogger("AYON")
+        root_logger.propagate = False
+        root_logger.setLevel(cls.log_level)
+        root_logger.addHandler(cls._get_console_handler())
+        cls._root_logger = root_logger
 
         # Mark as initialized
         cls.initialized = True

--- a/client/ayon_core/lib/log.py
+++ b/client/ayon_core/lib/log.py
@@ -9,6 +9,7 @@ import socket
 import time
 import threading
 import copy
+import warnings
 
 from . import Terminal
 
@@ -93,6 +94,19 @@ class LogFormatter(logging.Formatter):
         return out
 
 
+def _deprecated_getter(func):
+    def _get_logger_deprecate(cls, name: str | None = None) -> logging.Logger:
+        if name is None:
+            warnings.warn(
+                "DEPRECATION: 'Logger.get_logger' without passed name is"
+                " deprecated and will be removed in future versions.",
+                stacklevel=2,
+            )
+            name = "__main__"
+        return func(cls, name)
+    return _get_logger_deprecate
+
+
 class Logger:
     DFT = '%(levelname)s >>> { %(name)s }: [ %(message)s ] '
     DBG = "  - { %(name)s }: [ %(message)s ] "
@@ -123,7 +137,8 @@ class Logger:
     _process_name = None
 
     @classmethod
-    def get_logger(cls, name=None):
+    @_deprecated_getter
+    def get_logger(cls, name: str) -> logging.Logger:
         if not cls.initialized:
             cls.initialize()
 

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -12,6 +12,7 @@ import pyblish.api
 import pyblish.logic
 import pyblish.plugin
 
+from ayon_core.lib import Logger
 from ayon_core.settings import get_project_settings
 from ayon_core.pipeline.plugin_discover import DiscoverResult
 
@@ -1016,23 +1017,34 @@ class PublishLogic:
 
     @contextmanager
     def _log_manager(self, plugin: PluginType):
+        if self._log_to_console:
+            yield None
+            return
+
         root = logging.getLogger()
-        if not self._log_to_console:
-            plugin.log.propagate = False
-            plugin.log.addHandler(self._log_handler)
-            root.addHandler(self._log_handler)
+        plugin.log.propagate = False
+        plugin.log.addHandler(self._log_handler)
+        root.addHandler(self._log_handler)
+
+        ayon_loggers = []
+        for logger_name in Logger.logger_names:
+            logger = logging.getLogger(logger_name)
+            # Add only logger that are not propagating to root logger,
+            #   because root logger is already added to log handler.
+            if not logger.propagate:
+                ayon_loggers.append(logger)
+                logger.addHandler(self._log_handler)
 
         try:
-            if self._log_to_console:
-                yield None
-            else:
-                yield self._log_handler
+            yield self._log_handler
 
         finally:
-            if not self._log_to_console:
-                plugin.log.propagate = True
-                plugin.log.removeHandler(self._log_handler)
-                root.removeHandler(self._log_handler)
+            plugin.log.propagate = True
+            plugin.log.removeHandler(self._log_handler)
+            root.removeHandler(self._log_handler)
+
+            for logger in ayon_loggers:
+                logger.removeHandler(self._log_handler)
             self._log_handler.clear_records()
 
     def _process_plugin(

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -1017,34 +1017,23 @@ class PublishLogic:
 
     @contextmanager
     def _log_manager(self, plugin: PluginType):
-        if self._log_to_console:
-            yield None
-            return
-
         root = logging.getLogger()
-        plugin.log.propagate = False
-        plugin.log.addHandler(self._log_handler)
+        ayon_root = Logger.get_root_logger()
+        if not self._log_to_console:
+            plugin.log.propagate = False
+            plugin.log.addHandler(self._log_handler)
         root.addHandler(self._log_handler)
-
-        ayon_loggers = []
-        for logger_name in Logger.logger_names:
-            logger = logging.getLogger(logger_name)
-            # Add only logger that are not propagating to root logger,
-            #   because root logger is already added to log handler.
-            if not logger.propagate:
-                ayon_loggers.append(logger)
-                logger.addHandler(self._log_handler)
+        ayon_root.addHandler(self._log_handler)
 
         try:
             yield self._log_handler
 
         finally:
-            plugin.log.propagate = True
-            plugin.log.removeHandler(self._log_handler)
+            if not self._log_to_console:
+                plugin.log.propagate = True
+                plugin.log.removeHandler(self._log_handler)
             root.removeHandler(self._log_handler)
-
-            for logger in ayon_loggers:
-                logger.removeHandler(self._log_handler)
+            ayon_root.removeHandler(self._log_handler)
             self._log_handler.clear_records()
 
     def _process_plugin(

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -1019,9 +1019,13 @@ class PublishLogic:
     def _log_manager(self, plugin: PluginType):
         root = logging.getLogger()
         ayon_root = Logger.get_root_logger()
+        plugin_log_has_handler = False
         orig_propagate = plugin.log.propagate
         if not self._log_to_console:
             plugin.log.propagate = False
+
+        if not plugin.log.propagate:
+            plugin_log_has_handler = True
             plugin.log.addHandler(self._log_handler)
         root.addHandler(self._log_handler)
         ayon_root.addHandler(self._log_handler)
@@ -1030,7 +1034,7 @@ class PublishLogic:
             yield self._log_handler
 
         finally:
-            if not self._log_to_console:
+            if plugin_log_has_handler:
                 plugin.log.removeHandler(self._log_handler)
             plugin.log.propagate = orig_propagate
             root.removeHandler(self._log_handler)

--- a/client/ayon_core/pipeline/publish/logic.py
+++ b/client/ayon_core/pipeline/publish/logic.py
@@ -1019,6 +1019,7 @@ class PublishLogic:
     def _log_manager(self, plugin: PluginType):
         root = logging.getLogger()
         ayon_root = Logger.get_root_logger()
+        orig_propagate = plugin.log.propagate
         if not self._log_to_console:
             plugin.log.propagate = False
             plugin.log.addHandler(self._log_handler)
@@ -1030,8 +1031,8 @@ class PublishLogic:
 
         finally:
             if not self._log_to_console:
-                plugin.log.propagate = True
                 plugin.log.removeHandler(self._log_handler)
+            plugin.log.propagate = orig_propagate
             root.removeHandler(self._log_handler)
             ayon_root.removeHandler(self._log_handler)
             self._log_handler.clear_records()


### PR DESCRIPTION
## Changelog Description
Correctly capture logs if log to console is enabled and capture logs from AYON's `Logger` logger objects.

## Additional info
Root logger always does register publish handler to capture logs and plugin's log has added handler only if does not propagate records to parent logger.

To simplify work with the loggers in `Logger` a root logger was added. The root logger is the source for log level, formatting and record handlers.

With root logger for Logger loggers it is easy to add publish log handler for them. It actually also simplified management of AYON loggers `get_logger` function.

Also added deprecation for `get_logger` method, from now on the `name` has to be passed in. Not passing it triggers warning message. As far as I know there is no place that does not pass the name.

### Why is it needed
1. `PublishLogic` did not capture all logs by default. Running the same publish with publisher and PublishLogic might produce different reports.
2. We do pass along logger objects at many places to capture the logs for publishing report. With this change we don't really have to do that.

## Testing notes:
1. Logs triggered by any `Logger` object will be captured in publish report.
3. It is important that the logs are not duplicated.