### PR TITLE
Workfile build: Normalized the preset path when checking the valid path.

### DIFF
--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -151,7 +151,7 @@ class TemplatePreset:
             bool: Preset has set path to an existing file.
 
         """
-        return self.path and os.path.exists(self.path)
+        return self.path and os.path.exists(os.path.normpath(self.path))
 
 
 class AbstractTemplateBuilder(ABC):

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1190,8 +1190,11 @@ class AbstractTemplateBuilder(ABC):
         if create_first_version is None:
             create_first_version = True
 
+        if resolved_path:
+             resolved_path = os.path.normpath(resolved_path)
+
         return TemplatePreset(
-            path=os.path.normpath(resolved_path),
+            path=resolved_path,
             keep_placeholder=keep_placeholder,
             create_first_version=create_first_version,
             execute_on_app_launch=profile.get("execute_on_app_launch", False),

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -1191,7 +1191,7 @@ class AbstractTemplateBuilder(ABC):
             create_first_version = True
 
         if resolved_path:
-             resolved_path = os.path.normpath(resolved_path)
+            resolved_path = os.path.normpath(resolved_path)
 
         return TemplatePreset(
             path=resolved_path,

--- a/client/ayon_core/pipeline/workfile/workfile_template_builder.py
+++ b/client/ayon_core/pipeline/workfile/workfile_template_builder.py
@@ -151,7 +151,7 @@ class TemplatePreset:
             bool: Preset has set path to an existing file.
 
         """
-        return self.path and os.path.exists(os.path.normpath(self.path))
+        return self.path and os.path.exists(self.path)
 
 
 class AbstractTemplateBuilder(ABC):
@@ -1191,7 +1191,7 @@ class AbstractTemplateBuilder(ABC):
             create_first_version = True
 
         return TemplatePreset(
-            path=resolved_path,
+            path=os.path.normpath(resolved_path),
             keep_placeholder=keep_placeholder,
             create_first_version=create_first_version,
             execute_on_app_launch=profile.get("execute_on_app_launch", False),


### PR DESCRIPTION
## Changelog Description
This PR is to normalize the preset.path for `has_valid_path` function. This ensures the case of escaped filepath like `D:/studio/nuke/template.nk` can be checked if it existed correctly.


## Additional info
n/a

## Testing notes:
1. Go to AYON menu
2. Open template
