### PR TITLE
Option box: Fix hovering

### DIFF
--- a/client/ayon_core/tools/utils/widgets.py
+++ b/client/ayon_core/tools/utils/widgets.py
@@ -1037,6 +1037,8 @@ class OptionBox(QtWidgets.QLabel):
         if global_pos is None:
             return False
         pos = self.mapFromGlobal(global_pos)
+        if isinstance(pos, QtCore.QPointF):
+            pos = pos.toPoint()
         return self.rect().contains(pos)
 
 


### PR DESCRIPTION
## Changelog Description
Convert `QPointF` to `QPoint` to check if mouse is in geometry of OptionBox.

## Testing notes:
1. Option box does show correctly in Maya 2026.3.

Resolved https://github.com/ynput/ayon-core/issues/2026