### PR TITLE
UI: Center the status icons horizontally for the status columns on folder/tasks

### DIFF
--- a/client/ayon_core/tools/utils/delegates.py
+++ b/client/ayon_core/tools/utils/delegates.py
@@ -6,6 +6,8 @@ import logging
 
 from qtpy import QtWidgets, QtGui, QtCore
 
+from ayon_core.ui.components.tree_view import TreeViewItemDelegate
+
 log = logging.getLogger(__name__)
 
 
@@ -137,6 +139,28 @@ class PrettyTimeDelegate(QtWidgets.QStyledItemDelegate):
             if value is not None:
                 return value
         return self._default_value
+
+
+class CenteredIconDelegate(TreeViewItemDelegate):
+    """Status-icon-only column delegate that centers the icon.
+
+    'AYTreeView' paints entirely by itself (background/hover/selection
+    colors, icon and text layout) via 'TreeViewItemDelegate', bypassing
+    QStyle/QSS so its look stays correct even under a parent stylesheet.
+    A plain 'QStyledItemDelegate' painting through 'QStyle' therefore
+    renders with different colors than the rest of the view. Subclassing
+    'TreeViewItemDelegate' keeps that painting identical and only
+    overrides the content alignment, which is what positions the icon
+    within the column (see 'TreeViewItemDelegate.paint').
+    """
+
+    def initStyleOption(self, option, index):
+        super().initStyleOption(option, index)
+        # 'TreeViewItemDelegate.paint' centers content on an exact
+        # 'displayAlignment == AlignHCenter' check, so the combined
+        # 'AlignCenter' flag (AlignHCenter | AlignVCenter) would not
+        # match it and silently fall back to left alignment.
+        option.displayAlignment = QtCore.Qt.AlignHCenter
 
 
 class StatusDelegate(QtWidgets.QStyledItemDelegate):

--- a/client/ayon_core/tools/utils/delegates.py
+++ b/client/ayon_core/tools/utils/delegates.py
@@ -6,8 +6,6 @@ import logging
 
 from qtpy import QtWidgets, QtGui, QtCore
 
-from ayon_core.ui.components.tree_view import TreeViewItemDelegate
-
 log = logging.getLogger(__name__)
 
 
@@ -139,28 +137,6 @@ class PrettyTimeDelegate(QtWidgets.QStyledItemDelegate):
             if value is not None:
                 return value
         return self._default_value
-
-
-class CenteredIconDelegate(TreeViewItemDelegate):
-    """Status-icon-only column delegate that centers the icon.
-
-    'AYTreeView' paints entirely by itself (background/hover/selection
-    colors, icon and text layout) via 'TreeViewItemDelegate', bypassing
-    QStyle/QSS so its look stays correct even under a parent stylesheet.
-    A plain 'QStyledItemDelegate' painting through 'QStyle' therefore
-    renders with different colors than the rest of the view. Subclassing
-    'TreeViewItemDelegate' keeps that painting identical and only
-    overrides the content alignment, which is what positions the icon
-    within the column (see 'TreeViewItemDelegate.paint').
-    """
-
-    def initStyleOption(self, option, index):
-        super().initStyleOption(option, index)
-        # 'TreeViewItemDelegate.paint' centers content on an exact
-        # 'displayAlignment == AlignHCenter' check, so the combined
-        # 'AlignCenter' flag (AlignHCenter | AlignVCenter) would not
-        # match it and silently fall back to left alignment.
-        option.displayAlignment = QtCore.Qt.AlignHCenter
 
 
 class StatusDelegate(QtWidgets.QStyledItemDelegate):

--- a/client/ayon_core/tools/utils/folders_widget.py
+++ b/client/ayon_core/tools/utils/folders_widget.py
@@ -27,10 +27,10 @@ from ayon_core.ui.components import (
 
 from ayon_core.ui.style_types import get_ayon_style
 from ayon_core.ui.variants import QTreeViewVariants
+from ayon_core.ui.components.tree_view import TreeViewItemDelegate
 
 from .models import RecursiveSortFilterProxyModel
 from .lib import get_qt_icon
-from .delegates import CenteredIconDelegate
 
 
 FOLDERS_MODEL_SENDER_NAME = "qt_folders_model"
@@ -40,6 +40,12 @@ FOLDER_PATH_ROLE = QtCore.Qt.UserRole + 3
 FOLDER_TYPE_ROLE = QtCore.Qt.UserRole + 4
 FOLDER_STATUS_ROLE = QtCore.Qt.UserRole + 5
 FOLDER_STATUS_ICON_ROLE = QtCore.Qt.UserRole + 6
+
+
+class CenteredIconDelegate(TreeViewItemDelegate):
+    def initStyleOption(self, option, index):
+        super().initStyleOption(option, index)
+        option.displayAlignment = QtCore.Qt.AlignHCenter
 
 
 class RefreshTask(QtCore.QObject, QtCore.QRunnable):

--- a/client/ayon_core/tools/utils/folders_widget.py
+++ b/client/ayon_core/tools/utils/folders_widget.py
@@ -25,8 +25,12 @@ from ayon_core.ui.components import (
     AYTreeView
 )
 
+from ayon_core.ui.style_types import get_ayon_style
+from ayon_core.ui.variants import QTreeViewVariants
+
 from .models import RecursiveSortFilterProxyModel
 from .lib import get_qt_icon
+from .delegates import CenteredIconDelegate
 
 
 FOLDERS_MODEL_SENDER_NAME = "qt_folders_model"
@@ -571,6 +575,14 @@ class FoldersWidget(QtWidgets.QWidget):
         )
         header.resizeSection(1, 30)
         folders_view.setColumnHidden(1, True)
+        folders_view.setItemDelegateForColumn(
+            1,
+            CenteredIconDelegate(
+                parent=folders_view,
+                style_model=get_ayon_style().model,
+                variant=QTreeViewVariants.Default.value,
+            )
+        )
 
         main_layout = QtWidgets.QHBoxLayout(self)
         main_layout.setContentsMargins(0, 0, 0, 0)

--- a/client/ayon_core/tools/utils/tasks_widget.py
+++ b/client/ayon_core/tools/utils/tasks_widget.py
@@ -17,9 +17,9 @@ from ayon_core.ui.components import AYTreeView
 
 from ayon_core.ui.style_types import get_ayon_style
 from ayon_core.ui.variants import QTreeViewVariants
+from ayon_core.ui.components.tree_view import TreeViewItemDelegate
 
 from .lib import RefreshThread, get_qt_icon
-from .delegates import CenteredIconDelegate
 
 TASKS_MODEL_SENDER_NAME = "qt_tasks_model"
 ITEM_ID_ROLE = QtCore.Qt.UserRole + 1
@@ -29,6 +29,12 @@ TASK_TYPE_ROLE = QtCore.Qt.UserRole + 4
 TASK_TYPE_ORDER_ROLE = QtCore.Qt.UserRole + 5
 TASK_STATUS_ROLE = QtCore.Qt.UserRole + 6
 TASK_STATUS_ICON_ROLE = QtCore.Qt.UserRole + 7
+
+
+class CenteredIconDelegate(TreeViewItemDelegate):
+    def initStyleOption(self, option, index):
+        super().initStyleOption(option, index)
+        option.displayAlignment = QtCore.Qt.AlignHCenter
 
 
 class TasksQtModel(QtGui.QStandardItemModel):

--- a/client/ayon_core/tools/utils/tasks_widget.py
+++ b/client/ayon_core/tools/utils/tasks_widget.py
@@ -15,7 +15,11 @@ from ayon_core.style import (
 )
 from ayon_core.ui.components import AYTreeView
 
+from ayon_core.ui.style_types import get_ayon_style
+from ayon_core.ui.variants import QTreeViewVariants
+
 from .lib import RefreshThread, get_qt_icon
+from .delegates import CenteredIconDelegate
 
 TASKS_MODEL_SENDER_NAME = "qt_tasks_model"
 ITEM_ID_ROLE = QtCore.Qt.UserRole + 1
@@ -491,6 +495,14 @@ class TasksWidget(QtWidgets.QWidget):
         )
         header.resizeSection(1, 30)
         tasks_view.setColumnHidden(1, True)
+        tasks_view.setItemDelegateForColumn(
+            1,
+            CenteredIconDelegate(
+                parent=tasks_view,
+                style_model=get_ayon_style().model,
+                variant=QTreeViewVariants.Default.value,
+            )
+        )
 
         main_layout = QtWidgets.QHBoxLayout(self)
         main_layout.setContentsMargins(0, 0, 0, 0)

--- a/client/ayon_core/ui/components/tree_view.py
+++ b/client/ayon_core/ui/components/tree_view.py
@@ -407,7 +407,7 @@ class TreeViewItemDelegate(StyleMixin, QStyledItemDelegate):
                 icon_rect.moveTop(
                     (opt.rect.bottom() - icon_size.height()) + 1
                 )
-            elif opt.decorationAlignment & Qt.AlignmentFlag.AlignHCenter:
+            elif opt.decorationAlignment & Qt.AlignmentFlag.AlignVCenter:
                 icon_rect.moveTop(
                     (opt.rect.center().y() - (icon_size.height() // 2)) + 1
                 )
@@ -433,9 +433,9 @@ class TreeViewItemDelegate(StyleMixin, QStyledItemDelegate):
             )
             opt.text = elided_text
 
-        if opt.displayAlignment == Qt.AlignmentFlag.AlignRight:
+        if opt.displayAlignment & Qt.AlignmentFlag.AlignRight:
             content_left = content_rect.right() - content_width
-        elif opt.displayAlignment == Qt.AlignmentFlag.AlignHCenter:
+        elif opt.displayAlignment & Qt.AlignmentFlag.AlignHCenter:
             content_left = content_rect.left() + (
                 content_rect.width() - content_width
             ) // 2


### PR DESCRIPTION
## Changelog Description

Center the status icons horizontally for the status columns on folder/tasks

## Additional info

<img width="565" height="597" alt="image" src="https://github.com/user-attachments/assets/26bda4e1-dd14-4d1a-85aa-368a5cacfbcc" />


## Testing notes:

1. Status icons look ok.
2. Code is ok.