### PR TITLE
Fix icon for "Deliver Versions" action

### DIFF
--- a/client/ayon_core/plugins/loader/delivery.py
+++ b/client/ayon_core/plugins/loader/delivery.py
@@ -13,7 +13,7 @@ class DeliveryAction(LoaderSimpleActionPlugin):
     identifier = "core.delivery"
     label = "Deliver Versions"
     order = 35
-    icon = MaterialSymbolsIcon("uload", color="#d8d8d8")
+    icon = MaterialSymbolsIcon("upload", color="#d8d8d8")
 
     def is_compatible(self, selection: LoaderActionSelection) -> bool:
         if self.host_name is not None:


### PR DESCRIPTION
## Changelog Description

Fix icon for "Deliver Versions" action

## Additional info

Must have been a typo?

Before:

<img width="287" height="341" alt="image" src="https://github.com/user-attachments/assets/732090e2-5e3a-4809-ab93-59767a88d597" />


## Testing notes:

1. Icon shows on deliver versions.

<img width="373" height="351" alt="image" src="https://github.com/user-attachments/assets/a5a54593-7171-4399-9ab0-1e56dcd64a67" />
