### PR TITLE
Custom frame range: Plugin works with specific family

### DIFF
--- a/client/ayon_core/plugins/publish/collect_custom_frame_range.py
+++ b/client/ayon_core/plugins/publish/collect_custom_frame_range.py
@@ -1,30 +1,68 @@
 """Collect custom frame range for render submission."""
+from __future__ import annotations
+
+import typing
+
 import pyblish.api
-from typing import Optional
+
 from ayon_core.lib import EnumDef, TextDef
-from ayon_core.pipeline import KnownPublishError
+from ayon_core.pipeline import KnownPublishError, get_current_host_name
 from ayon_core.pipeline.publish import AYONPyblishPluginMixin
 
+if typing.TYPE_CHECKING:
+    from ayon_core.pipeline import CreatedInstance
 
-class CollectCustomFrameRange(pyblish.api.InstancePlugin,
-                              AYONPyblishPluginMixin):
+# For backwards compatibility with deadline's logic
+# - Combination of families and host names for which the plugin is compatible.
+# - To properly convert the hosts to use the "new way" they have to add
+#   "custom.frame.range" family to created instances.
+# - We can remove host names from the 'FARM_HOST_NAMES' set once the host
+#   integrations are updated to add the family to instances and core has
+#   bumped compatibility version for the host.
+FARM_FAMILIES = {
+    "render", "render.local", "render.farm", "render.frames_farm",
+    "prerender", "prerender.farm", "prerender.frames_farm",
+    "renderlayer", "imagesequence", "image",
+    "vrayscene", "maxrender",
+    "arnold_rop", "mantra_rop",
+    "karma_rop", "vray_rop", "redshift_rop",
+    "renderFarm", "usdrender", "publish.hou",
+    "remote_publish_on_farm",
+    "deadline"
+}
+FARM_HOST_NAMES = {
+    "aftereffects",
+    "blender",
+    "celaction",
+    "cinema4d",
+    "fusion",
+    "harmony",
+    "houdini",
+    "max",
+    "maya",
+    "nuke",
+    "unreal",
+}
+IS_FARM_HOST = get_current_host_name() in FARM_HOST_NAMES
+
+
+class CollectCustomFrameRange(
+    pyblish.api.InstancePlugin,
+    AYONPyblishPluginMixin
+):
     """Collect custom frame range for render submission."""
 
     order = pyblish.api.CollectorOrder + 0.018
     label = "Collect Custom Frame Range"
-    families = [
-            "render", "render.local", "render.farm", "render.frames_farm",
-            "prerender", "prerender.farm", "prerender.frames_farm",
-            "renderlayer", "imagesequence", "image",
-            "vrayscene", "maxrender",
-            "arnold_rop", "mantra_rop",
-            "karma_rop", "vray_rop", "redshift_rop",
-            "renderFarm", "usdrender", "publish.hou",
-            "remote_publish_on_farm",
-            "deadline"
-    ]
+
+    # TODO uncomment when all host integrations do add
+    #   the 'custom.frame.range' family to instances
+    # families = ["custom.frame.range"]
 
     def process(self, instance: pyblish.api.Instance) -> None:
+        if not self._is_compatible_instance(instance):
+            return
+
         attr_values = self.get_attr_values_from_data(instance.data)
         use_custom_frames = attr_values.get("use_custom_frames")
         if not self._is_custom_frames_used(use_custom_frames):
@@ -53,7 +91,7 @@ class CollectCustomFrameRange(pyblish.api.InstancePlugin,
         Returns:
             (list)
         """
-        if not cls.instance_matches_plugin_families(instance):
+        if not cls._is_compatible_instance(instance):
             return []
 
         use_custom_frames = (
@@ -93,12 +131,11 @@ class CollectCustomFrameRange(pyblish.api.InstancePlugin,
             custom_frame_change = cls._get_publish_use_custom_frames_value(
                 instance_change["changes"]
             )
-
-            instance = instance_change["instance"]
             if not custom_frame_change:
                 continue
 
-            if not cls.instance_matches_plugin_families(instance):
+            instance = instance_change["instance"]
+            if not cls._is_compatible_instance(instance):
                 continue
 
             new_attrs = cls.get_attr_defs_for_instance(
@@ -111,12 +148,31 @@ class CollectCustomFrameRange(pyblish.api.InstancePlugin,
         return value in ["custom_only", "reuse_last_version"]
 
     @classmethod
-    def _get_publish_use_custom_frames_value(
-        cls,
-        instance_data
-    ) -> Optional[str]:
-        return (
-            instance_data.get("publish_attributes", {})
-                         .get(cls.__name__, {})
-                         .get("use_custom_frames")
-        )
+    def _get_publish_use_custom_frames_value(cls, data) -> str | None:
+        plugin_data = cls.get_attr_values_from_data_for_plugin(cls, data)
+        return plugin_data.get("use_custom_frames")
+
+    @classmethod
+    def _is_compatible_instance(
+        cls, instance: CreatedInstance | pyblish.api.Instance
+    ) -> bool:
+        if isinstance(instance, pyblish.api.Instance):
+            i_families = instance.data.get("families")
+            i_product_base_type = instance.data.get("productBaseType")
+        else:
+            i_families = instance.get("families")
+            i_product_base_type = instance.product_base_type
+
+        # families = [instance.product_base_type]
+        families = set()
+        if i_families is not None:
+            families = set(i_families)
+
+        if "custom.frame.range" in families:
+            return True
+
+        if not IS_FARM_HOST:
+            return False
+
+        families.add(i_product_base_type)
+        return bool(families.intersection(FARM_HOST_NAMES))


### PR DESCRIPTION
## Changelog Description
The custom frame plugin does work with specific family `"custom.frame.range"`, but also has backwards compatibility for the families that were defined by deadline plugin but only for hosts that did work with deadline addon.

## Additional info
Using this approach it still works for hosts that did work before, but hosts that would like to use this new feature has to add `"custom.frame.range"` to instance to be able to show the option.

## Testing notes:
1. Validate the proposed logic if actually makes sense!!!
2. For hosts and families for which it was already working it should work.
3. Add the `"custom.frame.range"` family to an instance in some other host to validate it shows for it too.
