### PR TITLE
Fix styling on the workfiles save as dialog

### DIFF
--- a/client/ayon_core/tools/workfiles/widgets/save_as_dialog.py
+++ b/client/ayon_core/tools/workfiles/widgets/save_as_dialog.py
@@ -1,28 +1,41 @@
 from qtpy import QtWidgets, QtCore
 
-from ayon_core.tools.utils import PlaceholderPlainTextEdit
 from ayon_core.ui.components import (
     AYButton,
     AYCheckBox,
     AYComboBox,
+    AYContainer,
     AYLabel,
-    AYHBoxLayout,
+    AYMenu,
     AYVBoxLayout,
-    AYGridLayout,
     AYLineEdit,
     AYSpinBox,
+    AYTextEdit,
 )
 
+# Surface variant used by the dialog and by every plain wrapper widget
+# inside it, so the wrappers blend into the dialog surface instead of
+# falling back to the host/legacy stylesheet background.
+SURFACE_VARIANT = AYContainer.Variants.Dialog
 
-class SubversionLineEdit(QtWidgets.QWidget):
+
+class SubversionLineEdit(AYContainer):
     """QLineEdit with QPushButton for drop down selection of list of strings"""
 
     text_changed = QtCore.Signal(str)
 
-    def __init__(self, *args, **kwargs):
-        super(SubversionLineEdit, self).__init__(*args, **kwargs)
+    def __init__(self, parent=None):
+        super().__init__(
+            parent,
+            layout=AYContainer.Layout.HBox,
+            variant=SURFACE_VARIANT,
+            layout_margin=0,
+            layout_spacing=3,
+        )
 
-        input_field = AYLineEdit(parent=self)
+        input_field = AYLineEdit(
+            parent=self, variant=AYLineEdit.Variants.Low
+        )
         menu_btn = AYButton(
             variant=AYButton.Variants.Surface,
             icon="arrow_drop_down",
@@ -30,11 +43,10 @@ class SubversionLineEdit(QtWidgets.QWidget):
         )
         menu_btn.setFixedWidth(18)
 
-        menu = QtWidgets.QMenu(self)
+        menu = AYMenu(self)
         menu_btn.setMenu(menu)
 
-        layout = AYHBoxLayout(self, margin=0, spacing=3)
-
+        layout = self.layout()
         layout.addWidget(input_field, 1)
         layout.addWidget(menu_btn, 0)
 
@@ -108,7 +120,7 @@ class SaveAsDialog(QtWidgets.QDialog):
 
     def __init__(self, controller, parent):
         super(SaveAsDialog, self).__init__(parent=parent)
-        self.setWindowFlags(self.windowFlags() | QtCore.Qt.FramelessWindowHint)
+        self.setWindowTitle("Save Workfile As")
         self.setMinimumWidth(330)
 
         self._controller = controller
@@ -126,8 +138,25 @@ class SaveAsDialog(QtWidgets.QDialog):
 
         self._result = None
 
+        # Dialog surface. Every visible widget lives inside this container so
+        # the dialog is painted from the AYON surface ramp rather than
+        # inheriting the host's (or the tool's legacy) stylesheet background.
+        surface = AYContainer(
+            self,
+            layout=AYContainer.Layout.VBox,
+            variant=SURFACE_VARIANT,
+            layout_margin=8,
+            layout_spacing=4,
+        )
+
         # Btns widget
-        btns_widget = QtWidgets.QWidget(self)
+        btns_widget = AYContainer(
+            surface,
+            layout=AYContainer.Layout.HBox,
+            variant=SURFACE_VARIANT,
+            layout_margin=0,
+            layout_spacing=4,
+        )
 
         btn_ok = AYButton(
             "Ok",
@@ -140,19 +169,32 @@ class SaveAsDialog(QtWidgets.QDialog):
             parent=btns_widget,
         )
 
-        btns_layout = AYHBoxLayout(btns_widget, margin=0, spacing=4)
+        btns_layout = btns_widget.layout()
         btns_layout.addWidget(btn_ok)
         btns_layout.addWidget(btn_cancel)
 
         # Inputs widget
-        inputs_widget = QtWidgets.QWidget(self)
+        inputs_widget = AYContainer(
+            surface,
+            layout=AYContainer.Layout.Grid,
+            variant=SURFACE_VARIANT,
+            layout_margin=0,
+            layout_spacing=4,
+        )
 
         # Version widget
-        version_widget = QtWidgets.QWidget(inputs_widget)
+        version_widget = AYContainer(
+            inputs_widget,
+            layout=AYContainer.Layout.HBox,
+            variant=SURFACE_VARIANT,
+            layout_margin=0,
+            layout_spacing=4,
+        )
 
         # Version number input
         version_input = AYSpinBox(
             parent=version_widget,
+            variant=AYSpinBox.Variants.Low,
             minimum=1,
             maximum=9999,
         )
@@ -167,14 +209,26 @@ class SaveAsDialog(QtWidgets.QDialog):
             QtWidgets.QSizePolicy.Fixed,
         )
 
-        version_layout = AYHBoxLayout(version_widget, margin=0, spacing=4)
+        version_layout = version_widget.layout()
         version_layout.addWidget(version_input)
         version_layout.addWidget(last_version_check)
 
-        # Artist note widget
-        description_input = PlaceholderPlainTextEdit(inputs_widget)
+        # Artist note widget. AYTextEdit does not paint a background of its
+        # own, so it is framed the same way as the side panel's note field.
+        description_frame = AYContainer(
+            inputs_widget,
+            layout=AYContainer.Layout.VBox,
+            variant=AYContainer.Variants.Low_Framed_Thin,
+            layout_margin=4,
+            layout_spacing=0,
+        )
+        description_input = AYTextEdit(
+            description_frame, variant=AYTextEdit.Variants.Low
+        )
         description_input.setPlaceholderText(
             "Provide a note about this workfile.")
+        description_input.setMinimumHeight(60)
+        description_frame.add_widget(description_input, stretch=1)
 
         # Preview widget
         preview_widget = AYLabel("Preview filename", parent=inputs_widget)
@@ -184,10 +238,11 @@ class SaveAsDialog(QtWidgets.QDialog):
         subversion_input = SubversionLineEdit(inputs_widget)
         subversion_input.set_placeholder("Will be part of filename.")
 
-        extension_combobox = AYComboBox(parent=inputs_widget)
-        # Add styled delegate to use stylesheets
-        extension_delegate = QtWidgets.QStyledItemDelegate()
-        extension_combobox.setItemDelegate(extension_delegate)
+        # Use the same fill as the other inputs so the form rows match
+        extension_combobox = AYComboBox(
+            parent=inputs_widget,
+            variant=AYComboBox.Variants.Low,
+        )
 
         version_label = AYLabel("Version:", parent=inputs_widget)
         subversion_label = AYLabel("Subversion:", parent=inputs_widget)
@@ -196,7 +251,7 @@ class SaveAsDialog(QtWidgets.QDialog):
         description_label = AYLabel("Artist Note:", parent=inputs_widget)
 
         # Build inputs
-        inputs_layout = AYGridLayout(inputs_widget, margin=0, spacing=4)
+        inputs_layout = inputs_widget.layout()
         inputs_layout.addWidget(version_label, 0, 0)
         inputs_layout.addWidget(version_widget, 0, 1)
         inputs_layout.addWidget(subversion_label, 1, 0)
@@ -206,12 +261,17 @@ class SaveAsDialog(QtWidgets.QDialog):
         inputs_layout.addWidget(preview_label, 3, 0)
         inputs_layout.addWidget(preview_widget, 3, 1)
         inputs_layout.addWidget(description_label, 4, 0, 1, 2)
-        inputs_layout.addWidget(description_input, 5, 0, 1, 2)
+        inputs_layout.addWidget(description_frame, 5, 0, 1, 2)
 
         # Build layout
-        main_layout = AYVBoxLayout(self, margin=8, spacing=4)
-        main_layout.addWidget(inputs_widget)
-        main_layout.addWidget(btns_widget)
+        surface_layout = surface.layout()
+        surface_layout.addWidget(inputs_widget)
+        surface_layout.addWidget(btns_widget)
+
+        # The surface fills the dialog so nothing of the dialog's own
+        # (host-provided) background is left showing.
+        main_layout = AYVBoxLayout(self, margin=0, spacing=0)
+        main_layout.addWidget(surface)
 
         # Signal callback registration
         version_input.valueChanged.connect(self._on_version_spinbox_change)
@@ -237,7 +297,6 @@ class SaveAsDialog(QtWidgets.QDialog):
         self._version_input = version_input
         self._last_version_check = last_version_check
 
-        self._extension_delegate = extension_delegate
         self._extension_combobox = extension_combobox
         self._subversion_input = subversion_input
         self._preview_widget = preview_widget

--- a/client/ayon_core/tools/workfiles/widgets/save_as_dialog.py
+++ b/client/ayon_core/tools/workfiles/widgets/save_as_dialog.py
@@ -1,4 +1,6 @@
-from qtpy import QtWidgets, QtCore
+from __future__ import annotations
+
+from qtpy import QtWidgets
 
 from ayon_core.ui.components import (
     AYButton,
@@ -11,101 +13,9 @@ from ayon_core.ui.components import (
     AYLineEdit,
     AYSpinBox,
     AYTextEdit,
+    AYHBoxLayout,
+    AYGridLayout,
 )
-
-# Surface variant used by the dialog and by every plain wrapper widget
-# inside it, so the wrappers blend into the dialog surface instead of
-# falling back to the host/legacy stylesheet background.
-SURFACE_VARIANT = AYContainer.Variants.Dialog
-
-
-class SubversionLineEdit(AYContainer):
-    """QLineEdit with QPushButton for drop down selection of list of strings"""
-
-    text_changed = QtCore.Signal(str)
-
-    def __init__(self, parent=None):
-        super().__init__(
-            parent,
-            layout=AYContainer.Layout.HBox,
-            variant=SURFACE_VARIANT,
-            layout_margin=0,
-            layout_spacing=3,
-        )
-
-        input_field = AYLineEdit(
-            parent=self, variant=AYLineEdit.Variants.Low
-        )
-        menu_btn = AYButton(
-            variant=AYButton.Variants.Surface,
-            icon="arrow_drop_down",
-            parent=self,
-        )
-        menu_btn.setFixedWidth(18)
-
-        menu = AYMenu(self)
-        menu_btn.setMenu(menu)
-
-        layout = self.layout()
-        layout.addWidget(input_field, 1)
-        layout.addWidget(menu_btn, 0)
-
-        input_field.textChanged.connect(self.text_changed)
-
-        self.setFocusProxy(input_field)
-
-        self._input_field = input_field
-        self._menu_btn = menu_btn
-        self._menu = menu
-
-    def set_placeholder(self, placeholder):
-        self._input_field.setPlaceholderText(placeholder)
-
-    def set_text(self, text):
-        self._input_field.setText(text)
-
-    def set_values(self, values):
-        self._update(values)
-
-    def _on_button_clicked(self):
-        self._menu.exec_()
-
-    def _on_action_clicked(self, action):
-        self._input_field.setText(action.text())
-
-    def _update(self, values):
-        """Create optional predefined product names
-
-        Args:
-            default_names(list): all predefined names
-
-        Returns:
-             None
-        """
-
-        menu = self._menu
-        button = self._menu_btn
-
-        state = any(values)
-        button.setEnabled(state)
-        if state is False:
-            return
-
-        # Include an empty string
-        values = [""] + sorted(values)
-
-        # Get and destroy the action group
-        group = button.findChild(QtWidgets.QActionGroup)
-        if group:
-            group.deleteLater()
-
-        # Build new action group
-        group = QtWidgets.QActionGroup(button)
-        for name in values:
-            action = group.addAction(name)
-            menu.addAction(action)
-
-        group.triggered.connect(self._on_action_clicked)
 
 
 class SaveAsDialog(QtWidgets.QDialog):
@@ -138,61 +48,21 @@ class SaveAsDialog(QtWidgets.QDialog):
 
         self._result = None
 
-        # Dialog surface. Every visible widget lives inside this container so
-        # the dialog is painted from the AYON surface ramp rather than
-        # inheriting the host's (or the tool's legacy) stylesheet background.
+        # Dialog surface to paint the background under other widgets.
         surface = AYContainer(
             self,
             layout=AYContainer.Layout.VBox,
-            variant=SURFACE_VARIANT,
+            variant=AYContainer.Variants.High_Dark,
             layout_margin=8,
             layout_spacing=4,
         )
 
-        # Btns widget
-        btns_widget = AYContainer(
-            surface,
-            layout=AYContainer.Layout.HBox,
-            variant=SURFACE_VARIANT,
-            layout_margin=0,
-            layout_spacing=4,
-        )
-
-        btn_ok = AYButton(
-            "Ok",
-            variant=AYButton.Variants.Filled,
-            parent=btns_widget,
-        )
-        btn_cancel = AYButton(
-            "Cancel",
-            variant=AYButton.Variants.Surface,
-            parent=btns_widget,
-        )
-
-        btns_widget.add_widget(btn_ok)
-        btns_widget.add_widget(btn_cancel)
-
         # Inputs widget
-        inputs_widget = AYContainer(
-            surface,
-            layout=AYContainer.Layout.Grid,
-            variant=SURFACE_VARIANT,
-            layout_margin=0,
-            layout_spacing=4,
-        )
-
-        # Version widget
-        version_widget = AYContainer(
-            inputs_widget,
-            layout=AYContainer.Layout.HBox,
-            variant=SURFACE_VARIANT,
-            layout_margin=0,
-            layout_spacing=4,
-        )
+        inputs_layout = AYGridLayout(margin=0, spacing=4)
 
         # Version number input
         version_input = AYSpinBox(
-            parent=version_widget,
+            parent=surface,
             variant=AYSpinBox.Variants.Low,
             minimum=1,
             maximum=9999,
@@ -200,7 +70,7 @@ class SaveAsDialog(QtWidgets.QDialog):
 
         # Last version checkbox
         last_version_check = AYCheckBox(
-            "Next Available Version", parent=version_widget,
+            "Next Available Version", parent=surface,
         )
         last_version_check.setChecked(True)
         last_version_check.setSizePolicy(
@@ -208,13 +78,14 @@ class SaveAsDialog(QtWidgets.QDialog):
             QtWidgets.QSizePolicy.Fixed,
         )
 
-        version_widget.add_widget(version_input)
-        version_widget.add_widget(last_version_check)
+        versions_layout = AYHBoxLayout(margin=0, spacing=4)
+        versions_layout.addWidget(version_input, 0)
+        versions_layout.addWidget(last_version_check, 0)
 
         # Artist note widget. AYTextEdit does not paint a background of its
         # own, so it is framed the same way as the side panel's note field.
         description_frame = AYContainer(
-            inputs_widget,
+            surface,
             layout=AYContainer.Layout.VBox,
             variant=AYContainer.Variants.Low_Framed_Thin,
             layout_margin=4,
@@ -229,31 +100,61 @@ class SaveAsDialog(QtWidgets.QDialog):
         description_frame.add_widget(description_input, stretch=1)
 
         # Preview widget
-        preview_widget = AYLabel("Preview filename", parent=inputs_widget)
+        preview_widget = AYLabel("Preview filename", parent=surface)
         preview_widget.setWordWrap(True)
 
         # Subversion input
-        subversion_input = SubversionLineEdit(inputs_widget)
-        subversion_input.set_placeholder("Will be part of filename.")
+        subversion_input = AYLineEdit(
+            parent=self, variant=AYLineEdit.Variants.Low
+        )
+        subversion_input.setPlaceholderText("Will be part of filename.")
+
+        subversion_menu_btn = AYButton(
+            variant=AYButton.Variants.Surface,
+            icon="arrow_drop_down",
+            parent=self,
+        )
+        subversion_menu_btn.setFixedWidth(18)
+
+        subversion_layout = AYHBoxLayout(margin=0, spacing=3)
+        subversion_layout.addWidget(subversion_input, 1)
+        subversion_layout.addWidget(subversion_menu_btn, 0)
+
+        subversion_menu = AYMenu()
+        subversion_menu_btn.setMenu(subversion_menu)
 
         # Use the same fill as the other inputs so the form rows match
         extension_combobox = AYComboBox(
-            parent=inputs_widget,
+            parent=surface,
             variant=AYComboBox.Variants.Low,
         )
 
-        version_label = AYLabel("Version:", parent=inputs_widget)
-        subversion_label = AYLabel("Subversion:", parent=inputs_widget)
-        extension_label = AYLabel("Extension:", parent=inputs_widget)
-        preview_label = AYLabel("Preview:", parent=inputs_widget)
-        description_label = AYLabel("Artist Note:", parent=inputs_widget)
+        version_label = AYLabel("Version:", parent=surface)
+        subversion_label = AYLabel("Subversion:", parent=surface)
+        extension_label = AYLabel("Extension:", parent=surface)
+        preview_label = AYLabel("Preview:", parent=surface)
+        description_label = AYLabel("Artist Note:", parent=surface)
+
+        # Btns widget
+        btn_ok = AYButton(
+            "Save",
+            variant=AYButton.Variants.Filled,
+            parent=surface,
+        )
+        btn_cancel = AYButton(
+            "Cancel",
+            variant=AYButton.Variants.Surface,
+            parent=surface,
+        )
+        btns_layout = AYHBoxLayout(margin=0, spacing=4)
+        btns_layout.addWidget(btn_ok, 1)
+        btns_layout.addWidget(btn_cancel, 1)
 
         # Build inputs
-        inputs_layout = inputs_widget.layout()
         inputs_layout.addWidget(version_label, 0, 0)
-        inputs_layout.addWidget(version_widget, 0, 1)
+        inputs_layout.addLayout(versions_layout, 0, 1)
         inputs_layout.addWidget(subversion_label, 1, 0)
-        inputs_layout.addWidget(subversion_input, 1, 1)
+        inputs_layout.addLayout(subversion_layout, 1, 1)
         inputs_layout.addWidget(extension_label, 2, 0)
         inputs_layout.addWidget(extension_combobox, 2, 1)
         inputs_layout.addWidget(preview_label, 3, 0)
@@ -261,8 +162,8 @@ class SaveAsDialog(QtWidgets.QDialog):
         inputs_layout.addWidget(description_label, 4, 0, 1, 2)
         inputs_layout.addWidget(description_frame, 5, 0, 1, 2)
 
-        surface.add_widget(inputs_widget)
-        surface.add_widget(btns_widget)
+        surface.add_layout(inputs_layout, 0)
+        surface.add_layout(btns_layout, 0)
 
         main_layout = AYVBoxLayout(self, margin=0, spacing=0)
         main_layout.addWidget(surface, 1)
@@ -273,7 +174,7 @@ class SaveAsDialog(QtWidgets.QDialog):
             self._on_version_checkbox_change
         )
 
-        subversion_input.text_changed.connect(self._on_comment_change)
+        subversion_input.textChanged.connect(self._on_comment_change)
         extension_combobox.currentIndexChanged.connect(
             self._on_extension_change)
 
@@ -286,13 +187,16 @@ class SaveAsDialog(QtWidgets.QDialog):
         self._btn_ok = btn_ok
         self._btn_cancel = btn_cancel
 
-        self._version_widget = version_widget
+        self._versions_layout = versions_layout
 
         self._version_input = version_input
         self._last_version_check = last_version_check
 
         self._extension_combobox = extension_combobox
+        self._subversion_layout = subversion_layout
         self._subversion_input = subversion_input
+        self._subversion_menu = subversion_menu
+        self._subversion_menu_btn = subversion_menu_btn
         self._preview_widget = preview_widget
         self._description_input = description_input
 
@@ -346,26 +250,28 @@ class SaveAsDialog(QtWidgets.QDialog):
 
         self._version_input.setValue(last_version)
 
-        vw_idx = self._inputs_layout.indexOf(self._version_widget)
+        vw_idx = self._inputs_layout.indexOf(self._versions_layout)
         self._version_label.setVisible(template_has_version)
-        self._version_widget.setVisible(template_has_version)
+        self._version_input.setVisible(template_has_version)
+        self._last_version_check.setVisible(template_has_version)
         if template_has_version:
             if vw_idx == -1:
                 self._inputs_layout.addWidget(self._version_label, 0, 0)
-                self._inputs_layout.addWidget(self._version_widget, 0, 1)
+                self._inputs_layout.addLayout(self._versions_layout, 0, 1)
         elif vw_idx != -1:
             self._inputs_layout.takeAt(vw_idx)
             self._inputs_layout.takeAt(
                 self._inputs_layout.indexOf(self._version_label)
             )
 
-        cw_idx = self._inputs_layout.indexOf(self._subversion_input)
+        cw_idx = self._inputs_layout.indexOf(self._subversion_layout)
         self._subversion_label.setVisible(template_has_comment)
         self._subversion_input.setVisible(template_has_comment)
+        self._subversion_menu_btn.setVisible(template_has_comment)
         if template_has_comment:
             if cw_idx == -1:
                 self._inputs_layout.addWidget(self._subversion_label, 1, 0)
-                self._inputs_layout.addWidget(self._subversion_input, 1, 1)
+                self._inputs_layout.addLayout(self._subversion_layout, 1, 1)
         elif cw_idx != -1:
             self._inputs_layout.takeAt(cw_idx)
             self._inputs_layout.takeAt(
@@ -373,8 +279,8 @@ class SaveAsDialog(QtWidgets.QDialog):
             )
 
         if template_has_comment:
-            self._subversion_input.set_text(comment or "")
-            self._subversion_input.set_values(comment_hints)
+            self._subversion_input.setText(comment or "")
+            self._set_subversion_items(comment_hints)
         self._update_filename()
 
     def _on_version_spinbox_change(self, value):
@@ -405,6 +311,37 @@ class SaveAsDialog(QtWidgets.QDialog):
             return
         self._ext_value = ext
         self._update_filename()
+
+    def _on_subversion_action_clicked(self, action) -> None:
+        self._subversion_input.setText(action.text())
+
+    def _set_subversion_items(self, values: list[str] | None) -> None:
+        values = values or []
+
+        menu = self._subversion_menu
+        button = self._subversion_menu_btn
+
+        button.setEnabled(any(values))
+        if not button.isEnabled():
+            return
+
+        # Include an empty string
+        values.sort()
+        if "" not in values:
+            values.insert(0, "")
+
+        # Get and destroy the action group
+        group = button.findChild(QtWidgets.QActionGroup)
+        if group:
+            group.deleteLater()
+
+        # Build new action group
+        group = QtWidgets.QActionGroup(button)
+        for name in values:
+            action = group.addAction(name)
+            menu.addAction(action)
+
+        group.triggered.connect(self._on_subversion_action_clicked)
 
     def _on_ok_pressed(self):
         self._result = {

--- a/client/ayon_core/tools/workfiles/widgets/save_as_dialog.py
+++ b/client/ayon_core/tools/workfiles/widgets/save_as_dialog.py
@@ -266,7 +266,7 @@ class SaveAsDialog(QtWidgets.QDialog):
         surface.add_widget(btns_widget)
 
         main_layout = AYVBoxLayout(self, margin=0, spacing=0)
-        main_layout.addWidget(surface)
+        main_layout.addWidget(surface, 1)
 
         # Signal callback registration
         version_input.valueChanged.connect(self._on_version_spinbox_change)

--- a/client/ayon_core/tools/workfiles/widgets/save_as_dialog.py
+++ b/client/ayon_core/tools/workfiles/widgets/save_as_dialog.py
@@ -105,14 +105,14 @@ class SaveAsDialog(QtWidgets.QDialog):
 
         # Subversion input
         subversion_input = AYLineEdit(
-            parent=self, variant=AYLineEdit.Variants.Low
+            parent=surface, variant=AYLineEdit.Variants.Low
         )
         subversion_input.setPlaceholderText("Will be part of filename.")
 
         subversion_menu_btn = AYButton(
             variant=AYButton.Variants.Surface,
             icon="arrow_drop_down",
-            parent=self,
+            parent=surface,
         )
         subversion_menu_btn.setFixedWidth(18)
 

--- a/client/ayon_core/tools/workfiles/widgets/save_as_dialog.py
+++ b/client/ayon_core/tools/workfiles/widgets/save_as_dialog.py
@@ -209,9 +209,8 @@ class SaveAsDialog(QtWidgets.QDialog):
             QtWidgets.QSizePolicy.Fixed,
         )
 
-        version_layout = version_widget.layout()
-        version_layout.addWidget(version_input)
-        version_layout.addWidget(last_version_check)
+        version_widget.add_widget(version_input)
+        version_widget.add_widget(last_version_check)
 
         # Artist note widget. AYTextEdit does not paint a background of its
         # own, so it is framed the same way as the side panel's note field.
@@ -263,13 +262,9 @@ class SaveAsDialog(QtWidgets.QDialog):
         inputs_layout.addWidget(description_label, 4, 0, 1, 2)
         inputs_layout.addWidget(description_frame, 5, 0, 1, 2)
 
-        # Build layout
-        surface_layout = surface.layout()
-        surface_layout.addWidget(inputs_widget)
-        surface_layout.addWidget(btns_widget)
+        surface.add_widget(inputs_widget)
+        surface.add_widget(btns_widget)
 
-        # The surface fills the dialog so nothing of the dialog's own
-        # (host-provided) background is left showing.
         main_layout = AYVBoxLayout(self, margin=0, spacing=0)
         main_layout.addWidget(surface)
 

--- a/client/ayon_core/tools/workfiles/widgets/save_as_dialog.py
+++ b/client/ayon_core/tools/workfiles/widgets/save_as_dialog.py
@@ -169,9 +169,8 @@ class SaveAsDialog(QtWidgets.QDialog):
             parent=btns_widget,
         )
 
-        btns_layout = btns_widget.layout()
-        btns_layout.addWidget(btn_ok)
-        btns_layout.addWidget(btn_cancel)
+        btns_widget.add_widget(btn_ok)
+        btns_widget.add_widget(btn_cancel)
 
         # Inputs widget
         inputs_widget = AYContainer(

--- a/client/ayon_core/tools/workfiles/widgets/save_as_dialog.py
+++ b/client/ayon_core/tools/workfiles/widgets/save_as_dialog.py
@@ -320,8 +320,7 @@ class SaveAsDialog(QtWidgets.QDialog):
 
         menu = self._subversion_menu
         button = self._subversion_menu_btn
-
-        button.setEnabled(any(values))
+        button.setEnabled(bool(values))
         if not button.isEnabled():
             return
 

--- a/client/ayon_core/tools/workfiles/widgets/workfiles_style.css
+++ b/client/ayon_core/tools/workfiles/widgets/workfiles_style.css
@@ -28,7 +28,6 @@ QSplitter::handle:horizontal, QSplitter::handle:vertical, QSplitter::handle:hori
     background: transparent;
 }
 
-
 QHeaderView {
 border: 0px solid #373D48;
     border-radius: 0px;
@@ -72,96 +71,4 @@ image: url(:/openpype/images/up_arrow.png);
     padding-right: 4px;
     subcontrol-origin: padding;
     subcontrol-position: center right;
-}
-
-/* TODO: Bring below full style match to
-/* ayon-core/client/ayon_core/ui/components/spin_box.py
-/* then eliminate QAbstractSpinBox style from here.
-/* Inputs */ QAbstractSpinBox{
-border: 1px solid #373D48;
-    border-radius: 0.2em;
-    background: #21252B;
-    padding: 1px;
-}
-
-QAbstractSpinBox:disabled{
-background: #2C313A;
-}
-
-QAbstractSpinBox:hover{
-border-color: rgb(92, 99, 111);
-}
-
-QAbstractSpinBox:focus{
-border-color: rgb(92, 173, 214);
-}
-
-QAbstractSpinBox:up-button {
-margin: 0px;
-    background-color: transparent;
-    subcontrol-origin: border;
-    subcontrol-position: top right;
-    border-top-right-radius: 0.3em;
-    border-top: 0px solid transparent;
-    border-right: 0px solid transparent;
-    border-left: 1px solid #373D48;
-    border-bottom: 1px solid #373D48;
-}
-
-QAbstractSpinBox:down-button {
-margin: 0px;
-    background-color: transparent;
-    subcontrol-origin: border;
-    subcontrol-position: bottom right;
-    border-bottom-right-radius: 0.3em;
-    border-bottom: 0px solid transparent;
-    border-right: 0px solid transparent;
-    border-left: 1px solid #373D48;
-    border-top: 1px solid #373D48;
-}
-
-QAbstractSpinBox:up-button:focus, QAbstractSpinBox:down-button:focus {
-border-color: rgb(92, 173, 214);
-}
-
-QAbstractSpinBox::up-arrow, QAbstractSpinBox::up-arrow:off {
-image: url(:/openpype/images/up_arrow.png);
-    width: 0.5em;
-    height: 1em;
-    border-width: 1px;
-}
-
-QAbstractSpinBox::up-arrow:hover {
-image: url(:/openpype/images/up_arrow_on.png);
-    bottom: 1;
-}
-
-QAbstractSpinBox::up-arrow:disabled {
-image: url(:/openpype/images/up_arrow_disabled.png);
-}
-
-QAbstractSpinBox::up-arrow:pressed {
-image: url(:/openpype/images/up_arrow_on.png);
-    bottom: 0;
-}
-
-QAbstractSpinBox::down-arrow, QAbstractSpinBox::down-arrow:off {
-image: url(:/openpype/images/down_arrow.png);
-    width: 0.5em;
-    height: 1em;
-    border-width: 1px;
-}
-
-QAbstractSpinBox::down-arrow:hover {
-image: url(:/openpype/images/down_arrow_on.png);
-    bottom: 1;
-}
-
-QAbstractSpinBox::down-arrow:disabled {
-image: url(:/openpype/images/down_arrow_disabled.png);
-}
-
-QAbstractSpinBox::down-arrow:hover:pressed {
-image: url(:/openpype/images/down_arrow_on.png);
-    bottom: 0;
 }

--- a/client/ayon_core/ui/ayon_style.json
+++ b/client/ayon_core/ui/ayon_style.json
@@ -538,7 +538,7 @@
                 "high": {
                     "background-color": "--md-sys-color-surface-container-dark"
                 },
-                "dialog": {
+                "high-dark": {
                     "background-color": "--md-sys-color-surface-container-high-dark"
                 },
                 "tag": {

--- a/client/ayon_core/ui/ayon_style.json
+++ b/client/ayon_core/ui/ayon_style.json
@@ -385,6 +385,13 @@
                         "opacity": 0.5
                     }
                 },
+                "low": {
+                    "background-color": "--md-sys-color-surface-container-low-dark",
+                    "disabled": {
+                        "background-color": "--md-sys-color-surface-container-low-dark",
+                        "opacity": 0.5
+                    }
+                },
                 "search-field": {
                     "background-color": "--md-sys-color-surface-container-low-dark",
                     "selection-background-color": "--md-sys-color-secondary-container-dark",
@@ -427,6 +434,13 @@
                     },
                     "disabled": {
                         "background-color": "--md-sys-color-surface-container-dark",
+                        "opacity": 0.5
+                    }
+                },
+                "low": {
+                    "background-color": "--md-sys-color-surface-container-low-dark",
+                    "disabled": {
+                        "background-color": "--md-sys-color-surface-container-low-dark",
                         "opacity": 0.5
                     }
                 }
@@ -523,6 +537,9 @@
                 },
                 "high": {
                     "background-color": "--md-sys-color-surface-container-dark"
+                },
+                "dialog": {
+                    "background-color": "--md-sys-color-surface-container-high-dark"
                 },
                 "tag": {
                     "border-radius": 10,

--- a/client/ayon_core/ui/components/scroll_area.py
+++ b/client/ayon_core/ui/components/scroll_area.py
@@ -22,8 +22,8 @@ class AYScrollBar(StyleMixin, QScrollBar):
     Overrides Qt's stylesheet painting with AYONStyle custom rendering.
 
     Args:
-        *args: Positional arguments passed to QTextEdit.
-        **kwargs: Keyword arguments passed to QTextEdit.
+        *args: Positional arguments passed to QScrollBar.
+        **kwargs: Keyword arguments passed to QScrollBar.
     """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -47,7 +47,6 @@ class AYScrollBar(StyleMixin, QScrollBar):
         get_ayon_style().drawComplexControl(
             QStyle.ComplexControl.CC_ScrollBar, option, p, self
         )
-        return
 
 
 class AYScrollArea(StyleMixin, QScrollArea):

--- a/client/ayon_core/ui/components/spinbox.py
+++ b/client/ayon_core/ui/components/spinbox.py
@@ -65,6 +65,24 @@ class AYSpinBox(StyleMixin, QSpinBox):
         # Suppress the native Qt frame
         self.setFrame(False)
 
+        # Neutralise any ancestor stylesheet that would intercept the spin
+        # box painting via QStyleSheetStyle and draw its own frame and
+        # up/down buttons on top of the ones we paint ourselves. The
+        # property selector is there for specificity: a bare type selector
+        # ties with an ancestor's "QAbstractSpinBox" rule, and the ancestor
+        # then wins.
+        self.setProperty("ayonPainted", True)
+        self.setStyleSheet(
+            "AYSpinBox[ayonPainted=\"true\"] { background: transparent; "
+            "border: none; padding: 0px; "
+            "selection-background-color: none; selection-color: none; }"
+            "AYSpinBox[ayonPainted=\"true\"]::up-button, "
+            "AYSpinBox[ayonPainted=\"true\"]::down-button { "
+            "background: transparent; border: none; }"
+            "AYSpinBox[ayonPainted=\"true\"]::up-arrow, "
+            "AYSpinBox[ayonPainted=\"true\"]::down-arrow { image: none; }"
+        )
+
         # Suppress macOS native focus ring (we draw our own)
         self.setAttribute(Qt.WidgetAttribute.WA_MacShowFocusRect, False)
 

--- a/client/ayon_core/ui/components/spinbox.py
+++ b/client/ayon_core/ui/components/spinbox.py
@@ -64,25 +64,6 @@ class AYSpinBox(StyleMixin, QSpinBox):
 
         # Suppress the native Qt frame
         self.setFrame(False)
-
-        # Neutralise any ancestor stylesheet that would intercept the spin
-        # box painting via QStyleSheetStyle and draw its own frame and
-        # up/down buttons on top of the ones we paint ourselves. The
-        # property selector is there for specificity: a bare type selector
-        # ties with an ancestor's "QAbstractSpinBox" rule, and the ancestor
-        # then wins.
-        self.setProperty("ayonPainted", True)
-        self.setStyleSheet(
-            "AYSpinBox[ayonPainted=\"true\"] { background: transparent; "
-            "border: none; padding: 0px; "
-            "selection-background-color: none; selection-color: none; }"
-            "AYSpinBox[ayonPainted=\"true\"]::up-button, "
-            "AYSpinBox[ayonPainted=\"true\"]::down-button { "
-            "background: transparent; border: none; }"
-            "AYSpinBox[ayonPainted=\"true\"]::up-arrow, "
-            "AYSpinBox[ayonPainted=\"true\"]::down-arrow { image: none; }"
-        )
-
         # Suppress macOS native focus ring (we draw our own)
         self.setAttribute(Qt.WidgetAttribute.WA_MacShowFocusRect, False)
 

--- a/client/ayon_core/ui/components/text_edit.py
+++ b/client/ayon_core/ui/components/text_edit.py
@@ -8,6 +8,7 @@ from qtpy.QtWidgets import QTextEdit
 from ..style_types import get_ayon_style
 from ..variants import QTextEditVariants
 from .style_mixin import StyleMixin
+from .scroll_area import AYScrollBar
 
 
 class AYTextEdit(StyleMixin, QTextEdit):
@@ -39,3 +40,12 @@ class AYTextEdit(StyleMixin, QTextEdit):
         super().__init__(*args, **kwargs)
         self.setStyle(get_ayon_style())
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+
+        self.setVerticalScrollBar(AYScrollBar(Qt.Orientation.Vertical))
+        self.setVerticalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAsNeeded
+        )
+        self.setHorizontalScrollBar(AYScrollBar(Qt.Orientation.Horizontal))
+        self.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAsNeeded
+        )

--- a/client/ayon_core/ui/variants.py
+++ b/client/ayon_core/ui/variants.py
@@ -71,7 +71,7 @@ class QFrameVariants(Enum):
     Low_Framed_Thin = "low-framed-thin"
     Low_Table_Editor = "low-table-editor"
     High = "high"
-    Dialog = "high-dark"
+    High_Dark = "high-dark"
     Tag = "tag"
     Item_View = "item-view"
     Criterion = "criterion"

--- a/client/ayon_core/ui/variants.py
+++ b/client/ayon_core/ui/variants.py
@@ -71,7 +71,7 @@ class QFrameVariants(Enum):
     Low_Framed_Thin = "low-framed-thin"
     Low_Table_Editor = "low-table-editor"
     High = "high"
-    Dialog = "dialog"
+    Dialog = "high-dark"
     Tag = "tag"
     Item_View = "item-view"
     Criterion = "criterion"

--- a/client/ayon_core/ui/variants.py
+++ b/client/ayon_core/ui/variants.py
@@ -41,11 +41,13 @@ class QTextEditVariants(Enum):
 
 class QLineEditVariants(Enum):
     Default = "default"
+    Low = "low"
     Search_Field = "search-field"
 
 
 class QSpinBoxVariants(Enum):
     Default = "default"
+    Low = "low"
 
 
 class QComboBoxVariants(Enum):
@@ -69,6 +71,7 @@ class QFrameVariants(Enum):
     Low_Framed_Thin = "low-framed-thin"
     Low_Table_Editor = "low-table-editor"
     High = "high"
+    Dialog = "dialog"
     Tag = "tag"
     Item_View = "item-view"
     Criterion = "criterion"
@@ -108,6 +111,10 @@ class QTreeViewVariants(Enum):
 
 
 class QStyledItemDelegateVariants(Enum):
+    Default = "default"
+
+
+class AYHeaderViewVariants(Enum):
     Default = "default"
 
 


### PR DESCRIPTION
## Changelog Description

Fix styling on the workfiles save as dialog

## Additional info

<img width="368" height="435" alt="image" src="https://github.com/user-attachments/assets/d360fe4f-da38-46d1-8312-f352a025419d" />


## Testing notes:

1. Workfiles tool works.