### PR TITLE
Material Symbols: Use alternative way how to draw icons

### DIFF
--- a/client/ayon_core/vendor/python/qtmaterialsymbols/iconic_font.py
+++ b/client/ayon_core/vendor/python/qtmaterialsymbols/iconic_font.py
@@ -17,8 +17,7 @@ import warnings
 from packaging.version import parse
 from typing import Dict, Optional, Union
 
-from qtpy import QtCore, QtGui, QtWidgets
-from qtpy import QT_VERSION
+from qtpy import QtCore, QtGui, QtWidgets, QT_VERSION
 
 from .structures import IconOptions, Position
 from .utils import get_char_mapping, _get_font_name_filled, _get_font_name

--- a/client/ayon_core/vendor/python/qtmaterialsymbols/iconic_font.py
+++ b/client/ayon_core/vendor/python/qtmaterialsymbols/iconic_font.py
@@ -14,9 +14,11 @@ methods returning instances of ``QIcon``.
 """
 import warnings
 
+from packaging.version import parse
 from typing import Dict, Optional, Union
 
 from qtpy import QtCore, QtGui, QtWidgets
+from qtpy import QT_VERSION
 
 from .structures import IconOptions, Position
 from .utils import get_char_mapping, _get_font_name_filled, _get_font_name
@@ -38,6 +40,12 @@ def get_icon(*args, **kwargs):
 
 class CharIconPainter:
     """Char icon painter."""
+
+    def __init__(self):
+        qt_version = parse(QT_VERSION)
+        self._use_path = parse("6.0") < qt_version < parse("6.6")
+        self._glyph_path_cache = {}
+
     def paint(self, iconic, painter, rect, mode, state, options):
         """Main paint method."""
         self._paint_icon(iconic, painter, rect, mode, state, options)
@@ -45,11 +53,10 @@ class CharIconPainter:
     def _paint_icon(self, iconic, painter, rect, mode, state, options):
         """Paint a single icon."""
         painter.save()
+        painter.setClipRect(rect)
 
         color = options.get_color_for_state(state, mode)
         char = options.get_char_for_state(state, mode)
-
-        painter.setPen(QtGui.QColor(color))
 
         draw_size = round(rect.height() * options.scale_factor)
 
@@ -58,7 +65,6 @@ class CharIconPainter:
             options.get_fill_for_state(state, mode)
         )
 
-        painter.setFont(font)
         if options.offset is not None:
             rect = QtCore.QRect(rect)
             rect.translate(
@@ -70,9 +76,8 @@ class CharIconPainter:
         scale_y = -1 if options.vflip else 1
 
         if options.vflip or options.hflip or options.rotate:
-            x_center = rect.width() * 0.5
-            y_center = rect.height() * 0.5
-            painter.translate(x_center, y_center)
+            center = rect.center()
+            painter.translate(center)
 
             transfrom = QtGui.QTransform()
             transfrom.scale(scale_x, scale_y)
@@ -80,12 +85,62 @@ class CharIconPainter:
 
             if options.rotate:
                 painter.rotate(options.rotate)
-            painter.translate(-x_center, -y_center)
+            painter.translate(-center)
 
         painter.setOpacity(options.opacity)
 
-        painter.drawText(rect, QtCore.Qt.AlignCenter, char)
+        if self._use_path:
+            painter.setRenderHint(QtGui.QPainter.Antialiasing, True)
+            path = self._get_glyph_path(font, char)
+            if not path.isEmpty():
+                metrics = QtGui.QFontMetricsF(font)
+                bounds = metrics.boundingRect(rect, QtCore.Qt.AlignCenter, char)
+
+                # Bounds width returns zero in Qt 6.5.4 (in e.g. Silhouette)
+                offset_x = bounds.x()
+                if bounds.width() == 0:
+                    pixel_size = font.pixelSize()
+                    offset_x = rect.x() + ((rect.width() - pixel_size) // 2)
+                painter.translate(
+                    offset_x, bounds.bottom() - metrics.descent()
+                )
+                painter.fillPath(path, QtGui.QColor(color))
+        else:
+            painter.setFont(font)
+            painter.setPen(QtGui.QColor(color))
+            painter.drawText(rect, QtCore.Qt.AlignCenter, char)
+
         painter.restore()
+
+    def _get_glyph_path(
+        self, font: QtGui.QFont, char: str
+    ) -> QtGui.QPainterPath:
+        """Get the outline path for a single glyph.
+
+        Args:
+            font (QtGui.QFont): The font to use for the glyph.
+            char (str): The character to get the path for.
+
+        """
+        if not char:
+            return QtGui.QPainterPath()
+
+        cache_key = (font.family(), font.pixelSize(), char)
+        path = self._glyph_path_cache.get(cache_key)
+        if path is not None:
+            return path
+
+        raw_font = QtGui.QRawFont.fromFont(font)
+        if not raw_font.isValid():
+            return QtGui.QPainterPath()
+
+        glyph_indexes = raw_font.glyphIndexesForString(char)
+        glyph_index = next(iter(glyph_indexes), None)
+        if glyph_index is None:
+            return QtGui.QPainterPath()
+        path = raw_font.pathForGlyph(glyph_index)
+        self._glyph_path_cache[cache_key] = path
+        return path
 
 
 class CharIconEngine(QtGui.QIconEngine):


### PR DESCRIPTION
## Changelog Description
Use glyph path instead of text rendering for specific range of Qt versions.

## Additional info
There was a bug in Qt related to painting unicode characters which do return 0 width of the character. To fix the issue a new approach was added which is painting the path directly. This does affect Silhouette and OpenRV applications.

This PR fixes ONLY material symbols, and does not fix Awesome icons, so there still might be missing icons here and there. That will NOT be fixed in this PR.

## Testing notes:
1. Launch Silhouette or OpenRV, and also other DCCs to validate we didn't break them.
2. Open AYON tools that do show the icons (e.g. folders or tasks in workfiles tool).
3. The icons should be visible.

Helps with https://github.com/ynput/ayon-core/issues/2046 but does not fully resolve it.