### PR TITLE
Publish: Remove dataclasses from publish plugins

### DIFF
--- a/client/ayon_core/plugins/publish/collect_addons.py
+++ b/client/ayon_core/plugins/publish/collect_addons.py
@@ -1,7 +1,6 @@
 """Collect AYON addons."""
 from __future__ import annotations
 
-from dataclasses import dataclass
 import os
 
 import pyblish.api
@@ -16,12 +15,23 @@ from ayon_core.lib.ayon_info import (
 from ayon_core.addon import AddonsManager, get_bundle_information
 
 
-@dataclass
 class AddonInfo:
     name: str
     version: str | None
     server_version: str | None
     label: str | None = None
+
+    def __init__(
+        self,
+        name: str,
+        version: str | None    ,
+        server_version: str | None,
+        label: str | None = None,
+    ):
+        self.name = name
+        self.version = version
+        self.server_version = server_version
+        self.label = label
 
     def get_row(
         self, name_width: int, version_width: int, server_version_width: int

--- a/client/ayon_core/plugins/publish/collect_addons.py
+++ b/client/ayon_core/plugins/publish/collect_addons.py
@@ -16,18 +16,13 @@ from ayon_core.addon import AddonsManager, get_bundle_information
 
 
 class AddonInfo:
-    name: str
-    version: str | None
-    server_version: str | None
-    label: str | None = None
-
     def __init__(
         self,
         name: str,
-        version: str | None    ,
+        version: str | None,
         server_version: str | None,
         label: str | None = None,
-    ):
+    ) -> None:
         self.name = name
         self.version = version
         self.server_version = server_version

--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import copy
-from dataclasses import dataclass, field, fields
 import os
 import subprocess
 import tempfile
-from typing import Dict, Any, List, Tuple, Optional, TYPE_CHECKING
+from typing import Dict, Any, Tuple, Optional, TYPE_CHECKING
 
 import pyblish.api
 from ayon_core.lib import (
@@ -33,41 +34,47 @@ if TYPE_CHECKING:
     from ayon_core.pipeline import Anatomy
 
 
-@dataclass
 class ThumbnailDef:
     """
     Data class representing the full configuration for selected profile
 
     Any change of controllable fields in Settings must propagate here!
     """
-    integrate_thumbnail: bool = False
+    def __init__(
+        self,
+        integrate_thumbnail: bool = False,
+        target_size: dict[str, Any] | None = None,
+        duration_split: float = 0.5,
+        oiiotool_defaults: dict[str, str] | None = None,
+        ffmpeg_args: dict[str, list[Any]] | None = None,
+        background_color: tuple[int, int, int, float] = (0, 0, 0, 0.0)
+    ) -> None:
+        if target_size is None:
+            target_size = {
+                "type": "source",
+                "resize": {"width": 1920, "height": 1080},
+            }
 
-    target_size: Dict[str, Any] = field(
-        default_factory=lambda: {
-            "type": "source",
-            "resize": {"width": 1920, "height": 1080},
-        }
-    )
+        if oiiotool_defaults is None:
+            oiiotool_defaults = {
+                "type": "colorspace",
+                "colorspace": "color_picking"
+            }
 
-    duration_split: float = 0.5
+        if ffmpeg_args is None:
+            ffmpeg_args = {"input": [], "output": []}
 
-    oiiotool_defaults: Dict[str, str] = field(
-        default_factory=lambda: {
-            "type": "colorspace",
-            "colorspace": "color_picking"
-        }
-    )
-
-    ffmpeg_args: Dict[str, List[Any]] = field(
-        default_factory=lambda: {"input": [], "output": []}
-    )
-
-    # Background color defined as (R, G, B, A) tuple.
-    # Note: Use float for alpha channel (0.0 to 1.0).
-    background_color: Tuple[int, int, int, float] = (0, 0, 0, 0.0)
+        self.integrate_thumbnail: bool = integrate_thumbnail
+        self.target_size: dict[str, Any] = target_size
+        self.duration_split: float = duration_split
+        self.oiiotool_defaults: dict[str, str] = oiiotool_defaults
+        self.ffmpeg_args: dict[str, list[Any]] = ffmpeg_args
+        # Background color defined as (R, G, B, A) tuple.
+        # Note: Use float for alpha channel (0.0 to 1.0).
+        self.background_color: Tuple[int, int, int, float] = background_color
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "ThumbnailDef":
+    def from_dict(cls, data: dict[str, Any]) -> ThumbnailDef:
         """
         Creates a ThumbnailDef instance from a dictionary, safely ignoring
         any keys in the dictionary that are not fields in the dataclass.
@@ -79,7 +86,14 @@ class ThumbnailDef:
             MediaConfig: A new instance of the dataclass.
         """
         # Get all field names defined in the dataclass
-        field_names = {f.name for f in fields(cls)}
+        field_names = {
+            "integrate_thumbnail",
+            "target_size",
+            "duration_split",
+            "oiiotool_defaults",
+            "ffmpeg_args",
+            "background_color",
+        }
 
         # Filter the input dictionary to include only keys matching field names
         filtered_data = {k: v for k, v in data.items() if k in field_names}

--- a/client/ayon_core/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_core/plugins/publish/extract_thumbnail.py
@@ -4,7 +4,7 @@ import copy
 import os
 import subprocess
 import tempfile
-from typing import Dict, Any, Tuple, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import pyblish.api
 from ayon_core.lib import (
@@ -71,7 +71,7 @@ class ThumbnailDef:
         self.ffmpeg_args: dict[str, list[Any]] = ffmpeg_args
         # Background color defined as (R, G, B, A) tuple.
         # Note: Use float for alpha channel (0.0 to 1.0).
-        self.background_color: Tuple[int, int, int, float] = background_color
+        self.background_color: tuple[int, int, int, float] = background_color
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ThumbnailDef:
@@ -80,7 +80,7 @@ class ThumbnailDef:
         any keys in the dictionary that are not fields in the dataclass.
 
         Args:
-            data (Dict[str, Any]): The dictionary containing configuration data
+            data (dict[str, Any]): The dictionary containing configuration data
 
         Returns:
             MediaConfig: A new instance of the dataclass.
@@ -468,8 +468,8 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
                 keys:
                     colorspace (str)
                     config (dict)
-                    display (Optional[str])
-                    view (Optional[str])
+                    display (str | None)
+                    view (str | None)
             thumbnail_def (ThumbnailDefinition): Thumbnail definition.
             anatomy (Anatomy): Current project Anatomy.
             review_layers (list[str]): List of reviewable layers.
@@ -688,7 +688,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
         video_file_path: str,
         output_dir: str,
         thumbnail_def: ThumbnailDef,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Convert video file to one frame image via ffmpeg"""
         # create output file path
         base_name = os.path.basename(video_file_path)
@@ -827,7 +827,7 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
     def _get_config_from_profile(
         self,
         instance: pyblish.api.Instance
-    ) -> Optional[ThumbnailDef]:
+    ) -> ThumbnailDef | None:
         """Returns profile if and how repre should be color transcoded."""
         host_name = instance.context.data["hostName"]
         product_base_type = instance.data.get("productBaseType")

--- a/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
+++ b/client/ayon_core/plugins/publish/extract_usd_layer_contributions.py
@@ -1,5 +1,4 @@
 import copy
-import dataclasses
 import os
 import platform
 from collections import defaultdict
@@ -58,32 +57,44 @@ USDContributionURI = Literal[
 ]
 
 
-@dataclasses.dataclass
 class _BaseContribution:
-    # What are we contributing?
-    instance: pyblish.api.Instance  # instance that contributes it
-
-    # Where are we contributing to?
-    layer_id: str  # usually the department or task name
-    target_product: str  # target product the layer should merge to
-
-    order: int
+    def __init__(
+        self,
+        # What are we contributing?
+        # instance that contributes it
+        instance: pyblish.api.Instance,
+        # Where are we contributing to?
+        # usually the department or task name
+        layer_id: str,
+        # target product the layer should merge to
+        target_product: str,
+        order: int,
+    ):
+        self.instance = instance
+        self.layer_id = layer_id
+        self.target_product = target_product
+        self.order = order
 
 
 class SublayerContribution(_BaseContribution):
     """Sublayer contribution"""
 
 
-@dataclasses.dataclass
 class VariantContribution(_BaseContribution):
     """Reference contribution within a Variant Set"""
-
-    # Variant
-    variant_set_name: str
-    variant_name: str
-    variant_default_policy: Literal[
-        "if_not_set", "always", "never"
-    ]  # Policy controlling variant selection opinion
+    def __init__(
+        self,
+        # Variant
+        variant_set_name: str,
+        variant_name: str,
+        # Policy controlling variant selection opinion
+        variant_default_policy: Literal["if_not_set", "always", "never"],
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.variant_set_name = variant_set_name
+        self.variant_name = variant_name
+        self.variant_default_policy = variant_default_policy
 
 
 CONTRIBUTION_VARIANT_DEFAULT_POLICY = {


### PR DESCRIPTION
## Changelog Description
Use classic classes instead of dataclasses in publish plugins.

## Additional info
Dataclasses are broken in case they are in publish plugin files which are discovered using pyblish discovery logic (it works if AYON's discovery is used...).

Replaced dataclasses with just classes -> added `__init__` and similar "work-like" logic.

## Testing notes:
1. Collect addons, Extract Thumbnail, Extract USD Layer plugins should work if pyblish publish logic is triggered instead of AYON's logic.

Resolves https://github.com/ynput/ayon-nuke/issues/366
