### PR TITLE
Publisher: Fix context change on instances

### DIFF
--- a/client/ayon_core/tools/publisher/widgets/product_context.py
+++ b/client/ayon_core/tools/publisher/widgets/product_context.py
@@ -713,13 +713,19 @@ class GlobalAttrsWidget(QtWidgets.QWidget):
         folder_path = None
         task_name = None
         if self.variant_input.has_value_changed():
-            variant_value = self.variant_input.get_value()[0]
+            variant_value = next(iter(
+                self.variant_input.get_value()
+            ))
 
         if self.folder_value_widget.has_value_changed():
-            folder_path = self.folder_value_widget.get_selected_items()[0]
+            folder_path = next(iter(
+                self.folder_value_widget.get_selected_items()
+            ))
 
         if self.task_value_widget.has_value_changed():
-            task_name = self.task_value_widget.get_selected_items()[0]
+            task_name = next(iter(
+                self.task_value_widget.get_selected_items()
+            ))
 
         product_names = set()
         invalid_tasks = False


### PR DESCRIPTION
## Changelog Description
Use next iter to get selected values instead of index access.

## Additional info
The index access can fail if the widget does return set or iterable.

## Testing notes:
1. Open publisher in a host.
2. Create an instance.
3. Select the instance, change folder/task and confirm it in the UI.
4. The context should be changed.