### PR TITLE
Extract OIIO transcode: add tif as supported extension

### DIFF
--- a/client/ayon_core/plugins/publish/extract_color_transcode.py
+++ b/client/ayon_core/plugins/publish/extract_color_transcode.py
@@ -63,7 +63,7 @@ class ExtractOIIOTranscode(publish.Extractor):
     optional = True
 
     # Supported extensions
-    supported_exts = {"exr", "jpg", "jpeg", "png", "dpx"}
+    supported_exts = {"exr", "jpg", "jpeg", "png", "dpx", "tif"}
 
     # Configurable by Settings
     profiles = None

--- a/client/ayon_core/plugins/publish/extract_color_transcode.py
+++ b/client/ayon_core/plugins/publish/extract_color_transcode.py
@@ -63,7 +63,7 @@ class ExtractOIIOTranscode(publish.Extractor):
     optional = True
 
     # Supported extensions
-    supported_exts = {"exr", "jpg", "jpeg", "png", "dpx", "tif"}
+    supported_exts = {"exr", "jpg", "jpeg", "png", "dpx", "tif", "tiff"}
 
     # Configurable by Settings
     profiles = None


### PR DESCRIPTION
## Changelog Description
This PR is to add tif as supported extension for color trancoding.
Resolve https://github.com/ynput/ayon-core/issues/2032

## Additional info
In order to test on this PR, you need to make sure fill in your value: ayon+settings://photoshop/imageio/remapping/rules/0 for converting Photoshop native color profile to OCIO colorspace

## Testing notes:
1. Fill in `ayon+settings://photoshop/imageio/remapping/rules/0`  You can find your application native colorspace name through `Edit -> Color Settings` 
<img width="887" height="563" alt="image" src="https://github.com/user-attachments/assets/ca2708b1-c34c-4ffb-bd6d-c7f286745f27" />

2. Fill in your transcode  `ayon+settings://core/publish/ExtractOIIOTranscode/profiles` and make sure `ayon+settings://photoshop/publish/ExtractImage/formats` has `tif` set
3. Create image instance in PS
4. Publish

