### PR TITLE
Hierarchy model: Better types and type hints

### DIFF
--- a/client/ayon_core/tools/common_models/hierarchy.py
+++ b/client/ayon_core/tools/common_models/hierarchy.py
@@ -34,7 +34,7 @@ class FolderItem:
     Folder can be a child of another folder or a project.
 
     Attributes:
-        entity_id (str): Folder id.
+        folder_id (str): Folder id.
         parent_id (str | None): Parent folder id. If 'None' then project
             is parent.
         name (str): Name of folder.
@@ -43,12 +43,17 @@ class FolderItem:
         label (str): Folder label.
 
     """
-    entity_id: str
+    folder_id: str
     parent_id: str | None
     name: str
     path: str
     folder_type: str
     label: str
+
+    @property
+    def entity_id(self) -> str:
+        """Alias for folder_id."""
+        return self.folder_id
 
     @classmethod
     def from_hierarchy_item(cls, item: dict[str, Any]) -> FolderItem:
@@ -64,7 +69,7 @@ class FolderItem:
         path_parts.insert(0, "")
         path = "/".join(path_parts)
         return FolderItem(
-            entity_id=item["id"],
+            folder_id=item["id"],
             parent_id=item["parentId"],
             name=name,
             path=path,
@@ -76,7 +81,7 @@ class FolderItem:
     def from_entity(cls, entity: dict[str, Any]) -> FolderItem:
         name = entity["name"]
         return FolderItem(
-            entity_id=entity["id"],
+            folder_id=entity["id"],
             parent_id=entity["parentId"],
             name=name,
             path=entity["path"],
@@ -92,7 +97,7 @@ class FolderItem:
 
         """
         return dict(
-            entity_id=self.entity_id,
+            folder_id=self.folder_id,
             parent_id=self.parent_id,
             name=self.name,
             path=self.path,

--- a/client/ayon_core/tools/common_models/hierarchy.py
+++ b/client/ayon_core/tools/common_models/hierarchy.py
@@ -34,7 +34,7 @@ class FolderItem:
     Folder can be a child of another folder or a project.
 
     Attributes:
-        folder_id (str): Folder id.
+        entity_id (str): Folder id.
         parent_id (str | None): Parent folder id. If 'None' then project
             is parent.
         name (str): Name of folder.

--- a/client/ayon_core/tools/common_models/hierarchy.py
+++ b/client/ayon_core/tools/common_models/hierarchy.py
@@ -50,6 +50,35 @@ class FolderItem:
     folder_type: str
     label: str
 
+    def to_data(self) -> dict[str, str | None]:
+        """Converts folder item to data.
+
+        Returns:
+            dict[str, str | None]: Folder item data.
+
+        """
+        return dict(
+            entity_id=self.entity_id,
+            parent_id=self.parent_id,
+            name=self.name,
+            path=self.path,
+            folder_type=self.folder_type,
+            label=self.label,
+        )
+
+    @classmethod
+    def from_data(cls, data: dict[str, str | None]) -> FolderItem:
+        """Re-creates folder item from data.
+
+        Args:
+            data (dict[str, str | None]): Folder item data.
+
+        Returns:
+            FolderItem: Folder item.
+
+        """
+        return cls(**data)
+
     @classmethod
     def from_hierarchy_item(cls, item: dict[str, Any]) -> FolderItem:
         """Creates folder item from hierarchy item.
@@ -83,35 +112,6 @@ class FolderItem:
             folder_type=entity["folderType"],
             label=entity["label"] or name,
         )
-
-    def to_data(self) -> dict[str, str | None]:
-        """Converts folder item to data.
-
-        Returns:
-            dict[str, str | None]: Folder item data.
-
-        """
-        return dict(
-            entity_id=self.entity_id,
-            parent_id=self.parent_id,
-            name=self.name,
-            path=self.path,
-            folder_type=self.folder_type,
-            label=self.label,
-        )
-
-    @classmethod
-    def from_data(cls, data: dict[str, str | None]) -> FolderItem:
-        """Re-creates folder item from data.
-
-        Args:
-            data (dict[str, str | None]): Folder item data.
-
-        Returns:
-            FolderItem: Folder item.
-
-        """
-        return cls(**data)
 
 
 @dataclass

--- a/client/ayon_core/tools/common_models/hierarchy.py
+++ b/client/ayon_core/tools/common_models/hierarchy.py
@@ -43,17 +43,12 @@ class FolderItem:
         label (str): Folder label.
 
     """
-    folder_id: str
+    entity_id: str
     parent_id: str | None
     name: str
     path: str
     folder_type: str
     label: str
-
-    @property
-    def entity_id(self) -> str:
-        """Alias for folder_id."""
-        return self.folder_id
 
     @classmethod
     def from_hierarchy_item(cls, item: dict[str, Any]) -> FolderItem:
@@ -69,7 +64,7 @@ class FolderItem:
         path_parts.insert(0, "")
         path = "/".join(path_parts)
         return FolderItem(
-            folder_id=item["id"],
+            entity_id=item["id"],
             parent_id=item["parentId"],
             name=name,
             path=path,
@@ -81,7 +76,7 @@ class FolderItem:
     def from_entity(cls, entity: dict[str, Any]) -> FolderItem:
         name = entity["name"]
         return FolderItem(
-            folder_id=entity["id"],
+            entity_id=entity["id"],
             parent_id=entity["parentId"],
             name=name,
             path=entity["path"],
@@ -97,7 +92,7 @@ class FolderItem:
 
         """
         return dict(
-            folder_id=self.folder_id,
+            entity_id=self.entity_id,
             parent_id=self.parent_id,
             name=self.name,
             path=self.path,
@@ -133,7 +128,7 @@ class TaskItem:
         name (str): Name of task.
         name (str | None): Task label.
         task_type (str): Type of task.
-        folder_id (str): Parent folder id.
+        parent_id (str): Parent folder id.
         tags (list[str]): List of tags assigned to task.
         full_label (str): Full label of task. Is filled automatically.
 
@@ -143,7 +138,7 @@ class TaskItem:
     label: str
     task_type: str
     task_type_order: int
-    folder_id: str
+    parent_id: str
     tags: list[str]
     full_label: str = ""
 
@@ -161,16 +156,6 @@ class TaskItem:
         """
         return self.task_id
 
-    @property
-    def parent_id(self):
-        """Alias for folder_id.
-
-        Returns:
-            str: Folder id.
-
-        """
-        return self.folder_id
-
     def to_data(self) -> dict[str, Any]:
         """Converts task item to data.
 
@@ -182,7 +167,7 @@ class TaskItem:
             task_id=self.task_id,
             name=self.name,
             label=self.label,
-            folder_id=self.folder_id,
+            parent_id=self.parent_id,
             task_type=self.task_type,
             task_type_order=self.task_type_order,
             tags=self.tags.copy(),
@@ -222,7 +207,7 @@ class TaskItem:
             label=entity["label"],
             task_type=entity["type"],
             task_type_order=task_type_order,
-            folder_id=entity["folderId"],
+            parent_id=entity["folderId"],
             tags=entity["tags"],
         )
 

--- a/client/ayon_core/tools/common_models/hierarchy.py
+++ b/client/ayon_core/tools/common_models/hierarchy.py
@@ -204,7 +204,7 @@ class TaskItem:
         return cls(
             task_id=entity["id"],
             name=entity["name"],
-            label=entity["label"],
+            label=entity["label"] or entity["name"],
             task_type=entity["type"],
             task_type_order=task_type_order,
             parent_id=entity["folderId"],

--- a/client/ayon_core/tools/common_models/hierarchy.py
+++ b/client/ayon_core/tools/common_models/hierarchy.py
@@ -222,7 +222,6 @@ class TaskItem:
         )
 
 
-
 class HierarchyModel:
     """Model for project hierarchy items.
 
@@ -329,7 +328,6 @@ class HierarchyModel:
         })
         return output
 
-    # TODO validate passed in type for 'folder_paths'
     def get_folder_items_by_paths(
         self, project_name: str, folder_paths: set[str] | list[str]
     ) -> dict[str, FolderItem | None]:
@@ -409,7 +407,7 @@ class HierarchyModel:
 
         """
         items = self.get_folder_items_by_paths(
-            project_name, [folder_path]
+            project_name, {folder_path}
         )
         return items.get(folder_path)
 
@@ -451,7 +449,6 @@ class HierarchyModel:
             self._refresh_tasks_cache(project_name, folder_id, sender)
         return task_cache.get_data()
 
-    # TODO validate type passed in for 'folder_ids'
     def get_folder_entities(
         self, project_name: str | None, folder_ids: set[str] | list[str]
     ) -> dict[str, dict[str, Any]]:
@@ -494,12 +491,13 @@ class HierarchyModel:
         output = self.get_folder_entities(project_name, {folder_id})
         return output[folder_id]
 
-    # TODO validate type passed in for 'task_ids'
     def get_task_entities(
         self, project_name: str | None, task_ids: set[str] | list[str]
     ) -> dict[str, dict[str, Any]]:
         output = {}
-        task_ids = set(task_ids)
+        if not isinstance(task_ids, set):
+            task_ids = set(task_ids)
+
         if not project_name or not task_ids:
             return output
 

--- a/client/ayon_core/tools/common_models/hierarchy.py
+++ b/client/ayon_core/tools/common_models/hierarchy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 import collections
 import contextlib
+from dataclasses import dataclass
 import time
 from typing import Any
 
@@ -21,61 +22,94 @@ class AbstractHierarchyController(ABC):
         pass
 
 
+@dataclass
 class FolderItem:
     """Item representing folder entity on a server.
 
     Folder can be a child of another folder or a project.
 
-    Args:
+    Attributes:
         entity_id (str): Folder id.
         parent_id (str | None): Parent folder id. If 'None' then project
             is parent.
         name (str): Name of folder.
         path (str): Folder path.
         folder_type (str): Type of folder.
-        label (str | None): Folder label.
+        label (str): Folder label.
+
     """
+    entity_id: str
+    parent_id: str | None
+    name: str
+    path: str
+    folder_type: str
+    label: str
 
-    def __init__(
-        self, entity_id, parent_id, name, path, folder_type, label
-    ):
-        self.entity_id = entity_id
-        self.parent_id = parent_id
-        self.name = name
-        self.path = path
-        self.folder_type = folder_type
-        self.label = label or name
+    @classmethod
+    def from_hierarchy_item(cls, item: dict[str, Any]) -> FolderItem:
+        """Creates folder item from hierarchy item.
 
-    def to_data(self):
+        Args:
+            item (dict[str, Any]): Hierarchy item.
+
+        """
+        name = item["name"]
+        path_parts = list(item["parents"])
+        path_parts.append(name)
+        path_parts.insert(0, "")
+        path = "/".join(path_parts)
+        return FolderItem(
+            entity_id=item["id"],
+            parent_id=item["parentId"],
+            name=name,
+            path=path,
+            folder_type=item["folderType"],
+            label=item["label"] or name,
+        )
+
+    @classmethod
+    def from_entity(cls, entity: dict[str, Any]) -> FolderItem:
+        name = entity["name"]
+        return FolderItem(
+            entity_id=entity["id"],
+            parent_id=entity["parentId"],
+            name=name,
+            path=entity["path"],
+            folder_type=entity["folderType"],
+            label=entity["label"] or name,
+        )
+
+    def to_data(self) -> dict[str, str | None]:
         """Converts folder item to data.
 
         Returns:
-            dict[str, Any]: Folder item data.
-        """
+            dict[str, str | None]: Folder item data.
 
-        return {
-            "entity_id": self.entity_id,
-            "parent_id": self.parent_id,
-            "name": self.name,
-            "path": self.path,
-            "folder_type": self.folder_type,
-            "label": self.label,
-        }
+        """
+        return dict(
+            entity_id=self.entity_id,
+            parent_id=self.parent_id,
+            name=self.name,
+            path=self.path,
+            folder_type=self.folder_type,
+            label=self.label,
+        )
 
     @classmethod
-    def from_data(cls, data):
+    def from_data(cls, data: dict[str, str | None]) -> FolderItem:
         """Re-creates folder item from data.
 
         Args:
-            data (dict[str, Any]): Folder item data.
+            data (dict[str, str | None]): Folder item data.
 
         Returns:
             FolderItem: Folder item.
-        """
 
+        """
         return cls(**data)
 
 
+@dataclass
 class TaskItem:
     """Task item representing task entity on a server.
 
@@ -89,28 +123,23 @@ class TaskItem:
         name (str): Name of task.
         name (str | None): Task label.
         task_type (str): Type of task.
-        parent_id (str): Parent folder id.
+        folder_id (str): Parent folder id.
+        tags (list[str]): List of tags assigned to task.
+        full_label (str): Full label of task. Is filled automatically.
+
     """
+    task_id: str
+    name: str
+    label: str
+    task_type: str
+    task_type_order: int
+    folder_id: str
+    tags: list[str]
+    full_label: str = ""
 
-    def __init__(
-        self,
-        task_id: str,
-        name: str,
-        label: str | None,
-        task_type: str,
-        task_type_order: int,
-        parent_id: str,
-        tags: list[str],
-    ):
-        self.task_id = task_id
-        self.name = name
-        self.label = label
-        self.task_type = task_type
-        self.task_type_order = task_type_order
-        self.parent_id = parent_id
-        self.tags = tags
-
-        self._full_label = None
+    def __post_init__(self):
+        if not self.full_label:
+            self.full_label = f"{self.label} ({self.task_type})"
 
     @property
     def id(self):
@@ -118,42 +147,40 @@ class TaskItem:
 
         Returns:
             str: Task id.
-        """
 
+        """
         return self.task_id
 
     @property
-    def full_label(self):
-        """Label of task item for UI.
+    def parent_id(self):
+        """Alias for folder_id.
 
         Returns:
-            str: Label of task item.
+            str: Folder id.
+
         """
+        return self.folder_id
 
-        if self._full_label is None:
-            label = self.label or self.name
-            self._full_label = f"{label} ({self.task_type})"
-        return self._full_label
-
-    def to_data(self):
+    def to_data(self) -> dict[str, Any]:
         """Converts task item to data.
 
         Returns:
             dict[str, Any]: Task item data.
-        """
 
-        return {
-            "task_id": self.task_id,
-            "name": self.name,
-            "label": self.label,
-            "parent_id": self.parent_id,
-            "task_type": self.task_type,
-            "task_type_order": self.task_type_order,
-            "tags": self.tags,
-        }
+        """
+        return dict(
+            task_id=self.task_id,
+            name=self.name,
+            label=self.label,
+            folder_id=self.folder_id,
+            task_type=self.task_type,
+            task_type_order=self.task_type_order,
+            tags=self.tags.copy(),
+            full_label=self.full_label,
+        )
 
     @classmethod
-    def from_data(cls, data):
+    def from_data(cls, data: dict[str, Any]) -> TaskItem:
         """Re-create task item from data.
 
         Args:
@@ -161,9 +188,33 @@ class TaskItem:
 
         Returns:
             TaskItem: Task item.
-        """
 
+        """
         return cls(**data)
+
+    @classmethod
+    def from_entity(
+        cls, entity: dict[str, Any], task_type_order: int
+    ) -> TaskItem:
+        """Re-create task item from data.
+
+        Args:
+            entity (dict[str, Any]): Task entity.
+            task_type_order (int): Task type order.
+
+        Returns:
+            TaskItem: Task item.
+
+        """
+        return cls(
+            task_id=entity["id"],
+            name=entity["name"],
+            label=entity["label"],
+            task_type=entity["type"],
+            task_type_order=task_type_order,
+            folder_id=entity["folderId"],
+            tags=entity["tags"],
+        )
 
 
 def _get_task_items_from_tasks(

--- a/client/ayon_core/tools/common_models/hierarchy.py
+++ b/client/ayon_core/tools/common_models/hierarchy.py
@@ -5,7 +5,7 @@ import collections
 import contextlib
 from dataclasses import dataclass
 import time
-from typing import Any
+from typing import Any, Generator
 
 import ayon_api
 
@@ -18,7 +18,12 @@ HIERARCHY_MODEL_SENDER = "hierarchy.model"
 
 class AbstractHierarchyController(ABC):
     @abstractmethod
-    def emit_event(self, topic, data, source):
+    def emit_event(
+        self,
+        topic: str,
+        data: dict[str, Any] = None,
+        source: str | None = None,
+    ) -> None:
         pass
 
 
@@ -217,64 +222,8 @@ class TaskItem:
         )
 
 
-def _get_task_items_from_tasks(
-    task_type_items: list[TaskTypeItem],
-    tasks: list[dict[str, Any]]
-) -> list[TaskItem]:
-    """
 
-    Returns:
-        TaskItem: Task item.
-
-    """
-    task_types = {
-        task_type.name: index
-        for index, task_type in enumerate(task_type_items)
-    }
-    output = []
-    for task in tasks:
-        folder_id = task["folderId"]
-        task_type_order = task_types[task["type"]]
-        output.append(TaskItem(
-            task["id"],
-            task["name"],
-            task["label"],
-            task["type"],
-            task_type_order,
-            folder_id,
-            task["tags"],
-        ))
-    return output
-
-
-def _get_folder_item_from_hierarchy_item(item):
-    name = item["name"]
-    path_parts = list(item["parents"])
-    path_parts.append(name)
-    path = "/" + "/".join(path_parts)
-    return FolderItem(
-        item["id"],
-        item["parentId"],
-        name,
-        path,
-        item["folderType"],
-        item["label"]
-    )
-
-
-def _get_folder_item_from_entity(entity):
-    name = entity["name"]
-    return FolderItem(
-        entity["id"],
-        entity["parentId"],
-        name,
-        entity["path"],
-        entity["folderType"],
-        entity["label"] or name
-    )
-
-
-class HierarchyModel(object):
+class HierarchyModel:
     """Model for project hierarchy items.
 
     Hierarchy items are folders and tasks. Folders can have as parent another
@@ -302,7 +251,7 @@ class HierarchyModel(object):
         self._tasks_refreshing = set()
         self._controller = controller
 
-    def reset(self):
+    def reset(self) -> None:
         self._tags_by_entity_type.reset()
         self._folders_items.reset()
         self._folders_by_id.reset()
@@ -312,16 +261,18 @@ class HierarchyModel(object):
 
         self._entity_ids_by_assignee.reset()
 
-    def refresh_project(self, project_name):
+    def refresh_project(self, project_name: str) -> None:
         """Force to refresh folder items for a project.
 
         Args:
             project_name (str): Name of project to refresh.
-        """
 
+        """
         self._refresh_folders_cache(project_name)
 
-    def get_folder_items(self, project_name, sender):
+    def get_folder_items(
+        self, project_name: str, sender: str | None
+    ) -> dict[str, FolderItem]:
         """Get folder items by project name.
 
         The folders are cached per project name. If the cache is not valid
@@ -329,17 +280,19 @@ class HierarchyModel(object):
 
         Args:
             project_name (str): Name of project where to look for folders.
-            sender (Union[str, None]): Who requested the folder ids.
+            sender (str | None): Who requested the folder ids.
 
         Returns:
             dict[str, FolderItem]: Folder items by id.
-        """
 
+        """
         if not self._folders_items[project_name].is_valid:
             self._refresh_folders_cache(project_name, sender)
         return self._folders_items[project_name].get_data()
 
-    def get_folder_items_by_id(self, project_name, folder_ids):
+    def get_folder_items_by_id(
+        self, project_name: str, folder_ids: set[str] | list[str]
+    ) -> dict[str, FolderItem | None]:
         """Get folder items by ids.
 
         This function will query folders if they are not in cache. But the
@@ -347,19 +300,22 @@ class HierarchyModel(object):
 
         Args:
             project_name (str): Name of project where to look for folders.
-            folder_ids (Iterable[str]): Folder ids.
+            folder_ids (set[str] | list[str]): Folder ids.
 
         Returns:
-            dict[str, Union[FolderItem, None]]: Folder items by id.
-        """
+            dict[str, FolderItem | None]: Folder items by id.
 
-        folder_ids = set(folder_ids)
+        """
+        if not isinstance(folder_ids, set):
+            folder_ids = set(folder_ids)
+
         if self._folders_items[project_name].is_valid:
             cache_data = self._folders_items[project_name].get_data()
             return {
                 folder_id: cache_data.get(folder_id)
                 for folder_id in folder_ids
             }
+
         folders = ayon_api.get_folders(
             project_name,
             folder_ids=folder_ids,
@@ -368,12 +324,15 @@ class HierarchyModel(object):
         # Make sure all folder ids are in output
         output = {folder_id: None for folder_id in folder_ids}
         output.update({
-            folder["id"]: _get_folder_item_from_entity(folder)
+            folder["id"]: FolderItem.from_entity(folder)
             for folder in folders
         })
         return output
 
-    def get_folder_items_by_paths(self, project_name, folder_paths):
+    # TODO validate passed in type for 'folder_paths'
+    def get_folder_items_by_paths(
+        self, project_name: str, folder_paths: set[str] | list[str]
+    ) -> dict[str, FolderItem | None]:
         """Get folder items by ids.
 
         This function will query folders if they are not in cache. But the
@@ -381,14 +340,17 @@ class HierarchyModel(object):
 
         Args:
             project_name (str): Name of project where to look for folders.
-            folder_paths (Iterable[str]): Folder paths.
+            folder_paths (set[str] | list[str]): Folder paths.
 
         Returns:
-            dict[str, Union[FolderItem, None]]: Folder items by id.
-        """
+            dict[str, FolderItem | None]: Folder items by path.
 
-        folder_paths = set(folder_paths)
-        output = {folder_path: None for folder_path in folder_paths}
+        """
+        if not isinstance(folder_paths, set):
+            folder_paths = set(folder_paths)
+        output: dict[str, FolderItem | None] = {
+            folder_path: None for folder_path in folder_paths
+        }
         if not folder_paths:
             return output
 
@@ -405,11 +367,13 @@ class HierarchyModel(object):
         )
         # Make sure all folder ids are in output
         for folder in folders:
-            item = _get_folder_item_from_entity(folder)
+            item = FolderItem.from_entity(folder)
             output[item.path] = item
         return output
 
-    def get_folder_item(self, project_name, folder_id):
+    def get_folder_item(
+        self, project_name: str, folder_id: str
+    ) -> FolderItem | None:
         """Get folder item by id.
 
         This function will query folder if they is not in cache. But the
@@ -420,14 +384,17 @@ class HierarchyModel(object):
             folder_id (str): Folder id.
 
         Returns:
-            Union[FolderItem, None]: Folder item.
+            FolderItem | None: Folder item.
+
         """
         items = self.get_folder_items_by_id(
-            project_name, [folder_id]
+            project_name, {folder_id}
         )
         return items.get(folder_id)
 
-    def get_folder_item_by_path(self, project_name, folder_path):
+    def get_folder_item_by_path(
+        self, project_name: str, folder_path: str
+    ) -> FolderItem | None:
         """Get folder item by path.
 
         This function will query folder if they is not in cache. But the
@@ -438,7 +405,7 @@ class HierarchyModel(object):
             folder_path (str): Folder path.
 
         Returns:
-            Union[FolderItem, None]: Folder item.
+            FolderItem | None: Folder item.
 
         """
         items = self.get_folder_items_by_paths(
@@ -447,18 +414,22 @@ class HierarchyModel(object):
         return items.get(folder_path)
 
     def get_task_item_by_name(
-        self, project_name, folder_id, task_name, sender
-    ):
+        self,
+        project_name: str,
+        folder_id: str,
+        task_name: str,
+        sender: str | None,
+    ) -> TaskItem | None:
         """Get task item by name and folder id.
 
         Args:
             project_name (str): Project name.
             folder_id (str): Folder id.
             task_name (str): Task name.
-            sender (Union[str, None]): Who requested the task item.
+            sender (str | None): Who requested the task item.
 
         Returns:
-            Optional[TaskItem]: Task item found by name and folder id.
+            TaskItem | None: Task item found by name and folder id.
 
         """
         for task_item in self.get_task_items(project_name, folder_id, sender):
@@ -466,7 +437,12 @@ class HierarchyModel(object):
                 return task_item
         return None
 
-    def get_task_items(self, project_name, folder_id, sender):
+    def get_task_items(
+        self,
+        project_name: str | None,
+        folder_id: str | None,
+        sender: str | None,
+    ) -> list[TaskItem]:
         if not project_name or not folder_id:
             return []
 
@@ -475,19 +451,24 @@ class HierarchyModel(object):
             self._refresh_tasks_cache(project_name, folder_id, sender)
         return task_cache.get_data()
 
-    def get_folder_entities(self, project_name, folder_ids):
+    # TODO validate type passed in for 'folder_ids'
+    def get_folder_entities(
+        self, project_name: str | None, folder_ids: set[str] | list[str]
+    ) -> dict[str, dict[str, Any]]:
         """Get folder entities by ids.
 
         Args:
-            project_name (str): Project name.
-            folder_ids (Iterable[str]): Folder ids.
+            project_name (str | None): Project name.
+            folder_ids (set[str] | list[str]): Folder ids.
 
         Returns:
-            dict[str, Any]: Folder entities by id.
-        """
+            dict[str, dict[str, Any]]: Folder entities by id.
 
+        """
         output = {}
-        folder_ids = set(folder_ids)
+        if not isinstance(folder_ids, set):
+            folder_ids = set(folder_ids)
+
         if not project_name or not folder_ids:
             return output
 
@@ -500,17 +481,23 @@ class HierarchyModel(object):
                 folder_ids_to_query.add(folder_id)
             else:
                 output[folder_id] = None
+
         self._query_folder_entities(project_name, folder_ids_to_query)
         for folder_id in folder_ids_to_query:
             cache = self._folders_by_id[project_name][folder_id]
             output[folder_id] = cache.get_data()
         return output
 
-    def get_folder_entity(self, project_name, folder_id):
+    def get_folder_entity(
+        self, project_name: str, folder_id: str
+    ) -> dict[str, Any] | None:
         output = self.get_folder_entities(project_name, {folder_id})
         return output[folder_id]
 
-    def get_task_entities(self, project_name, task_ids):
+    # TODO validate type passed in for 'task_ids'
+    def get_task_entities(
+        self, project_name: str | None, task_ids: set[str] | list[str]
+    ) -> dict[str, dict[str, Any]]:
         output = {}
         task_ids = set(task_ids)
         if not project_name or not task_ids:
@@ -531,13 +518,15 @@ class HierarchyModel(object):
             output[task_id] = cache.get_data()
         return output
 
-    def get_task_entity(self, project_name, task_id):
+    def get_task_entity(
+        self, project_name: str, task_id: str
+    ) -> dict[str, Any] | None:
         output = self.get_task_entities(project_name, {task_id})
         return output[task_id]
 
     def get_entity_ids_for_assignees(
-        self, project_name: str, assignees: list[str]
-    ):
+        self, project_name: str, assignees: set[str] | list[str]
+    ) -> dict[str, set[str]]:
         folder_ids = set()
         task_ids = set()
         output = {
@@ -609,7 +598,9 @@ class HierarchyModel(object):
         return cache.get_data()
 
     @contextlib.contextmanager
-    def _folder_refresh_event_manager(self, project_name, sender):
+    def _folder_refresh_event_manager(
+        self, project_name: str, sender: str | None
+    ) -> Generator[None, None, None]:
         self._folders_refreshing.add(project_name)
         self._controller.emit_event(
             "folders.refresh.started",
@@ -629,8 +620,8 @@ class HierarchyModel(object):
 
     @contextlib.contextmanager
     def _task_refresh_event_manager(
-        self, project_name, folder_id, sender
-    ):
+        self, project_name: str, folder_id: str, sender: str | None
+    ) -> Generator[None, None, None]:
         self._tasks_refreshing.add(folder_id)
         self._controller.emit_event(
             "tasks.refresh.started",
@@ -656,7 +647,9 @@ class HierarchyModel(object):
             )
             self._tasks_refreshing.discard(folder_id)
 
-    def _refresh_folders_cache(self, project_name, sender=None):
+    def _refresh_folders_cache(
+        self, project_name: str, sender: str | None = None
+    ) -> None:
         if project_name in self._folders_refreshing:
             return
 
@@ -664,20 +657,22 @@ class HierarchyModel(object):
             folder_items = self._query_folders(project_name)
             self._folders_items[project_name].update_data(folder_items)
 
-    def _query_folders(self, project_name):
+    def _query_folders(self, project_name: str) -> dict[str, FolderItem]:
         hierarchy = ayon_api.get_folders_hierarchy(project_name)
 
         folder_items = {}
         hierachy_queue = collections.deque(hierarchy["hierarchy"])
         while hierachy_queue:
             item = hierachy_queue.popleft()
-            folder_item = _get_folder_item_from_hierarchy_item(item)
+            folder_item = FolderItem.from_hierarchy_item(item)
             folder_items[folder_item.entity_id] = folder_item
             hierachy_queue.extend(item["children"] or [])
         return folder_items
 
-    def _query_folder_entities(self, project_name, folder_ids):
-        if not project_name or not folder_ids:
+    def _query_folder_entities(
+        self, project_name: str, folder_ids: set[str]
+    ) -> None:
+        if not folder_ids:
             return
         project_cache = self._folders_by_id[project_name]
         folders = ayon_api.get_folders(project_name, folder_ids=folder_ids)
@@ -685,8 +680,10 @@ class HierarchyModel(object):
             folder_id = folder["id"]
             project_cache[folder_id].update_data(folder)
 
-    def _query_task_entities(self, project_name, task_ids):
-        if not project_name or not task_ids:
+    def _query_task_entities(
+        self, project_name: str, task_ids: set[str]
+    ) -> None:
+        if not task_ids:
             return
 
         project_cache = self._tasks_by_id[project_name]
@@ -695,7 +692,9 @@ class HierarchyModel(object):
             task_id = task["id"]
             project_cache[task_id].update_data(task)
 
-    def _refresh_tasks_cache(self, project_name, folder_id, sender=None):
+    def _refresh_tasks_cache(
+        self, project_name: str, folder_id: str, sender: str | None = None
+    ) -> None:
         if folder_id in self._tasks_refreshing:
             while folder_id in self._tasks_refreshing:
                 time.sleep(0.01)
@@ -707,11 +706,23 @@ class HierarchyModel(object):
         ):
             cache.update_data(self._query_tasks(project_name, folder_id))
 
-    def _query_tasks(self, project_name, folder_id):
+    def _query_tasks(
+        self, project_name: str, folder_id: str
+    ) -> list[TaskItem]:
         tasks = list(ayon_api.get_tasks(
             project_name,
             folder_ids=[folder_id],
             fields={"id", "name", "label", "folderId", "type", "tags"}
         ))
-        task_type_items = self._controller.get_task_type_items(project_name)
-        return _get_task_items_from_tasks(task_type_items, tasks)
+        task_type_items: list[TaskTypeItem] = (
+            self._controller.get_task_type_items(project_name)
+        )
+
+        order_by_task_type = {
+            task_type.name: index
+            for index, task_type in enumerate(task_type_items)
+        }
+        return [
+            TaskItem.from_entity(task, order_by_task_type[task["type"]])
+            for task in tasks
+        ]


### PR DESCRIPTION
## Changelog Description
Added type hints to hierarchy model and converted `FolderItem` and `TaskItem` to dataclasses.

## Additional info
Converted `FolderItem` and `TaskItem` to dataclasses for convenience. Some of the methods are not used or are used only internally. Removed helper functions for `FolderItem` and `TaskItem` and use classmethods to do the same thing.

## Testing notes:
1. Validate code changes.
2. Tools showing folders and tasks should work.
